### PR TITLE
Migrate test chat from enqueue+poll to SSE streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hooks/use-test-chat.ts
+++ b/src/hooks/use-test-chat.ts
@@ -3,15 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   deleteHistory,
   deleteMemory,
-  enqueueMessage,
   fetchHistory,
-  pollEvents,
+  streamChat,
 } from "@/lib/chat-api";
-import type { ChatHistoryEntry, ChatMessage, SSEEvent } from "@/types/chat";
-
-const POLL_INTERVAL_ACTIVE = 600;
-const POLL_INTERVAL_IDLE = 1500;
-const POLL_TIMEOUT = 120_000;
+import { consumeSSEStream } from "@/lib/sse-stream";
+import type { ChatHistoryEntry, ChatMessage } from "@/types/chat";
 
 export function useTestChat(userId: string) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -25,7 +21,7 @@ export function useTestChat(userId: string) {
   const abortRef = useRef<AbortController | null>(null);
   const pendingCompleteRef = useRef<{ message: ChatMessage } | null>(null);
 
-  // Abort polling on unmount
+  // Abort streaming on unmount
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
@@ -93,80 +89,6 @@ export function useTestChat(userId: string) {
     setStreamingText("");
   }, []);
 
-  const pollLoop = useCallback(
-    async (messageId: string, signal: AbortSignal) => {
-      let cursor = "0";
-      let accumulated = "";
-      let lastEventTime = Date.now();
-      const startTime = Date.now();
-
-      while (!signal.aborted) {
-        // Timeout check
-        if (Date.now() - startTime > POLL_TIMEOUT) {
-          throw new Error("Response timed out after 2 minutes");
-        }
-
-        const response = await pollEvents(messageId, cursor, userId, signal);
-        cursor = response.cursor;
-
-        for (const rawEvent of response.events) {
-          lastEventTime = Date.now();
-          let parsed: SSEEvent;
-          try {
-            parsed = JSON.parse(rawEvent.data) as SSEEvent;
-          } catch (e) {
-            console.warn(
-              "[useTestChat] malformed SSE event data:",
-              rawEvent.data,
-              e
-            );
-            continue;
-          }
-
-          switch (parsed.type) {
-            case "status":
-              setStatusMessage(parsed.message);
-              break;
-            case "progress":
-              accumulated += parsed.text;
-              setStreamingText(accumulated);
-              break;
-            case "complete": {
-              const finalText =
-                parsed.response.responses.join("\n\n") || accumulated;
-              return { finalText, hadStreaming: accumulated.length > 0 };
-            }
-            case "error":
-              throw new Error(parsed.error);
-            case "tool_use":
-              setStatusMessage(`Using tool: ${parsed.tool}`);
-              break;
-            case "tool_result":
-              setStatusMessage(null);
-              break;
-          }
-        }
-
-        if (response.done) {
-          return {
-            finalText: accumulated,
-            hadStreaming: accumulated.length > 0,
-          };
-        }
-
-        // Adaptive polling: faster when receiving events, slower when idle
-        const timeSinceLastEvent = Date.now() - lastEventTime;
-        const interval =
-          timeSinceLastEvent > 3000 ? POLL_INTERVAL_IDLE : POLL_INTERVAL_ACTIVE;
-
-        await new Promise((resolve) => setTimeout(resolve, interval));
-      }
-
-      return { finalText: accumulated, hadStreaming: accumulated.length > 0 };
-    },
-    [userId]
-  );
-
   const sendMessage = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
@@ -192,16 +114,14 @@ export function useTestChat(userId: string) {
       setStatusMessage(null);
 
       try {
-        const { message_id } = await enqueueMessage(
-          trimmed,
-          userId,
-          controller.signal
-        );
+        const response = await streamChat(trimmed, userId, controller.signal);
 
-        const { finalText, hadStreaming } = await pollLoop(
-          message_id,
-          controller.signal
-        );
+        const { finalText, hadStreaming } = await consumeSSEStream(response, {
+          onStatus: (msg) => setStatusMessage(msg),
+          onProgress: (_text, acc) => setStreamingText(acc),
+          onToolUse: (tool) => setStatusMessage(`Using tool: ${tool}`),
+          onToolResult: () => setStatusMessage(null),
+        });
 
         if (!finalText) return;
 
@@ -236,7 +156,7 @@ export function useTestChat(userId: string) {
         setStatusMessage(null);
       }
     },
-    [isLoading, pollLoop, userId]
+    [isLoading, userId]
   );
 
   const clearMessages = useCallback(() => {

--- a/src/lib/chat-api.ts
+++ b/src/lib/chat-api.ts
@@ -1,18 +1,14 @@
-import type {
-  ChatHistoryResponse,
-  EnqueueResponse,
-  PollResponse,
-} from "@/types/chat";
+import type { ChatHistoryResponse } from "@/types/chat";
 
 const SAME_ORIGIN_HEADERS = {
   "X-Requested-With": "XMLHttpRequest",
 } as const;
 
-export async function enqueueMessage(
+export async function streamChat(
   message: string,
   userId: string,
   signal?: AbortSignal
-): Promise<EnqueueResponse> {
+): Promise<Response> {
   const res = await fetch("/api/chat/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
@@ -22,34 +18,10 @@ export async function enqueueMessage(
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(`Enqueue failed (${res.status}): ${body}`);
+    throw new Error(`Chat stream failed (${res.status}): ${body}`);
   }
 
-  return (await res.json()) as EnqueueResponse;
-}
-
-export async function pollEvents(
-  messageId: string,
-  cursor: string,
-  userId: string,
-  signal?: AbortSignal
-): Promise<PollResponse> {
-  const params = new URLSearchParams({
-    message_id: messageId,
-    cursor,
-    user_id: userId,
-  });
-  const res = await fetch(`/api/chat/stream/poll?${params.toString()}`, {
-    headers: SAME_ORIGIN_HEADERS,
-    signal,
-  });
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Poll failed (${res.status}): ${body}`);
-  }
-
-  return (await res.json()) as PollResponse;
+  return res;
 }
 
 export async function fetchHistory(

--- a/src/lib/sse-stream.ts
+++ b/src/lib/sse-stream.ts
@@ -1,0 +1,77 @@
+import type { ChatResponse, SSEEvent } from "@/types/chat";
+
+export interface SSEStreamCallbacks {
+  onStatus?: (message: string) => void;
+  onProgress?: (text: string, accumulated: string) => void;
+  onComplete?: (response: ChatResponse) => void;
+  onError?: (error: string) => void;
+  onToolUse?: (tool: string, input: Record<string, unknown>) => void;
+  onToolResult?: (tool: string, result: string) => void;
+}
+
+export async function consumeSSEStream(
+  response: Response,
+  callbacks: SSEStreamCallbacks
+): Promise<{ finalText: string; hadStreaming: boolean }> {
+  if (!response.body) {
+    throw new Error("Response has no body");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let sseBuffer = "";
+  let accumulated = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      sseBuffer += decoder.decode(value, { stream: true });
+      const lines = sseBuffer.split("\n");
+      sseBuffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+
+        let event: SSEEvent;
+        try {
+          event = JSON.parse(line.slice(6)) as SSEEvent;
+        } catch {
+          continue;
+        }
+
+        switch (event.type) {
+          case "status":
+            callbacks.onStatus?.(event.message);
+            break;
+          case "progress":
+            accumulated += event.text;
+            callbacks.onProgress?.(event.text, accumulated);
+            break;
+          case "complete": {
+            const finalText =
+              event.response.responses.join("\n\n") || accumulated;
+            callbacks.onComplete?.(event.response);
+            return { finalText, hadStreaming: accumulated.length > 0 };
+          }
+          case "error":
+            callbacks.onError?.(event.error);
+            throw new Error(event.error);
+          case "tool_use":
+            callbacks.onToolUse?.(event.tool, event.input);
+            break;
+          case "tool_result":
+            callbacks.onToolResult?.(event.tool, event.result);
+            break;
+          case "keepalive":
+            break;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return { finalText: accumulated, hadStreaming: accumulated.length > 0 };
+}

--- a/src/lib/sse-stream.ts
+++ b/src/lib/sse-stream.ts
@@ -70,6 +70,7 @@ export async function consumeSSEStream(
       }
     }
   } finally {
+    await reader.cancel();
     reader.releaseLock();
   }
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,4 +1,4 @@
-// SSE event types from the engine's queue/poll endpoint
+// SSE event types from the engine's streaming endpoint
 
 export interface SSEStatusEvent {
   type: "status";
@@ -33,18 +33,24 @@ export interface SSEToolResultEvent {
   result: string;
 }
 
+export interface SSEKeepaliveEvent {
+  type: "keepalive";
+}
+
 export type SSEEvent =
   | SSEStatusEvent
   | SSEProgressEvent
   | SSECompleteEvent
   | SSEErrorEvent
   | SSEToolUseEvent
-  | SSEToolResultEvent;
+  | SSEToolResultEvent
+  | SSEKeepaliveEvent;
 
 export interface ChatResponse {
   responses: string[];
   response_language: string;
   voice_audio_base64: string | null;
+  voice_audio_url: string | null;
 }
 
 export interface ChatMessage {

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -61,20 +61,24 @@ export interface ChatMessage {
   isStreaming?: boolean;
 }
 
+// TODO: Remove after Baruch SSE migration
 export interface EnqueueRequest {
   message: string;
   message_type: string;
 }
 
+// TODO: Remove after Baruch SSE migration
 export interface EnqueueResponse {
   message_id: string;
 }
 
+// TODO: Remove after Baruch SSE migration
 export interface PollEvent {
   event: string;
   data: string;
 }
 
+// TODO: Remove after Baruch SSE migration
 export interface PollResponse {
   message_id: string;
   events: PollEvent[];

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -17,7 +17,7 @@ function resolveUserId(
   return session.userId;
 }
 
-export async function handleEnqueue(
+export async function handleStream(
   request: Request,
   env: Env,
   session: SessionData
@@ -37,7 +37,7 @@ export async function handleEnqueue(
     return errorResponse("Missing 'message' field", 400);
   }
 
-  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/chat/queue`;
+  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/chat`;
   const engineBody = {
     message: body.message,
     message_type: body.message_type || "text",
@@ -57,81 +57,16 @@ export async function handleEnqueue(
 
   if (!engineRes.ok) {
     const text = await engineRes.text().catch(() => "");
-    console.error(`Engine enqueue failed (${engineRes.status}): ${text}`);
-    return errorResponse("Failed to enqueue message", 502);
+    console.error(`Engine stream failed (${engineRes.status}): ${text}`);
+    return errorResponse("Failed to stream chat response", 502);
   }
 
-  const data: unknown = await engineRes.json();
-  if (!data || typeof data !== "object" || !("message_id" in data)) {
-    console.error("Engine enqueue returned unexpected shape:", data);
-    return errorResponse("Unexpected engine response", 502);
-  }
-
-  return jsonResponse({
-    message_id: (data as { message_id: string }).message_id,
-  });
-}
-
-export async function handlePoll(
-  request: Request,
-  env: Env,
-  session: SessionData
-): Promise<Response> {
-  if (request.method !== "GET") {
-    return errorResponse("Method not allowed", 405);
-  }
-
-  const url = new URL(request.url);
-  const messageId = url.searchParams.get("message_id");
-  const cursor = url.searchParams.get("cursor") || "0";
-
-  if (!messageId) {
-    return errorResponse("Missing 'message_id' parameter", 400);
-  }
-
-  const params = new URLSearchParams({
-    user_id: resolveUserId(url.searchParams.get("user_id"), session),
-    message_id: messageId,
-    org: session.org,
-    cursor,
-  });
-
-  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/chat/queue/poll?${params.toString()}`;
-
-  const engineRes = await fetch(engineUrl, {
+  return new Response(engineRes.body, {
     headers: {
-      Authorization: `Bearer ${env.ENGINE_API_KEY}`,
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
     },
-  });
-
-  if (!engineRes.ok) {
-    const text = await engineRes.text().catch(() => "");
-    console.error(`Engine poll failed (${engineRes.status}): ${text}`);
-    return errorResponse("Failed to poll events", 502);
-  }
-
-  const data: unknown = await engineRes.json();
-  if (
-    !data ||
-    typeof data !== "object" ||
-    !("events" in data) ||
-    !Array.isArray((data as { events: unknown }).events)
-  ) {
-    console.error("Engine poll returned unexpected shape:", data);
-    return errorResponse("Unexpected engine response", 502);
-  }
-
-  const typed = data as {
-    events: unknown[];
-    done?: boolean;
-    cursor?: string;
-    message_id?: string;
-  };
-  return jsonResponse({
-    message_id: typed.message_id,
-    events: typed.events,
-    done: typed.done ?? false,
-    cursor: typed.cursor ?? "",
   });
 }
 

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -65,7 +65,6 @@ export async function handleStream(
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
-      Connection: "keep-alive",
     },
   });
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -16,9 +16,8 @@ import {
 import {
   handleDeleteHistory,
   handleDeleteMemory,
-  handleEnqueue,
   handleHistory,
-  handlePoll,
+  handleStream,
 } from "./chat";
 import { handleConfig } from "./config";
 import type { Env } from "./helpers";
@@ -56,7 +55,6 @@ export default {
     // Chat endpoints — session required
     if (
       url.pathname === "/api/chat/stream" ||
-      url.pathname === "/api/chat/stream/poll" ||
       url.pathname === "/api/chat/history" ||
       url.pathname === "/api/chat/memory"
     ) {
@@ -69,7 +67,7 @@ export default {
       }
 
       if (url.pathname === "/api/chat/stream") {
-        return handleEnqueue(request, env, session);
+        return handleStream(request, env, session);
       }
       if (url.pathname === "/api/chat/history") {
         if (request.method === "DELETE") {
@@ -77,13 +75,11 @@ export default {
         }
         return handleHistory(request, env, session);
       }
-      if (url.pathname === "/api/chat/memory") {
-        if (request.method === "DELETE") {
-          return handleDeleteMemory(request, env, session);
-        }
-        return errorResponse("Method not allowed", 405);
+      // /api/chat/memory
+      if (request.method === "DELETE") {
+        return handleDeleteMemory(request, env, session);
       }
-      return handlePoll(request, env, session);
+      return errorResponse("Method not allowed", 405);
     }
 
     // Config endpoints — session required


### PR DESCRIPTION
## Summary

Closes #60

The bt-servant-worker backend (v2.11.0) removed its polling infrastructure (`GET /api/v1/chat/queue/poll` is gone). This migrates the test chat pane to consume the new `POST /api/v1/chat` SSE stream directly.

- **Worker BFF**: Replace `handleEnqueue`/`handlePoll` with `handleStream` that pipes the engine's SSE body through (same pattern as Baruch initiate). Remove `/api/chat/stream/poll` route.
- **New `src/lib/sse-stream.ts`**: Shared SSE stream consumer extracted from the proven Baruch inline pattern — `getReader()` + `TextDecoder` + SSE line buffering.
- **`src/lib/chat-api.ts`**: Replace `enqueueMessage` + `pollEvents` with single `streamChat()` returning the raw `Response`.
- **`src/hooks/use-test-chat.ts`**: Replace `pollLoop` with `consumeSSEStream` callbacks. Remove polling constants/timeout.
- **`src/types/chat.ts`**: Add `SSEKeepaliveEvent` to union, `voice_audio_url` to `ChatResponse`.

Baruch chat is **unchanged** (separate migration). `EnqueueResponse`, `PollResponse`, `PollEvent` types are kept since Baruch still uses them.

## Test plan

- [ ] Open admin portal test chat pane on staging
- [ ] Send a message — verify real-time text streaming (smoother than polling, no 600ms gaps)
- [ ] Send a message that triggers tool use — verify tool_use/tool_result status messages appear
- [ ] Abort mid-stream (close panel or send new message) — verify no errors/hanging
- [ ] Verify history loads and clears correctly (unchanged endpoints)
- [ ] Verify memory clear works (unchanged endpoint)
- [ ] Check browser console for any errors