### PR TITLE
Bump MAX_SLOT_LENGTH to 8000 to match worker (closes #70)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-admin-portal",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.1.0",
         "@fortawesome/pro-duotone-svg-icons": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/types/prompt-override.ts
+++ b/src/types/prompt-override.ts
@@ -7,7 +7,7 @@ export type PromptSlot =
   | "memory_instructions"
   | "closing";
 
-export type PromptOverrides = Partial<Record<PromptSlot, string>>; // max 4000 chars/slot
+export type PromptOverrides = Partial<Record<PromptSlot, string>>; // max 8000 chars/slot
 
 export const PROMPT_SLOTS: PromptSlot[] = [
   "identity",
@@ -40,7 +40,7 @@ export const SLOT_DESCRIPTIONS: Record<PromptSlot, string> = {
   closing: "How the assistant wraps up and signs off",
 };
 
-export const MAX_SLOT_LENGTH = 4000;
+export const MAX_SLOT_LENGTH = 8000;
 
 export interface PromptMode {
   name: string;


### PR DESCRIPTION
## Summary

- `src/types/prompt-override.ts`: `MAX_SLOT_LENGTH` 4000 → 8000; update the stale `// max 4000 chars/slot` comment on `PromptOverrides` to match.
- Patch-bump `1.5.0` → `1.5.1`.

Mirrors the worker-side validator raise in [bt-servant-worker#167](https://github.com/unfoldingWord/bt-servant-worker/pull/167). Without this, the prompt-panel editor caps slot drafts at 4000 chars even though the API now accepts up to 8000 — blocking the "Closing the Turn" guidance additions on legacy closing slots that were already near the old limit.

`src/components/prompt-panel.tsx` already references `MAX_SLOT_LENGTH` by name in three places (over-limit gate + two character counters), so the new ceiling is picked up automatically. No other files reference the constant or the literal `4000`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (zero warnings)
- [x] `npm run build` clean
- [ ] Dev server: open a mode in the prompt panel — counter reads `/ 8,000` and the over-limit warning only fires past 8000 chars
- [ ] Post-merge + post-worker-deploy: save a ~6000-char slot to staging and confirm the API accepts it

Closes #70