### PR TITLE
docs: seed progress_tracker with 2026-05-07 entry

### DIFF
--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -7,6 +7,13 @@ name: Cleanup PR Worker
 on:
   pull_request:
     types: [closed]
+    # Stay in sync with deploy-pr.yml — if the deploy was skipped for
+    # docs-only changes, there's no worker to clean up.
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "mockups/**"
+      - ".gitignore"
 
 jobs:
   cleanup:

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -13,6 +13,13 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+    # Skip the deploy when only docs/mockups change — no build artefacts
+    # depend on those, so a Worker redeploy is wasted CI time.
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "mockups/**"
+      - ".gitignore"
 
 jobs:
   deploy:

--- a/docs/progress_tracker.md
+++ b/docs/progress_tracker.md
@@ -1,0 +1,89 @@
+# BT Servant Admin Portal — Progress Tracker
+
+> Single source of truth for project status. Updated via `/progress` and `/eod`.
+
+## Current Status
+
+**Phase**: Active development on Epic #72 (Admin Portal Redesign for Response Tuning)
+**Last Updated**: 2026-05-07
+**Demo target**: June 9 — `#spoken @arabic` working end-to-end with the new editor
+
+## Milestones
+
+| Milestone                         | Progress | Status             |
+| --------------------------------- | -------- | ------------------ |
+| Per-PR ephemeral CF Workers (#83) | 100%     | Shipped 2026-05-07 |
+| Epic #72 — Admin Portal Redesign  | ~10%     | In Progress        |
+
+### Per-PR ephemeral CF Workers — Shipped
+
+- [x] Issue filed (#83)
+- [x] Implementation (#84) — `deploy-pr.yml` + `cleanup-pr.yml`
+- [x] Frank review + P1 fix (`--force` on wrangler delete)
+- [x] Merged at `3e8d087`
+- [x] Validated end-to-end via #85 deploy + cleanup
+- [x] Pattern documented for Ian's adoption in sibling repos
+
+### Epic #72 — Admin Portal Redesign for Response Tuning (In Progress)
+
+This-repo sub-issues:
+
+- [x] **#75** — Markdown editor + TOC component (shipped 2026-05-07, PR #85)
+- [ ] #73 — Add Languages tab to admin portal sidebar (depends on #79 + #75)
+- [ ] #74 — Pre-load structural heading scaffold for new language documents
+- [ ] #76 — Replace six-box mode editor with markdown editor + TOC (depends on #75 + engine #204)
+- [ ] #77 — Comment-block syntax in editor (depends on #75; uses Ulysses `%%` + `++…++`)
+- [ ] #79 — Languages CRUD API (worker BFF + frontend client)
+- [ ] #80 — Define and enforce language-shepherd permissions
+- [ ] #81 — Wire test chat to active mode + language selection
+- [ ] #82 — Mode data migration (portal side; depends on engine #204)
+
+Engine repo (`unfoldingWord/bt-servant-engine`):
+
+- [ ] #203 — `#<mode> @<language>` trigger syntax (prompt-driven, not regex)
+- [ ] #204 — Mode migration Phase 1 (synthesize markdown on GET, tolerate both shapes)
+- [ ] #205 — Strip Ulysses-style comments before assembling system prompt
+
+## Session Log
+
+### 2026-05-07 — Project kickoff + per-PR deploys + #75 markdown editor
+
+**Completed:**
+
+- **Repo setup** — `git init` in `/workspace/bt-servant-admin-portal`, added `unfoldingWord` remote, fetched `main`. Migrated Claude state from host to uw-sandbox container.
+- **Epic #72 triage** — Read all existing sub-issues (#73–#77), audited the codebase, identified gaps in the Epic's filings, drafted six new sub-issues (Drafts A–F) covering: Languages CRUD API, language-shepherd permissions, test-chat wiring, trigger syntax, mode migration, comment-block stripping.
+- **Filed sub-issues** — #79, #80, #81, #82 (this repo); #203, #204, #205 (engine repo). All cross-linked. #82 + #204 paired and gated.
+- **Updated #77 + engine #205** — Tim Jore corrected the comment-syntax convention to canonical Ulysses (`%%` paragraph + `++…++` span, not the `&&...&&` originally proposed). Researched against official Ulysses docs (help.ulysses.app), posted findings with provenance on both issues.
+- **#83 — Per-PR ephemeral CF Workers** — filed, implemented, reviewed by Frank (P1 caught: `wrangler delete` needs `--force` in CI), fixed, re-reviewed clean, merged at `3e8d087`.
+- **#75 — Markdown editor + TOC** — Designed via cowork mockup with frontend-design skill pass ("Outline-as-Index-Page" direction: spine rail + Roman numerals + active-section pin + paper-toned editor surface). Aligned mockup to project tokens (Outfit-only typography, FA Pro convention noted). Lifted into source: parser, types, two components, three hooks, design tokens. Merged at `e347370`.
+- **Pattern doc** — Wrote up the per-PR deploy mechanism as a reusable reference for Ian to adopt in sibling repos (engine, data-loaders).
+
+**In Progress:**
+
+- None — both shipped items merged. Next session opens with sub-issue selection from the Epic #72 list above.
+
+**Blockers:**
+
+- None.
+
+**Next Steps:**
+
+- Pick the next Epic #72 sub-issue to start. Most foundational and parallelizable: **#79 (Languages CRUD API)** — design-independent, foundational for #73 + #80. After that, **#76 (replace six-box editor)** is the natural follow-on now that #75 has shipped, but it's gated on engine #204 deploying first.
+- Validate engine team progress on #203, #204, #205 before locking the consumer-side work.
+- AGENTS.md is untracked (Codex-equivalent of CLAUDE.md, generated locally, not in git). Decide whether to commit, add to `.gitignore`, or leave untracked.
+- Consider whether the GitHub Actions workflows are using deprecated Node.js 20 — `actions/checkout@v4`, `actions/setup-node@v4` etc. flagged as deprecated by Sept 2026. Worth a tech-debt issue but not urgent.
+
+## Known Issues
+
+- None
+
+## Architectural Decisions
+
+Track ADRs under `docs/adr/` if/when needed.
+
+Notable decisions made 2026-05-07 (captured here pending ADRs):
+
+- **Ulysses comment syntax** — Mode and language documents use `%%` (paragraph comment) and `++…++` (paired inline span), verbatim Ulysses convention per Tim Jore. Source: [help.ulysses.app](https://help.ulysses.app/en_US/comments-notes-annotations).
+- **Per-PR deploy pattern** — Each PR deploys to `bt-servant-admin-portal-pr-<N>`, auto-deleted on close. `wrangler delete --force` is required for non-interactive runs (per Frank review).
+- **Trigger-syntax parsing** — `#<mode> @<language>` should be parsed using BT Servant's existing prompt-driven intent classification pattern, not regex (per Ian).
+- **Editor design direction** — "Outline-as-Index-Page": spine rail with Roman-numeral H2s and subordinate-rail H3s, active-section pin (`--editor-active`), warm-paper editor surface distinct from the chrome's neutral `--card`. Lives in `src/components/markdown-toc.tsx`.


### PR DESCRIPTION
## Summary
- Replaces the empty `docs/progress_tracker.md` template with today's session entry, populating Phase / Last Updated / Demo target.
- Captures milestones (Per-PR ephemeral CF Workers shipped; Epic #72 ~10% complete) with sub-issue checklist.
- Records 2026-05-07 session log: kickoff, sub-issue triage and filings, Ulysses syntax research, #83/#84 (per-PR deploys), #75/#85 (markdown editor + TOC).
- Captures four notable architectural decisions made today (Ulysses syntax, per-PR deploy pattern, trigger-syntax parsing, editor design direction).

This pairs with the `/eod` skill's expected canonical project-state location. Future sessions will append to the Session Log here.

## Test plan
- [ ] CI green
- [ ] Per-PR deploy creates a `bt-servant-admin-portal-pr-<N>` worker (verifies new pipeline still works on a docs-only PR)
- [ ] Closing the PR triggers cleanup