### PR TITLE
Derive UI version display from package.json

### DIFF
--- a/src/app/pages/login.tsx
+++ b/src/app/pages/login.tsx
@@ -140,7 +140,7 @@ export function LoginPage() {
 
       {/* Version footer */}
       <p className="text-muted-foreground/60 mt-3 text-xs">
-        BT Servant Admin Portal v0.5.1
+        BT Servant Admin Portal v{__APP_VERSION__}
       </p>
     </div>
   );

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -64,7 +64,7 @@ export function UserMenu() {
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <p className="text-muted-foreground/50 px-2 py-1.5 text-[10px]">
-            BAP v0.5.1
+            BAP v{__APP_VERSION__}
           </p>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,12 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { defineConfig } from "vite";
+import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [react(), cloudflare()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Replaces hardcoded `v0.5.1` version strings on the login page and user menu with a build-time `__APP_VERSION__` constant
- Version is injected via Vite's `define` config from `package.json`, so it stays in sync automatically
- Adds `src/globals.d.ts` for the TypeScript type declaration

## Test plan
- [ ] Verify login page shows `v0.6.0`
- [ ] Verify user menu dropdown shows `v0.6.0`
- [ ] Confirm version updates automatically when `package.json` version changes