### PR TITLE
feat: Languages CRUD API in worker BFF + frontend client (closes #79)

### DIFF
--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -1,0 +1,85 @@
+import type { Language, OrgLanguages } from "@/types/language";
+
+const SAME_ORIGIN_HEADERS = {
+  "X-Requested-With": "XMLHttpRequest",
+} as const;
+
+export async function listLanguages(
+  signal?: AbortSignal
+): Promise<OrgLanguages> {
+  const res = await fetch("/api/config/languages", {
+    headers: SAME_ORIGIN_HEADERS,
+    signal,
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to load languages (${res.status}): ${body}`);
+  }
+
+  return (await res.json()) as OrgLanguages;
+}
+
+export async function getLanguage(
+  name: string,
+  signal?: AbortSignal
+): Promise<Language> {
+  const res = await fetch(`/api/config/languages/${encodeURIComponent(name)}`, {
+    headers: SAME_ORIGIN_HEADERS,
+    signal,
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to load language (${res.status}): ${body}`);
+  }
+
+  const data = (await res.json()) as Record<string, unknown>;
+
+  // Engine API may wrap in { org, language: {...} } (mirror of how
+  // GET /modes/{name} wraps as { org, mode: {...} }). Unwrap if present.
+  if ("language" in data && typeof data.language === "object") {
+    return data.language as Language;
+  }
+  return data as unknown as Language;
+}
+
+export async function putLanguage(
+  name: string,
+  body: {
+    label?: string;
+    document: string;
+    published?: boolean;
+  },
+  signal?: AbortSignal
+): Promise<Language> {
+  const res = await fetch(`/api/config/languages/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Failed to save language (${res.status}): ${text}`);
+  }
+
+  return (await res.json()) as Language;
+}
+
+export async function deleteLanguage(
+  name: string,
+  signal?: AbortSignal
+): Promise<void> {
+  const res = await fetch(`/api/config/languages/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+    headers: SAME_ORIGIN_HEADERS,
+    signal,
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to delete language (${res.status}): ${body}`);
+  }
+}

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,0 +1,10 @@
+export interface Language {
+  name: string;
+  label?: string;
+  document: string;
+  published?: boolean;
+}
+
+export interface OrgLanguages {
+  languages: Language[];
+}

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -80,6 +80,18 @@ export async function handleConfig(
     );
   }
 
+  // /api/config/languages/{name} → GET/PUT/DELETE
+  const languageMatch = pathname.match(/^\/api\/config\/languages\/(.+)$/);
+  if (languageMatch?.[1]) {
+    const languageName = decodeURIComponent(languageMatch[1]);
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(languageName)}`,
+      ["GET", "PUT", "DELETE"]
+    );
+  }
+
   // /api/config/user-mode/{userId} → PUT/DELETE (UUID v4 only)
   const userModeMatch = pathname.match(/^\/api\/config\/user-mode\/(.+)$/);
   if (userModeMatch?.[1]) {
@@ -113,6 +125,13 @@ export async function handleConfig(
   // /api/config/modes → GET
   if (pathname === "/api/config/modes") {
     return proxyToEngine(request, env, `/api/v1/admin/orgs/${org}/modes`, [
+      "GET",
+    ]);
+  }
+
+  // /api/config/languages → GET
+  if (pathname === "/api/config/languages") {
+    return proxyToEngine(request, env, `/api/v1/admin/orgs/${org}/languages`, [
       "GET",
     ]);
   }


### PR DESCRIPTION
## Summary

Mirrors the existing modes API surface so Epic #72's per-language tuning work has a backing API. Three thin pieces of plumbing — no UI yet, no consumers yet, just the contract surface that #73 / #76 / #81 will build on.

Engine companion issue (acceptance criterion of #79): unfoldingWord/bt-servant-engine#206.

## Changes

### Worker BFF (`worker/config.ts`)

Two new routes following the modes pattern:

```
/api/config/languages          GET
/api/config/languages/{name}   GET, PUT, DELETE
```

Both proxy to the engine at `/api/v1/admin/orgs/{org}/languages` with the same auth + error-passthrough as modes.

### Frontend types (`src/types/language.ts`)

```ts
Language { name, label?, document, published? }
OrgLanguages { languages: Language[] }
```

Note the asymmetry from `PromptMode`: a mode has slotted `overrides` (identity / methodology / tool_guidance / etc.); a language has a single markdown `document`. Per #76, language tuning is one editable document, not a slotted form.

### Frontend client (`src/lib/languages-api.ts`)

```
listLanguages(signal)
getLanguage(name, signal)        # unwraps { org, language: {...} } if present, mirroring getMode
putLanguage(name, body, signal)
deleteLanguage(name, signal)
```

## Acceptance criteria — all met

- [x] `worker/config.ts` proxies `/api/config/languages/*` using the same helper as modes
- [x] `Language` type exists in `src/types/language.ts`
- [x] `src/lib/languages-api.ts` exposes the four CRUD helpers
- [x] Companion engine issue (#206) open and linked from #79's comments

## Test plan

This PR is API plumbing only — no UI consumers yet. Real validation requires the engine endpoints (#206) to land first; until then, calls will get whatever the engine returns for the new path (likely 404). That is acceptable for this PR — the contract is in place for #73 / #76 / #81 to consume.

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Local pre-commit (husky → lint-staged → typecheck → build) passes
- [ ] CI green: Code Quality, Build, Secret Scan, Deploy to Cloudflare Workers (per-PR ephemeral)
- [ ] Smoke from the per-PR ephemeral worker — `curl /api/config/languages` should pass auth and proxy to engine (returning whatever the engine currently returns for the as-yet-unimplemented endpoint)

Closes #79.