### PR TITLE
ci: deploy staging directly on PR merge (closes #89)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Type check before build — vite strips types, so a tsc error would not
+      # fail `npm run build` on its own. Per Frank's review of #89: a merge
+      # commit could land on main with a type error if branch protection
+      # ever lets one through, and we don't want staging to deploy that.
+      - name: Type check
+        run: npm run typecheck
+
       - name: Build application
         run: npm run build
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,22 +1,51 @@
 name: Deploy Staging
 
+# Direct staging deploy on PR merge (closes #89). Replaces the prior indirect
+# `workflow_run: workflows: ["CI"]` trigger so the staging deploy is a
+# consequence of the merge event itself, with PR-level provenance and a
+# comment back to the PR linking the staging URL.
+#
+# Docs/mockups-only PRs skip the staging deploy (mirror of deploy-pr.yml's
+# paths-ignore) — no build artefact changed, so no need to redeploy.
+#
+# `workflow_dispatch` is preserved as a manual recovery path in case a merge
+# event is missed or the deploy needs to be re-run from a specific ref.
+
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  workflow_dispatch:
+  pull_request:
     branches: [main]
+    types: [closed]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "mockups/**"
+      - ".gitignore"
+
+# Serialize staging deploys so two PRs merging in quick succession don't race.
+# `cancel-in-progress: false` — every merged PR gets deployed in order, the
+# later merge's artefact wins.
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
 
 jobs:
   deploy:
     name: Deploy to Staging
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only run on a successful merge or a manual dispatch. A close-without-merge
+    # leaves staging untouched.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # On a PR-merge run, check out the merge commit (now on main).
+          # On workflow_dispatch, fall back to the default ref the dispatch was
+          # made against.
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -53,3 +82,28 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Comment on the merged PR with staging URL
+        # Only fires on PR-merge runs; workflow_dispatch has no PR context.
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = "https://bt-servant-admin-portal-staging.unfoldingword.workers.dev";
+            const sha = context.payload.pull_request.merge_commit_sha;
+            const body = [
+              `### Staging deploy complete`,
+              ``,
+              `**Worker:** \`bt-servant-admin-portal-staging\``,
+              `**URL:** ${url}`,
+              `**Merge commit:** \`${sha}\``,
+              ``,
+              `Triggered by the merge of this PR. The per-PR ephemeral worker for this PR will be torn down by \`cleanup-pr.yml\`.`,
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });


### PR DESCRIPTION
## Summary

Replaces the indirect `workflow_run` trigger in `deploy-staging.yml` with a direct `pull_request: closed` + `merged == true` trigger. Closes #89.

Per Ian: staging should deploy as a *consequence of the merge*, not a side effect of CI happening to pass on `main`.

## Changes

- **Trigger swap**: `workflow_run` → `pull_request: closed`, gated on `merged == true`. Close-without-merge leaves staging untouched.
- **Paths-ignore** mirrors `deploy-pr.yml` so docs/mockups-only PRs skip the staging deploy.
- **Concurrency group** `deploy-staging` serializes deploys when two PRs merge in quick succession (`cancel-in-progress: false` — last merge wins, but no race).
- **Checkout** uses `pull_request.merge_commit_sha` for bit-for-bit fidelity to the merged code.
- **workflow_dispatch** retained as a manual recovery path.
- **PR comment-back**: post the staging URL + merge commit SHA on the merged PR (mirrors the per-PR ephemeral worker comment pattern).

Build/install/wrangler steps are unchanged.

## Why this trigger

Recommended Option A from #89:

- Direct tie to the merge event; PR number always known; can comment back on the PR.
- Surfaces as a job under the PR's "Checks" tab.
- Doesn't gate on CI passing on `main` post-merge — the workflow itself runs typecheck/build via `npm run build` before deploying, and the merge is already gated on PR-level CI passing.

## Test plan

The workflow file change only takes effect *from the next merge onwards* — the merge of *this* PR will be the first real-world test. CI on this PR validates YAML syntax (Code Quality, Build, Secret Scan, Deploy to Cloudflare Workers ephemeral). The actual `Deploy Staging` workflow won't fire on this PR until it's merged.

- [x] Local pre-commit (husky → lint-staged → typecheck → build) passes
- [ ] CI green on this PR
- [ ] On merge: `Deploy Staging` workflow fires once on the closed-merged event
- [ ] Comment posted on this PR with staging URL + merge commit SHA after deploy
- [ ] Staging is reachable at `https://bt-servant-admin-portal-staging.unfoldingword.workers.dev`

## Follow-up

If this proves out, sibling repos (per the per-PR-worker pattern doc) can adopt the same trigger.