### PR TITLE
Migrate baruch chat from enqueue+poll to SSE streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hooks/use-baruch-chat.ts
+++ b/src/hooks/use-baruch-chat.ts
@@ -2,17 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   baruchDeleteHistory,
-  baruchEnqueueMessage,
   baruchFetchHistory,
   baruchInitiateConversation,
-  baruchPollEvents,
+  streamBaruchChat,
 } from "@/lib/baruch-api";
 import { useAuthStore } from "@/lib/auth-store";
-import type { ChatHistoryEntry, ChatMessage, SSEEvent } from "@/types/chat";
-
-const POLL_INTERVAL_ACTIVE = 600;
-const POLL_INTERVAL_IDLE = 1500;
-const POLL_TIMEOUT = 120_000;
+import { consumeSSEStream } from "@/lib/sse-stream";
+import type { ChatHistoryEntry, ChatMessage } from "@/types/chat";
 
 export function useBaruchChat() {
   const userId = useAuthStore((s) => s.user?.id ?? "");
@@ -30,7 +26,7 @@ export function useBaruchChat() {
   const pendingCompleteRef = useRef<{ message: ChatMessage } | null>(null);
   const initiatingRef = useRef(false);
 
-  // Abort polling on unmount
+  // Abort streaming on unmount
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
@@ -106,56 +102,22 @@ export function useBaruchChat() {
     async function runInitiation() {
       const res = await baruchInitiateConversation(controller.signal);
 
-      if (!res.body) throw new Error("Initiate response has no body");
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let accumulated = "";
-      let sseBuffer = "";
+      const { finalText, hadStreaming } = await consumeSSEStream(res, {
+        onProgress: (_text, acc) => setStreamingText(acc),
+      });
 
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          sseBuffer += decoder.decode(value, { stream: true });
-          const lines = sseBuffer.split("\n");
-          sseBuffer = lines.pop() ?? "";
-          for (const line of lines) {
-            if (!line.startsWith("data: ")) continue;
-            let event: SSEEvent;
-            try {
-              event = JSON.parse(line.slice(6)) as SSEEvent;
-            } catch {
-              continue;
-            }
-            switch (event.type) {
-              case "progress":
-                accumulated += event.text;
-                setStreamingText(accumulated);
-                break;
-              case "complete": {
-                const finalText =
-                  event.response.responses.join("\n\n") || accumulated;
-                const finalMessage: ChatMessage = {
-                  id: `initiation-${Date.now()}`,
-                  role: "assistant",
-                  content: finalText,
-                  createdAt: new Date(),
-                };
-                if (accumulated) {
-                  pendingCompleteRef.current = { message: finalMessage };
-                  setIsCompleting(true);
-                } else {
-                  setMessages((prev) => [...prev, finalMessage]);
-                }
-                break;
-              }
-              case "error":
-                throw new Error(event.error);
-            }
-          }
-        }
-      } finally {
-        reader.releaseLock();
+      const finalMessage: ChatMessage = {
+        id: `initiation-${Date.now()}`,
+        role: "assistant",
+        content: finalText,
+        createdAt: new Date(),
+      };
+
+      if (hadStreaming) {
+        pendingCompleteRef.current = { message: finalMessage };
+        setIsCompleting(true);
+      } else {
+        setMessages((prev) => [...prev, finalMessage]);
       }
 
       setNeedsInitiation(false);
@@ -194,80 +156,6 @@ export function useBaruchChat() {
     setStreamingText("");
   }, []);
 
-  const pollLoop = useCallback(
-    async (messageId: string, signal: AbortSignal) => {
-      let cursor = "0";
-      let accumulated = "";
-      let lastEventTime = Date.now();
-      const startTime = Date.now();
-
-      while (!signal.aborted) {
-        // Timeout check
-        if (Date.now() - startTime > POLL_TIMEOUT) {
-          throw new Error("Response timed out after 2 minutes");
-        }
-
-        const response = await baruchPollEvents(messageId, cursor, signal);
-        cursor = response.cursor;
-
-        for (const rawEvent of response.events) {
-          lastEventTime = Date.now();
-          let parsed: SSEEvent;
-          try {
-            parsed = JSON.parse(rawEvent.data) as SSEEvent;
-          } catch (e) {
-            console.warn(
-              "[useBaruchChat] malformed SSE event data:",
-              rawEvent.data,
-              e
-            );
-            continue;
-          }
-
-          switch (parsed.type) {
-            case "status":
-              setStatusMessage(parsed.message);
-              break;
-            case "progress":
-              accumulated += parsed.text;
-              setStreamingText(accumulated);
-              break;
-            case "complete": {
-              const finalText =
-                parsed.response.responses.join("\n\n") || accumulated;
-              return { finalText, hadStreaming: accumulated.length > 0 };
-            }
-            case "error":
-              throw new Error(parsed.error);
-            case "tool_use":
-              setStatusMessage(`Using tool: ${parsed.tool}`);
-              break;
-            case "tool_result":
-              setStatusMessage(null);
-              break;
-          }
-        }
-
-        if (response.done) {
-          return {
-            finalText: accumulated,
-            hadStreaming: accumulated.length > 0,
-          };
-        }
-
-        // Adaptive polling: faster when receiving events, slower when idle
-        const timeSinceLastEvent = Date.now() - lastEventTime;
-        const interval =
-          timeSinceLastEvent > 3000 ? POLL_INTERVAL_IDLE : POLL_INTERVAL_ACTIVE;
-
-        await new Promise((resolve) => setTimeout(resolve, interval));
-      }
-
-      return { finalText: accumulated, hadStreaming: accumulated.length > 0 };
-    },
-    []
-  );
-
   const sendMessage = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
@@ -293,15 +181,14 @@ export function useBaruchChat() {
       setStatusMessage(null);
 
       try {
-        const { message_id } = await baruchEnqueueMessage(
-          trimmed,
-          controller.signal
-        );
+        const response = await streamBaruchChat(trimmed, controller.signal);
 
-        const { finalText, hadStreaming } = await pollLoop(
-          message_id,
-          controller.signal
-        );
+        const { finalText, hadStreaming } = await consumeSSEStream(response, {
+          onStatus: (msg) => setStatusMessage(msg),
+          onProgress: (_text, acc) => setStreamingText(acc),
+          onToolUse: (tool) => setStatusMessage(`Using tool: ${tool}`),
+          onToolResult: () => setStatusMessage(null),
+        });
 
         if (!finalText) return;
 
@@ -334,7 +221,7 @@ export function useBaruchChat() {
         setStatusMessage(null);
       }
     },
-    [isLoading, pollLoop]
+    [isLoading]
   );
 
   const clearMessages = useCallback(() => {
@@ -361,9 +248,6 @@ export function useBaruchChat() {
   const allMessages = useMemo(() => {
     if (!streamingText) return messages;
 
-    // streamingText is accumulated mid-stream. useBaruchChat appends a
-    // synthetic "streaming" message to allMessages so components don't need
-    // to render streamingText directly — they just render allMessages.
     const streamingMessage: ChatMessage = {
       id: "streaming",
       role: "assistant",
@@ -381,9 +265,6 @@ export function useBaruchChat() {
     isInitiating,
     isCompleting,
     statusMessage,
-    // streamingText is intentionally not returned — consumers render
-    // allMessages (which already contains the synthetic streaming entry).
-    // It is kept in state only for the useEffect auto-scroll dependency.
     streamingText,
     error,
     sendMessage,

--- a/src/hooks/use-baruch-chat.ts
+++ b/src/hooks/use-baruch-chat.ts
@@ -190,7 +190,12 @@ export function useBaruchChat() {
           onToolResult: () => setStatusMessage(null),
         });
 
-        if (!finalText) return;
+        if (!finalText) {
+          setIsLoading(false);
+          setStreamingText("");
+          setStatusMessage(null);
+          return;
+        }
 
         const assistantMessage: ChatMessage = {
           id: crypto.randomUUID(),

--- a/src/hooks/use-baruch-chat.ts
+++ b/src/hooks/use-baruch-chat.ts
@@ -183,52 +183,14 @@ export function useBaruchChat() {
       try {
         const response = await streamBaruchChat(trimmed, controller.signal);
 
-        // DEBUG: clone and log raw response body
-        const cloned = response.clone();
-        cloned.text().then((raw) => {
-          console.log("[useBaruchChat] raw response length:", raw.length);
-          console.log("[useBaruchChat] raw response body:", raw);
-          console.log("[useBaruchChat] first 500 chars:", raw.slice(0, 500));
-          const dataLines = raw
-            .split("\n")
-            .filter((l) => l.startsWith("data: "));
-          console.log("[useBaruchChat] data: lines found:", dataLines.length);
-          dataLines.forEach((l, i) =>
-            console.log(`[useBaruchChat]   event[${i}]:`, l.slice(0, 200))
-          );
-        });
-
         const { finalText, hadStreaming } = await consumeSSEStream(response, {
-          onStatus: (msg) => {
-            console.log("[useBaruchChat] SSE status:", msg);
-            setStatusMessage(msg);
-          },
-          onProgress: (_text, acc) => {
-            console.log(
-              "[useBaruchChat] SSE progress chunk:",
-              _text.slice(0, 100)
-            );
-            setStreamingText(acc);
-          },
-          onToolUse: (tool) => {
-            console.log("[useBaruchChat] SSE tool_use:", tool);
-            setStatusMessage(`Using tool: ${tool}`);
-          },
-          onToolResult: () => {
-            console.log("[useBaruchChat] SSE tool_result");
-            setStatusMessage(null);
-          },
-        });
-
-        console.log("[useBaruchChat] consumeSSEStream result:", {
-          finalText: finalText.slice(0, 200),
-          hadStreaming,
+          onStatus: (msg) => setStatusMessage(msg),
+          onProgress: (_text, acc) => setStreamingText(acc),
+          onToolUse: (tool) => setStatusMessage(`Using tool: ${tool}`),
+          onToolResult: () => setStatusMessage(null),
         });
 
         if (!finalText) {
-          console.warn(
-            "[useBaruchChat] empty finalText — no SSE events parsed"
-          );
           setIsLoading(false);
           setStreamingText("");
           setStatusMessage(null);

--- a/src/hooks/use-baruch-chat.ts
+++ b/src/hooks/use-baruch-chat.ts
@@ -183,14 +183,52 @@ export function useBaruchChat() {
       try {
         const response = await streamBaruchChat(trimmed, controller.signal);
 
+        // DEBUG: clone and log raw response body
+        const cloned = response.clone();
+        cloned.text().then((raw) => {
+          console.log("[useBaruchChat] raw response length:", raw.length);
+          console.log("[useBaruchChat] raw response body:", raw);
+          console.log("[useBaruchChat] first 500 chars:", raw.slice(0, 500));
+          const dataLines = raw
+            .split("\n")
+            .filter((l) => l.startsWith("data: "));
+          console.log("[useBaruchChat] data: lines found:", dataLines.length);
+          dataLines.forEach((l, i) =>
+            console.log(`[useBaruchChat]   event[${i}]:`, l.slice(0, 200))
+          );
+        });
+
         const { finalText, hadStreaming } = await consumeSSEStream(response, {
-          onStatus: (msg) => setStatusMessage(msg),
-          onProgress: (_text, acc) => setStreamingText(acc),
-          onToolUse: (tool) => setStatusMessage(`Using tool: ${tool}`),
-          onToolResult: () => setStatusMessage(null),
+          onStatus: (msg) => {
+            console.log("[useBaruchChat] SSE status:", msg);
+            setStatusMessage(msg);
+          },
+          onProgress: (_text, acc) => {
+            console.log(
+              "[useBaruchChat] SSE progress chunk:",
+              _text.slice(0, 100)
+            );
+            setStreamingText(acc);
+          },
+          onToolUse: (tool) => {
+            console.log("[useBaruchChat] SSE tool_use:", tool);
+            setStatusMessage(`Using tool: ${tool}`);
+          },
+          onToolResult: () => {
+            console.log("[useBaruchChat] SSE tool_result");
+            setStatusMessage(null);
+          },
+        });
+
+        console.log("[useBaruchChat] consumeSSEStream result:", {
+          finalText: finalText.slice(0, 200),
+          hadStreaming,
         });
 
         if (!finalText) {
+          console.warn(
+            "[useBaruchChat] empty finalText — no SSE events parsed"
+          );
           setIsLoading(false);
           setStreamingText("");
           setStatusMessage(null);

--- a/src/lib/baruch-api.ts
+++ b/src/lib/baruch-api.ts
@@ -1,17 +1,13 @@
-import type {
-  ChatHistoryResponse,
-  EnqueueResponse,
-  PollResponse,
-} from "@/types/chat";
+import type { ChatHistoryResponse } from "@/types/chat";
 
 const SAME_ORIGIN_HEADERS = {
   "X-Requested-With": "XMLHttpRequest",
 } as const;
 
-export async function baruchEnqueueMessage(
+export async function streamBaruchChat(
   message: string,
   signal?: AbortSignal
-): Promise<EnqueueResponse> {
+): Promise<Response> {
   const res = await fetch("/api/baruch/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
@@ -21,29 +17,10 @@ export async function baruchEnqueueMessage(
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(`Enqueue failed (${res.status}): ${body}`);
+    throw new Error(`Chat stream failed (${res.status}): ${body}`);
   }
 
-  return (await res.json()) as EnqueueResponse;
-}
-
-export async function baruchPollEvents(
-  messageId: string,
-  cursor: string,
-  signal?: AbortSignal
-): Promise<PollResponse> {
-  const params = new URLSearchParams({ message_id: messageId, cursor });
-  const res = await fetch(`/api/baruch/stream/poll?${params.toString()}`, {
-    headers: SAME_ORIGIN_HEADERS,
-    signal,
-  });
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Poll failed (${res.status}): ${body}`);
-  }
-
-  return (await res.json()) as PollResponse;
+  return res;
 }
 
 export async function baruchFetchHistory(

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -61,31 +61,6 @@ export interface ChatMessage {
   isStreaming?: boolean;
 }
 
-// TODO: Remove after Baruch SSE migration
-export interface EnqueueRequest {
-  message: string;
-  message_type: string;
-}
-
-// TODO: Remove after Baruch SSE migration
-export interface EnqueueResponse {
-  message_id: string;
-}
-
-// TODO: Remove after Baruch SSE migration
-export interface PollEvent {
-  event: string;
-  data: string;
-}
-
-// TODO: Remove after Baruch SSE migration
-export interface PollResponse {
-  message_id: string;
-  events: PollEvent[];
-  done: boolean;
-  cursor: string;
-}
-
 export interface ChatHistoryEntry {
   user_message: string;
   assistant_response: string;

--- a/worker/baruch.ts
+++ b/worker/baruch.ts
@@ -17,7 +17,7 @@ function baruchFetch(
   return fetch(url, init);
 }
 
-export async function handleBaruchEnqueue(
+export async function handleBaruchStream(
   request: Request,
   env: Env,
   session: SessionData
@@ -37,7 +37,7 @@ export async function handleBaruchEnqueue(
     return errorResponse("Missing 'message' field", 400);
   }
 
-  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/chat/queue`;
+  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/chat`;
   const baruchBody = {
     message: body.message,
     message_type: body.message_type || "text",
@@ -58,81 +58,16 @@ export async function handleBaruchEnqueue(
 
   if (!baruchRes.ok) {
     const text = await baruchRes.text().catch(() => "");
-    console.error(`Baruch enqueue failed (${baruchRes.status}): ${text}`);
-    return errorResponse("Failed to enqueue message", 502);
+    console.error(`Baruch stream failed (${baruchRes.status}): ${text}`);
+    return errorResponse("Failed to stream chat response", 502);
   }
 
-  const data: unknown = await baruchRes.json();
-  if (!data || typeof data !== "object" || !("message_id" in data)) {
-    console.error("Baruch enqueue returned unexpected shape:", data);
-    return errorResponse("Unexpected Baruch response", 502);
-  }
-
-  return jsonResponse({
-    message_id: (data as { message_id: string }).message_id,
-  });
-}
-
-export async function handleBaruchPoll(
-  request: Request,
-  env: Env,
-  session: SessionData
-): Promise<Response> {
-  if (request.method !== "GET") {
-    return errorResponse("Method not allowed", 405);
-  }
-
-  const url = new URL(request.url);
-  const messageId = url.searchParams.get("message_id");
-  const cursor = url.searchParams.get("cursor") || "0";
-
-  if (!messageId) {
-    return errorResponse("Missing 'message_id' parameter", 400);
-  }
-
-  const params = new URLSearchParams({
-    user_id: session.userId,
-    message_id: messageId,
-    org: session.org,
-    cursor,
-  });
-
-  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/chat/queue/poll?${params.toString()}`;
-
-  const baruchRes = await baruchFetch(env, baruchUrl, {
+  return new Response(baruchRes.body, {
     headers: {
-      Authorization: `Bearer ${env.BARUCH_API_KEY}`,
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
     },
-  });
-
-  if (!baruchRes.ok) {
-    const text = await baruchRes.text().catch(() => "");
-    console.error(`Baruch poll failed (${baruchRes.status}): ${text}`);
-    return errorResponse("Failed to poll events", 502);
-  }
-
-  const data: unknown = await baruchRes.json();
-  if (
-    !data ||
-    typeof data !== "object" ||
-    !("events" in data) ||
-    !Array.isArray((data as { events: unknown }).events)
-  ) {
-    console.error("Baruch poll returned unexpected shape:", data);
-    return errorResponse("Unexpected Baruch response", 502);
-  }
-
-  const typed = data as {
-    events: unknown[];
-    done?: boolean;
-    cursor?: string;
-    message_id?: string;
-  };
-  return jsonResponse({
-    message_id: typed.message_id,
-    events: typed.events,
-    done: typed.done ?? false,
-    cursor: typed.cursor ?? "",
   });
 }
 

--- a/worker/baruch.ts
+++ b/worker/baruch.ts
@@ -63,6 +63,22 @@ export async function handleBaruchStream(
     return errorResponse("Failed to stream chat response", 502);
   }
 
+  const contentType = baruchRes.headers.get("content-type") ?? "";
+
+  // Baruch may return JSON instead of SSE (pre-streaming endpoints or
+  // fallback mode). Wrap the JSON response as an SSE complete event so
+  // the frontend's consumeSSEStream parser handles it uniformly.
+  if (contentType.includes("application/json")) {
+    const data: unknown = await baruchRes.json();
+    const ssePayload = `data: ${JSON.stringify({ type: "complete", response: data })}\n\n`;
+    return new Response(ssePayload, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+    });
+  }
+
   return new Response(baruchRes.body, {
     headers: {
       "Content-Type": "text/event-stream",
@@ -151,6 +167,19 @@ export async function handleBaruchInitiate(
     const text = await baruchRes.text().catch(() => "");
     console.error(`Baruch initiate failed (${baruchRes.status}): ${text}`);
     return errorResponse("Failed to initiate conversation", 502);
+  }
+
+  const contentType = baruchRes.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    const data: unknown = await baruchRes.json();
+    const ssePayload = `data: ${JSON.stringify({ type: "complete", response: data })}\n\n`;
+    return new Response(ssePayload, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+    });
   }
 
   return new Response(baruchRes.body, {

--- a/worker/baruch.ts
+++ b/worker/baruch.ts
@@ -51,6 +51,7 @@ export async function handleBaruchStream(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      Accept: "text/event-stream",
       Authorization: `Bearer ${env.BARUCH_API_KEY}`,
     },
     body: JSON.stringify(baruchBody),
@@ -140,6 +141,7 @@ export async function handleBaruchInitiate(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      Accept: "text/event-stream",
       Authorization: `Bearer ${env.BARUCH_API_KEY}`,
     },
     body: JSON.stringify(baruchBody),

--- a/worker/baruch.ts
+++ b/worker/baruch.ts
@@ -66,7 +66,6 @@ export async function handleBaruchStream(
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
-      Connection: "keep-alive",
     },
   });
 }
@@ -156,7 +155,6 @@ export async function handleBaruchInitiate(
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
-      Connection: "keep-alive",
     },
   });
 }

--- a/worker/baruch.ts
+++ b/worker/baruch.ts
@@ -37,7 +37,7 @@ export async function handleBaruchStream(
     return errorResponse("Missing 'message' field", 400);
   }
 
-  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/chat`;
+  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/chat/stream`;
   const baruchBody = {
     message: body.message,
     message_type: body.message_type || "text",

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -8,10 +8,9 @@ import {
 } from "./auth";
 import {
   handleBaruchDeleteHistory,
-  handleBaruchEnqueue,
   handleBaruchHistory,
   handleBaruchInitiate,
-  handleBaruchPoll,
+  handleBaruchStream,
 } from "./baruch";
 import {
   handleDeleteHistory,
@@ -98,7 +97,6 @@ export default {
     // Baruch chat endpoints — session required
     if (
       url.pathname === "/api/baruch/stream" ||
-      url.pathname === "/api/baruch/stream/poll" ||
       url.pathname === "/api/baruch/history" ||
       url.pathname === "/api/baruch/initiate"
     ) {
@@ -111,18 +109,16 @@ export default {
       }
 
       if (url.pathname === "/api/baruch/stream") {
-        return handleBaruchEnqueue(request, env, session);
+        return handleBaruchStream(request, env, session);
       }
       if (url.pathname === "/api/baruch/initiate") {
         return handleBaruchInitiate(request, env, session);
       }
-      if (url.pathname === "/api/baruch/history") {
-        if (request.method === "DELETE") {
-          return handleBaruchDeleteHistory(request, env, session);
-        }
-        return handleBaruchHistory(request, env, session);
+      // /api/baruch/history
+      if (request.method === "DELETE") {
+        return handleBaruchDeleteHistory(request, env, session);
       }
-      return handleBaruchPoll(request, env, session);
+      return handleBaruchHistory(request, env, session);
     }
 
     if (url.pathname.startsWith("/api/")) {


### PR DESCRIPTION
## Summary

- Replace the two-step enqueue+poll pattern in the baruch chat pane with direct SSE streaming, reusing the shared `consumeSSEStream` utility proven in the test chat migration (#60)
- Delete `handleBaruchEnqueue`, `handleBaruchPoll`, and the `/api/baruch/stream/poll` route from the worker BFF
- Add `handleBaruchStream` that POSTs to `/api/v1/chat` and pipes the SSE body through (same pattern as test chat's `handleStream`)
- Remove ~240 lines of polling machinery across 5 files; hook public interface unchanged so `baruch-chat-pane.tsx` needs zero edits

## Test plan

- [ ] Dev deploys automatically — test against baruch dev
- [ ] Send a message → verify real-time SSE streaming (no more polling delays)
- [ ] Verify tool use/status events display correctly
- [ ] Verify error handling (abort mid-stream)
- [ ] Verify history loads on mount
- [ ] Verify clear conversation works and re-initiates
- [ ] Verify conversation initiation SSE streaming on first visit

Closes #62