### PR TITLE
Surface published flag in mode list and editor (closes #68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-admin-portal",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.1.0",
         "@fortawesome/pro-duotone-svg-icons": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/pages/manual-config.tsx
+++ b/src/app/pages/manual-config.tsx
@@ -50,23 +50,21 @@ export function ManualConfigPage() {
 
   const handleSaveSlot = useCallback(
     (slot: PromptSlot, value: string) => {
-      const updated = { ...currentOverrides, [slot]: value || undefined };
-
       if (selectedMode !== null) {
+        // Partial update: only the one edited slot is sent. The engine merges
+        // overrides per-slot and preserves label/description/published when
+        // absent from the PUT. Sending the full cached object would race with
+        // a concurrent publish/unpublish (stale `published` flips it back) or
+        // another concurrent slot save (stale overrides clobber it).
         saveMode.mutate({
           name: selectedMode,
-          body: {
-            label: modeQuery.data?.label,
-            description: modeQuery.data?.description,
-            overrides: updated,
-            published: modeQuery.data?.published,
-          },
+          body: { overrides: { [slot]: value || undefined } },
         });
       } else {
-        updateOrg.mutate(updated);
+        updateOrg.mutate({ ...currentOverrides, [slot]: value || undefined });
       }
     },
-    [currentOverrides, selectedMode, modeQuery.data, saveMode, updateOrg]
+    [currentOverrides, selectedMode, saveMode, updateOrg]
   );
 
   const handleCreateMode = useCallback(

--- a/src/app/pages/manual-config.tsx
+++ b/src/app/pages/manual-config.tsx
@@ -11,6 +11,7 @@ import {
   useModes,
   useOrgOverrides,
   useSaveMode,
+  useSetModePublished,
   useUpdateOrgOverrides,
 } from "@/hooks/use-prompt-config";
 import type { PromptOverrides, PromptSlot } from "@/types/prompt-override";
@@ -23,6 +24,8 @@ export function ManualConfigPage() {
   const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
   const selectedMode = useUiStore((s) => s.selectedMode);
   const setSelectedMode = useUiStore((s) => s.setSelectedMode);
+  const showDrafts = useUiStore((s) => s.showDrafts);
+  const setShowDrafts = useUiStore((s) => s.setShowDrafts);
   const [memoryDialogOpen, setMemoryDialogOpen] = useState(false);
 
   // Queries
@@ -34,6 +37,7 @@ export function ManualConfigPage() {
   const updateOrg = useUpdateOrgOverrides();
   const saveMode = useSaveMode();
   const deleteMode = useDeleteMode();
+  const setModePublished = useSetModePublished();
 
   // Current overrides based on selection
   const currentOverrides = useMemo<PromptOverrides>(
@@ -55,6 +59,7 @@ export function ManualConfigPage() {
             label: modeQuery.data?.label,
             description: modeQuery.data?.description,
             overrides: updated,
+            published: modeQuery.data?.published,
           },
         });
       } else {
@@ -73,12 +78,20 @@ export function ManualConfigPage() {
             label: label || undefined,
             description: description || undefined,
             overrides: orgOverrides.data ?? {},
+            published: false,
           },
         },
         { onSuccess: () => setSelectedMode(name) }
       );
     },
     [saveMode, orgOverrides.data, setSelectedMode]
+  );
+
+  const handleSetPublished = useCallback(
+    (name: string, published: boolean) => {
+      setModePublished.mutate({ name, published });
+    },
+    [setModePublished]
   );
 
   const handleDeleteMode = useCallback(
@@ -119,8 +132,13 @@ export function ManualConfigPage() {
             onSelectMode={setSelectedMode}
             onCreateMode={handleCreateMode}
             onDeleteMode={handleDeleteMode}
+            onSetPublished={handleSetPublished}
             isCreating={saveMode.isPending}
             isDeleting={deleteMode.isPending}
+            isSettingPublished={setModePublished.isPending}
+            showDrafts={showDrafts}
+            onToggleShowDrafts={setShowDrafts}
+            isAdmin={isAdmin}
           />
 
           {/* Error banner */}

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useState } from "react";
 import { faLayerGroup } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Plus, Trash2 } from "lucide-react";
+import { Eye, EyeOff, Plus, Send, SendHorizontal, Trash2 } from "lucide-react";
 
-import type { OrgModes } from "@/types/prompt-override";
+import type { OrgModes, PromptMode } from "@/types/prompt-override";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -15,6 +15,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -34,8 +35,17 @@ interface ModeSelectorProps {
   onSelectMode: (mode: string | null) => void;
   onCreateMode: (name: string, label: string, description: string) => void;
   onDeleteMode: (name: string) => void;
+  onSetPublished: (name: string, published: boolean) => void;
   isCreating: boolean;
   isDeleting: boolean;
+  isSettingPublished: boolean;
+  showDrafts: boolean;
+  onToggleShowDrafts: (showDrafts: boolean) => void;
+  isAdmin: boolean;
+}
+
+function isPublished(mode: Pick<PromptMode, "published">): boolean {
+  return mode.published === true;
 }
 
 export function ModeSelector({
@@ -44,8 +54,13 @@ export function ModeSelector({
   onSelectMode,
   onCreateMode,
   onDeleteMode,
+  onSetPublished,
   isCreating,
   isDeleting,
+  isSettingPublished,
+  showDrafts,
+  onToggleShowDrafts,
+  isAdmin,
 }: ModeSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -53,6 +68,16 @@ export function ModeSelector({
   const [newDescription, setNewDescription] = useState("");
 
   const modes = modesData?.modes ?? [];
+  const selectedModeData = modes.find((m) => m.name === selectedMode) ?? null;
+  const selectedIsPublished = selectedModeData
+    ? isPublished(selectedModeData)
+    : false;
+
+  // If drafts are hidden, still show the currently-selected draft so we don't
+  // orphan the user's selection.
+  const visibleModes = modes.filter(
+    (m) => showDrafts || isPublished(m) || m.name === selectedMode
+  );
 
   const handleCreate = useCallback(() => {
     const slug = newName
@@ -92,23 +117,97 @@ export function ModeSelector({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="__org__">Org Defaults</SelectItem>
-              {modes.length > 0 && <SelectSeparator />}
-              {modes.map((m) => (
+              {visibleModes.length > 0 && <SelectSeparator />}
+              {visibleModes.map((m) => (
                 <SelectItem key={m.name} value={m.name}>
-                  {m.label || m.name}
+                  <span className="flex items-center gap-2">
+                    <span className="truncate">{m.label || m.name}</span>
+                    {!isPublished(m) && (
+                      <Badge
+                        variant="outline"
+                        className="px-1.5 py-0 text-[10px]"
+                      >
+                        Draft
+                      </Badge>
+                    )}
+                  </span>
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
 
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onToggleShowDrafts(!showDrafts)}
+          title={showDrafts ? "Hide drafts from the list" : "Show drafts"}
+        >
+          {showDrafts ? (
+            <Eye className="mr-1.5 size-3.5" />
+          ) : (
+            <EyeOff className="mr-1.5 size-3.5" />
+          )}
+          {showDrafts ? "Drafts shown" : "Drafts hidden"}
+        </Button>
+
         <Button size="sm" onClick={() => setShowCreate(!showCreate)}>
           <Plus className="mr-1.5 size-3.5" />
           New Mode
         </Button>
 
-        {selectedMode !== null && (
-          <div className="border-border flex items-center gap-1 sm:border-l sm:pl-3">
+        {selectedMode !== null && selectedModeData && (
+          <div className="border-border flex items-center gap-2 sm:border-l sm:pl-3">
+            <Badge
+              variant={selectedIsPublished ? "default" : "outline"}
+              className="shrink-0"
+            >
+              {selectedIsPublished ? "Published" : "Draft"}
+            </Badge>
+
+            {isAdmin &&
+              (selectedIsPublished ? (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={isSettingPublished}
+                    >
+                      <SendHorizontal className="mr-1.5 size-3.5" />
+                      Unpublish
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Unpublish mode?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This mode will immediately disappear for all end users.
+                        Admins will still be able to see and edit it as a draft.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => onSetPublished(selectedMode, false)}
+                      >
+                        Unpublish
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={isSettingPublished}
+                  onClick={() => onSetPublished(selectedMode, true)}
+                >
+                  <Send className="mr-1.5 size-3.5" />
+                  Publish
+                </Button>
+              ))}
+
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button
@@ -151,6 +250,10 @@ export function ModeSelector({
         <div className="bg-card animate-in fade-in slide-in-from-bottom-4 rounded-xl border p-4 shadow-sm duration-200">
           <p className="text-foreground mb-3 text-sm font-medium">
             Create a new mode
+          </p>
+          <p className="text-muted-foreground mb-3 text-xs">
+            New modes are created as drafts and are not visible to end users
+            until published.
           </p>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
@@ -204,7 +307,7 @@ export function ModeSelector({
               onClick={handleCreate}
               disabled={!newName.trim() || isCreating}
             >
-              {isCreating ? "Creating..." : "Create Mode"}
+              {isCreating ? "Creating..." : "Create Draft"}
             </Button>
           </div>
         </div>

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -66,8 +66,34 @@ export function useSaveMode() {
         label?: string;
         description?: string;
         overrides: PromptOverrides;
+        published?: boolean;
       };
     }) => configApi.putMode(name, body),
+    onSuccess: (_data, { name }) => {
+      void qc.invalidateQueries({ queryKey: keys.modes });
+      void qc.invalidateQueries({ queryKey: keys.mode(name) });
+    },
+  });
+}
+
+export function useSetModePublished() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      name,
+      published,
+    }: {
+      name: string;
+      published: boolean;
+    }) => {
+      const current = await configApi.getMode(name);
+      return configApi.putMode(name, {
+        label: current.label,
+        description: current.description,
+        overrides: current.overrides,
+        published,
+      });
+    },
     onSuccess: (_data, { name }) => {
       void qc.invalidateQueries({ queryKey: keys.modes });
       void qc.invalidateQueries({ queryKey: keys.mode(name) });

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -79,21 +79,12 @@ export function useSaveMode() {
 export function useSetModePublished() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async ({
-      name,
-      published,
-    }: {
-      name: string;
-      published: boolean;
-    }) => {
-      const current = await configApi.getMode(name);
-      return configApi.putMode(name, {
-        label: current.label,
-        description: current.description,
-        overrides: current.overrides,
-        published,
-      });
-    },
+    // Partial update: only `published` is sent. The engine merges `overrides`
+    // per-slot and preserves label/description/overrides when they are absent
+    // from the PUT (incoming.x ?? existing.x). This avoids the GET→PUT race
+    // where a concurrent slot save could be overwritten by stale overrides.
+    mutationFn: ({ name, published }: { name: string; published: boolean }) =>
+      configApi.putMode(name, { overrides: {}, published }),
     onSuccess: (_data, { name }) => {
       void qc.invalidateQueries({ queryKey: keys.modes });
       void qc.invalidateQueries({ queryKey: keys.mode(name) });

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -112,7 +112,12 @@ export async function getMode(
 
 export async function putMode(
   name: string,
-  body: { label?: string; description?: string; overrides: PromptOverrides },
+  body: {
+    label?: string;
+    description?: string;
+    overrides: PromptOverrides;
+    published?: boolean;
+  },
   signal?: AbortSignal
 ): Promise<PromptMode> {
   const res = await fetch(`/api/config/modes/${encodeURIComponent(name)}`, {

--- a/src/lib/ui-store.ts
+++ b/src/lib/ui-store.ts
@@ -21,6 +21,8 @@ interface UiState {
   testChatPanelWidth: number;
   setTestChatPanelWidth: (width: number) => void;
   persistTestChatPanelWidth: () => void;
+  showDrafts: boolean;
+  setShowDrafts: (showDrafts: boolean) => void;
   reset: () => void;
 }
 
@@ -37,7 +39,14 @@ type InitialUiState = Pick<
   | "chatModeSeeded"
   | "testChatUserId"
   | "testChatPanelWidth"
+  | "showDrafts"
 >;
+
+function loadPersistedShowDrafts(): boolean {
+  const stored = localStorage.getItem("showDrafts");
+  if (stored === "false") return false;
+  return true;
+}
 
 function loadPersistedWidth(): number {
   const stored = localStorage.getItem("testChatPanelWidth");
@@ -63,6 +72,7 @@ const initialState: InitialUiState = {
   // used for the very first session (before any logout occurs).
   testChatUserId: crypto.randomUUID(),
   testChatPanelWidth: loadPersistedWidth(),
+  showDrafts: loadPersistedShowDrafts(),
 };
 
 export const useUiStore = create<UiState>()((set) => ({
@@ -97,6 +107,10 @@ export const useUiStore = create<UiState>()((set) => ({
     const { testChatPanelWidth } = useUiStore.getState();
     localStorage.setItem("testChatPanelWidth", String(testChatPanelWidth));
   },
+  setShowDrafts: (showDrafts) => {
+    localStorage.setItem("showDrafts", String(showDrafts));
+    set({ showDrafts });
+  },
   // Resets all session-scoped UI state and generates a new testChatUserId so
   // the next user's chat session is fully isolated from the previous one.
   // testChatPanelWidth is intentionally preserved — it's a UI preference, not
@@ -106,5 +120,6 @@ export const useUiStore = create<UiState>()((set) => ({
       ...initialState,
       testChatUserId: crypto.randomUUID(),
       testChatPanelWidth: state.testChatPanelWidth,
+      showDrafts: state.showDrafts,
     })),
 }));

--- a/src/types/prompt-override.ts
+++ b/src/types/prompt-override.ts
@@ -47,6 +47,7 @@ export interface PromptMode {
   label?: string;
   description?: string;
   overrides: PromptOverrides;
+  published?: boolean;
 }
 
 export interface OrgModes {


### PR DESCRIPTION
## Summary

- Adds `published?: boolean` to the `PromptMode` type and threads it through the API/hook layer.
- `ModeSelector` now shows Draft/Published badges (inline in the dropdown + prominent next to the selected mode), a persisted "Drafts shown/hidden" toggle, and an **admin-only** Publish/Unpublish button. Unpublish is gated by an `AlertDialog` warning that end users will immediately lose access.
- New modes are created with `published: false` (drafts by default); publishing is an explicit follow-up action. Slot saves preserve the current published state.
- Version bump: **1.4.1 → 1.5.0**.

## Dependency

Requires unfoldingWord/bt-servant-worker#151 (already merged) and its backfill of existing modes to `published: true`. Do not merge this before the backfill is confirmed — otherwise every existing mode would disappear for end users.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] Against staging worker: create a new mode → confirm Draft badge renders and chat's `list_modes` does not return it
- [ ] Click **Publish** → badge flips, mode appears in chat's `list_modes` / switchable via `switch_mode`
- [ ] Click **Unpublish** → confirmation dialog → confirm → mode disappears from chat again
- [ ] Toggle "Drafts hidden" → drafts disappear from dropdown; a currently-selected draft stays visible (not orphaned)
- [ ] Sign in as a non-admin → Publish/Unpublish buttons are hidden; badges still render
- [ ] Backfilled modes in staging show the Published badge

Closes #68