### PR TITLE
ci: per-PR ephemeral CF Workers (closes #83)

### DIFF
--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -24,7 +24,11 @@ jobs:
 
       - name: Delete the per-PR worker
         id: delete
-        run: npx --yes wrangler@^4 delete --name "$WORKER_NAME"
+        # `--force` is required for non-interactive runs — wrangler 4.x prompts
+        # for confirmation by default even without a TTY, so without --force
+        # the step would hang or appear to silently no-op (per Frank review,
+        # 2026-05-07).
+        run: npx --yes wrangler@^4 delete "$WORKER_NAME" --force
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -1,0 +1,51 @@
+name: Cleanup PR Worker
+
+# Deletes the per-PR ephemeral Cloudflare Worker when a PR closes (merge or
+# close-without-merge). Without this, ephemeral workers from `deploy-pr.yml`
+# would accumulate forever in the Cloudflare account.
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: Delete ephemeral worker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      WORKER_NAME: bt-servant-admin-portal-pr-${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Delete the per-PR worker
+        id: delete
+        run: npx --yes wrangler@^4 delete --name "$WORKER_NAME"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        continue-on-error: true
+
+      - name: Comment on the closed PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          WORKER_NAME: ${{ env.WORKER_NAME }}
+          DELETE_OUTCOME: ${{ steps.delete.outcome }}
+        with:
+          script: |
+            const name = process.env.WORKER_NAME;
+            const ok = process.env.DELETE_OUTCOME === "success";
+            const body = ok
+              ? `### PR cleanup complete\n\nDeleted ephemeral worker \`${name}\`. If you reopen this PR, a fresh deploy will be created.`
+              : `### PR cleanup attempted\n\nCould not delete ephemeral worker \`${name}\` — it may not have been deployed, or the delete already happened. If a worker still exists, remove it via the Cloudflare dashboard.`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,4 +1,12 @@
-name: Deploy Dev
+name: Deploy PR
+
+# Per-PR ephemeral Cloudflare Workers, one worker per open PR. Each PR gets a
+# uniquely-named worker (`bt-servant-admin-portal-pr-<N>`) so concurrent PRs
+# do not clobber each other. The companion `cleanup-pr.yml` deletes the
+# worker when the PR closes.
+#
+# `workflow_dispatch` runs (no PR number) fall back to the legacy
+# `bt-servant-admin-portal-dev` worker as a manual scratch deploy target.
 
 on:
   workflow_dispatch:
@@ -8,11 +16,14 @@ on:
 
 jobs:
   deploy:
-    name: Deploy to Dev
+    name: Deploy to Cloudflare Workers
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+    env:
+      WORKER_NAME: ${{ github.event.pull_request.number && format('bt-servant-admin-portal-pr-{0}', github.event.pull_request.number) || 'bt-servant-admin-portal-dev' }}
+      WORKER_URL: ${{ github.event.pull_request.number && format('https://bt-servant-admin-portal-pr-{0}.unfoldingword.workers.dev', github.event.pull_request.number) || 'https://bt-servant-admin-portal-dev.unfoldingword.workers.dev' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,13 +43,13 @@ jobs:
       - name: Build application
         run: npm run build
 
-      - name: Patch wrangler config for dev environment
+      - name: Patch wrangler config (per-PR worker name)
         run: |
           node -e "
             const fs = require('fs');
             const p = 'dist/bt_servant_admin_portal/wrangler.json';
             const c = JSON.parse(fs.readFileSync(p, 'utf8'));
-            c.name = 'bt-servant-admin-portal-dev';
+            c.name = process.env.WORKER_NAME;
             c.kv_namespaces = [{ binding: 'AUTH_KV', id: 'fe1fdafdb04a4fa085b38c0a79e7a590' }];
             c.services = [{ binding: 'BARUCH', service: 'baruch-dev' }];
             c.vars = { ENGINE_BASE_URL: 'https://staging-api.btservant.ai', BARUCH_BASE_URL: 'https://baruch-dev.unfoldingword.workers.dev' };
@@ -46,22 +57,30 @@ jobs:
             console.log('Patched:', JSON.stringify({ name: c.name, services: c.services, kv: c.kv_namespaces, vars: c.vars }));
           "
 
-      - name: Deploy to Cloudflare Workers (dev)
+      - name: Deploy
         run: npx wrangler deploy --config dist/bt_servant_admin_portal/wrangler.json
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Comment PR with dev URL
+      - name: Comment PR with deploy URL
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          WORKER_NAME: ${{ env.WORKER_NAME }}
+          WORKER_URL: ${{ env.WORKER_URL }}
         with:
           script: |
-            const body = `### Dev deployment complete
-
-            **URL:** https://bt-servant-admin-portal-dev.unfoldingword.workers.dev
-
-            This dev deployment is updated on every push to this PR.`;
+            const name = process.env.WORKER_NAME;
+            const url = process.env.WORKER_URL;
+            const body = [
+              `### Dev deployment complete`,
+              ``,
+              `**Worker:** \`${name}\``,
+              `**URL:** ${url}`,
+              ``,
+              `This per-PR worker is updated on every push to this PR and removed when the PR closes.`,
+            ].join("\n");
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- Each PR now deploys to its own uniquely-named worker (`bt-servant-admin-portal-pr-<N>`) instead of clobbering the shared `bt-servant-admin-portal-dev`.
- Closing a PR (merge or close-without-merge) automatically deletes its ephemeral worker via a new `cleanup-pr.yml` workflow.
- Manual `workflow_dispatch` runs fall back to the legacy `bt-servant-admin-portal-dev` name as a scratch deploy target.

Closes #83.

## What changed

`.github/workflows/deploy-dev.yml` → `.github/workflows/deploy-pr.yml`
- WORKER_NAME computed at job level via a GH-expression ternary on `github.event.pull_request.number`.
- Wrangler-config patch step reads `$WORKER_NAME` instead of hardcoding the dev worker name.
- PR comment links to the per-PR URL and surfaces the worker name so reviewers know which worker their PR is hitting.
- KV namespace, BARUCH service binding, and ENGINE_BASE_URL still shared with the dev environment — cross-PR session bleed in dev is acceptable, and per-PR KV provisioning would add CI complexity not justified at this scale.

`.github/workflows/cleanup-pr.yml` (new)
- Triggered on `pull_request: types: [closed]`.
- Runs `npx --yes wrangler@^4 delete --name "$WORKER_NAME"` directly (no `npm ci`, so FA Pro auth isn't needed for the cleanup path).
- Posts a confirmation comment, distinguishing successful delete from "delete attempted" (worker may not have been deployed).
- `continue-on-error: true` on the delete step so the comment posts even if delete fails — preferable to a silent CI failure on PRs that never had their first deploy succeed.

Staging and production workflows are unaffected.

## Caveat about this PR specifically

GitHub Actions on `pull_request` runs workflow files from `main`, not from the PR branch (when the workflow file is new in the PR). That means **this PR's own deploy will run via the OLD `deploy-dev.yml` from main** — clobbering whatever was at `bt-servant-admin-portal-dev`. Once merged, all subsequent PRs use the new pattern.

## Test plan

- [ ] CI passes on this PR (lint, format, typecheck, build, audit).
- [ ] Old `deploy-dev.yml` from main runs and deploys to `bt-servant-admin-portal-dev` as before (this PR's deploy uses the old workflow per the caveat above).
- [ ] After merge: open a follow-up trivial PR (e.g., README typo) and confirm it deploys to `bt-servant-admin-portal-pr-<N>` and posts the per-PR URL comment.
- [ ] Close that follow-up PR and confirm `cleanup-pr.yml` runs, deletes the worker, and posts the cleanup comment.
- [ ] Confirm `workflow_dispatch` from the Actions UI still produces a deploy to `bt-servant-admin-portal-dev` as a scratch target.