### PR TITLE
Resizable test chat panel

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from "react-router";
 
 import { cn } from "@/lib/utils";
-import { useUiStore } from "@/lib/ui-store";
+import { useUiStore, CHAT_PANEL_MIN_WIDTH, CHAT_PANEL_MAX_WIDTH } from "@/lib/ui-store";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useResizeHandle } from "@/hooks/use-resize-handle";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
@@ -10,14 +10,32 @@ import { ActivityBar } from "@/components/activity-bar";
 import { TestChatPanel } from "@/components/test-chat-panel";
 
 export function AppShell() {
-  const { testChatOpen, setTestChatOpen, testChatPanelWidth, setTestChatPanelWidth } = useUiStore();
+  const {
+    testChatOpen,
+    setTestChatOpen,
+    testChatPanelWidth,
+    setTestChatPanelWidth,
+    persistTestChatPanelWidth,
+  } = useUiStore();
   const isDesktop = useMediaQuery("(min-width: 768px)");
   const { handleMouseDown, isResizing } = useResizeHandle({
     onResize: setTestChatPanelWidth,
+    onCommit: persistTestChatPanelWidth,
     currentWidth: testChatPanelWidth,
-    minWidth: 280,
-    maxWidth: 800,
+    minWidth: CHAT_PANEL_MIN_WIDTH,
+    maxWidth: CHAT_PANEL_MAX_WIDTH,
   });
+
+  function handleResizeKeyDown(e: React.KeyboardEvent) {
+    const step = e.shiftKey ? 50 : 10;
+    if (e.key === "ArrowLeft") {
+      setTestChatPanelWidth(testChatPanelWidth + step);
+      persistTestChatPanelWidth();
+    } else if (e.key === "ArrowRight") {
+      setTestChatPanelWidth(testChatPanelWidth - step);
+      persistTestChatPanelWidth();
+    }
+  }
 
   return (
     <TooltipProvider>
@@ -37,9 +55,17 @@ export function AppShell() {
             style={{ width: testChatPanelWidth }}
           >
             <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize chat panel"
+              aria-valuenow={testChatPanelWidth}
+              aria-valuemin={CHAT_PANEL_MIN_WIDTH}
+              aria-valuemax={CHAT_PANEL_MAX_WIDTH}
+              tabIndex={0}
               onMouseDown={handleMouseDown}
+              onKeyDown={handleResizeKeyDown}
               className={cn(
-                "absolute left-0 top-0 z-10 h-full w-1.5 cursor-col-resize transition-colors",
+                "absolute left-0 top-0 z-10 h-full w-1.5 cursor-col-resize transition-colors focus:outline-none focus-visible:bg-primary/50",
                 isResizing ? "bg-primary" : "hover:bg-border"
               )}
             />

--- a/src/hooks/use-resize-handle.ts
+++ b/src/hooks/use-resize-handle.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseResizeHandleOptions {
   onResize: (width: number) => void;
+  onCommit?: () => void;
   currentWidth: number;
   minWidth: number;
   maxWidth: number;
@@ -9,6 +10,7 @@ interface UseResizeHandleOptions {
 
 export function useResizeHandle({
   onResize,
+  onCommit,
   currentWidth,
   minWidth,
   maxWidth,
@@ -45,6 +47,7 @@ export function useResizeHandle({
 
     function onMouseUp() {
       setIsResizing(false);
+      onCommit?.();
     }
 
     document.addEventListener("mousemove", onMouseMove);
@@ -56,7 +59,7 @@ export function useResizeHandle({
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
     };
-  }, [isResizing, minWidth, maxWidth, onResize]);
+  }, [isResizing, minWidth, maxWidth, onResize, onCommit]);
 
   return { handleMouseDown, isResizing };
 }

--- a/src/lib/ui-store.ts
+++ b/src/lib/ui-store.ts
@@ -2,6 +2,10 @@ import { create } from "zustand";
 
 import type { Section } from "@/types/ui";
 
+export const CHAT_PANEL_MIN_WIDTH = 280;
+export const CHAT_PANEL_MAX_WIDTH = 800;
+export const CHAT_PANEL_DEFAULT_WIDTH = 340;
+
 interface UiState {
   activeSection: Section;
   setActiveSection: (section: Section) => void;
@@ -16,6 +20,7 @@ interface UiState {
   testChatUserId: string;
   testChatPanelWidth: number;
   setTestChatPanelWidth: (width: number) => void;
+  persistTestChatPanelWidth: () => void;
   reset: () => void;
 }
 
@@ -38,9 +43,14 @@ function loadPersistedWidth(): number {
   const stored = localStorage.getItem("testChatPanelWidth");
   if (stored) {
     const parsed = Number(stored);
-    if (!Number.isNaN(parsed) && parsed >= 280 && parsed <= 800) return parsed;
+    if (
+      !Number.isNaN(parsed) &&
+      parsed >= CHAT_PANEL_MIN_WIDTH &&
+      parsed <= CHAT_PANEL_MAX_WIDTH
+    )
+      return parsed;
   }
-  return 340;
+  return CHAT_PANEL_DEFAULT_WIDTH;
 }
 
 const initialState: InitialUiState = {
@@ -77,9 +87,15 @@ export const useUiStore = create<UiState>()((set) => ({
   setSelectedMode: (selectedMode) => set({ selectedMode }),
   setChatMode: (chatMode) => set({ chatMode }),
   setTestChatPanelWidth: (width) => {
-    const clamped = Math.max(280, Math.min(800, width));
-    localStorage.setItem("testChatPanelWidth", String(clamped));
+    const clamped = Math.max(
+      CHAT_PANEL_MIN_WIDTH,
+      Math.min(CHAT_PANEL_MAX_WIDTH, width)
+    );
     set({ testChatPanelWidth: clamped });
+  },
+  persistTestChatPanelWidth: () => {
+    const { testChatPanelWidth } = useUiStore.getState();
+    localStorage.setItem("testChatPanelWidth", String(testChatPanelWidth));
   },
   // Resets all session-scoped UI state and generates a new testChatUserId so
   // the next user's chat session is fully isolated from the previous one.


### PR DESCRIPTION
## Summary

- Add drag-to-resize on the desktop test chat panel's left edge (min 280px, max 800px)
- Persist chosen width in localStorage across navigations and reloads
- Preserve width preference through logout/reset (UI pref, not session state)
- Mobile Sheet behavior unchanged

## Implementation

- **`src/lib/ui-store.ts`** — `testChatPanelWidth` state with localStorage read/write and clamping
- **`src/hooks/use-resize-handle.ts`** — New hook handling mousedown/mousemove/mouseup drag lifecycle
- **`src/components/app-shell.tsx`** — Dynamic aside width + visible drag handle with hover/active states

## Test plan

- [ ] Open test chat panel on desktop — drag left edge to resize
- [ ] Verify min (280px) and max (800px) constraints are enforced
- [ ] Refresh page — width should persist
- [ ] Toggle panel closed/open — width should be preserved
- [ ] Resize browser below 768px — Sheet drawer still works normally
- [ ] Logout and log back in — width preference should be preserved

Closes #29

cc @IanLindsley