### PR TITLE
Migrate worker chat BFF to /api/v1/chat/stream (fixes #65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.2.2",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-admin-portal",
-      "version": "1.0.3",
+      "version": "1.4.1",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.1.0",
         "@fortawesome/pro-duotone-svg-icons": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -37,7 +37,7 @@ export async function handleStream(
     return errorResponse("Missing 'message' field", 400);
   }
 
-  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/chat`;
+  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/chat/stream`;
   const engineBody = {
     message: body.message,
     message_type: body.message_type || "text",

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -57,7 +57,9 @@ export async function handleStream(
 
   if (!engineRes.ok) {
     const text = await engineRes.text().catch(() => "");
-    console.error(`Engine stream failed (${engineRes.status}): ${text}`);
+    console.error(
+      `Engine stream failed (${engineRes.status}) ${engineUrl}: ${text}`
+    );
     return errorResponse("Failed to stream chat response", 502);
   }
 


### PR DESCRIPTION
## Summary
- Point `worker/chat.ts` at `/api/v1/chat/stream` instead of `/api/v1/chat`
- Unblocks bt-servant-worker v2.14.0, which will make `/chat` final-only JSON

## Why
Worker v2.14.0 will make `POST /api/v1/chat` final-only JSON and reject `progress_callback_url`. Our BFF currently pipes the response as SSE (`Content-Type: text/event-stream`) — once v2.14.0 ships, that pipe breaks and the chat UI stops streaming. Worker v2.13.0 (already on staging) exposes the new explicit transport endpoint `/api/v1/chat/stream`, which is SSE-only and schema-compatible with the body we already forward.

## Verified safe
- Body forwarded at `worker/chat.ts:41-47` is clean: `message`, `message_type`, `user_id`, `org`, `client_id` — none of the fields `/chat/stream` rejects (`progress_callback_url`, `progress_mode`, `progress_throttle_seconds`, `message_key`).
- Response handling already SSE-ready (pipes `engineRes.body` + sets `text/event-stream`).
- Routing in `worker/index.ts` unchanged — portal-facing `/api/chat/stream` still resolves to `handleStream()`.
- Client in `src/lib/chat-api.ts` unchanged.
- `worker/baruch.ts` unaffected (targets `BARUCH_BASE_URL`, already on `/api/v1/chat/stream`).

## Test plan
- [x] CI lint / typecheck / build pass
- [x] Dev deploy succeeds (automatic on PR)
- [x] Smoke test on dev: send a message in the chat pane, confirm progressive `status` / `progress` / `complete` SSE events render (not a single JSON blob)
- [x] `claude-code-review` sub-agent review completed with no medium+ issues
- [ ] After merge: staging smoke test, then manual prod deploy, then comment on #65

Closes #65