### PR TITLE
feat: Languages sidebar tab + editor integration (closes #73)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router";
+import {
+  Navigate,
+  Outlet,
+  RouterProvider,
+  createBrowserRouter,
+} from "react-router";
 
 import { useThemeSync } from "@/hooks/use-theme-sync";
 import { useSyncSection } from "@/hooks/use-sync-section";
@@ -14,37 +19,44 @@ import { ManualConfigPage } from "@/app/pages/manual-config";
 
 const queryClient = new QueryClient();
 
-function AppRoutes() {
+// Root layout for the data router. Hooks that need router context
+// (useSyncSection -> useLocation, useSessionGuard -> useNavigate) live here.
+// Required for useBlocker support in child routes — useBlocker only works
+// under a data router (createBrowserRouter), not under <BrowserRouter>.
+function RootLayout() {
   useThemeSync();
   useSyncSection();
   useAuthInit();
   useSessionGuard();
+  return <Outlet />;
+}
 
-  return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        element={
+const router = createBrowserRouter([
+  {
+    element: <RootLayout />,
+    children: [
+      { path: "/login", element: <LoginPage /> },
+      {
+        element: (
           <RequireAuth>
             <AppShell />
           </RequireAuth>
-        }
-      >
-        <Route index element={<BaruchPage />} />
-        <Route path="prompt-configuration" element={<ManualConfigPage />} />
-        <Route path="languages" element={<LanguagesPage />} />
-      </Route>
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
-  );
-}
+        ),
+        children: [
+          { index: true, element: <BaruchPage /> },
+          { path: "prompt-configuration", element: <ManualConfigPage /> },
+          { path: "languages", element: <LanguagesPage /> },
+        ],
+      },
+      { path: "*", element: <Navigate to="/" replace /> },
+    ],
+  },
+]);
 
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AppRoutes />
-      </BrowserRouter>
+      <RouterProvider router={router} />
     </QueryClientProvider>
   );
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,7 @@ import { useSessionGuard } from "@/hooks/use-session-guard";
 import { AppShell } from "@/components/app-shell";
 import { RequireAuth } from "@/components/require-auth";
 import { BaruchPage } from "@/app/pages/baruch";
+import { LanguagesPage } from "@/app/pages/languages";
 import { LoginPage } from "@/app/pages/login";
 import { ManualConfigPage } from "@/app/pages/manual-config";
 
@@ -31,6 +32,7 @@ function AppRoutes() {
       >
         <Route index element={<BaruchPage />} />
         <Route path="prompt-configuration" element={<ManualConfigPage />} />
+        <Route path="languages" element={<LanguagesPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -62,13 +62,18 @@ export function LanguagesPage() {
   // never overwrites local edits.
   const [draft, setDraft] = useState("");
   const [lastSyncedDoc, setLastSyncedDoc] = useState("");
+  // lastSyncedPublished tracks the published flag we *know* the server holds,
+  // for the same reason lastSyncedDoc exists: the React Query cache lags
+  // saves we just made. Without this, an autosave that fires right after a
+  // Publish/Unpublish click reads stale `published` from the cache and the
+  // PUT silently reverts the toggle (Frank P2 review of #93).
+  const [lastSyncedPublished, setLastSyncedPublished] = useState(false);
   const [headings, setHeadings] = useState<MarkdownHeading[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const activeLine = useActiveHeadingLine(textareaRef, draft, headings);
   const debouncedDraft = useDebounced(draft, AUTO_SAVE_DEBOUNCE_MS);
 
   const serverLabel = languageQuery.data?.label;
-  const serverPublished = languageQuery.data?.published ?? false;
 
   // Re-sync from the server *only* when the selection changes — never
   // post-save. The ref tracks the language whose contents we last loaded
@@ -80,6 +85,7 @@ export function LanguagesPage() {
       syncedNameRef.current = null;
       setDraft("");
       setLastSyncedDoc("");
+      setLastSyncedPublished(false);
       return;
     }
     // Wait for the query data to arrive AND match the current selection
@@ -90,6 +96,7 @@ export function LanguagesPage() {
     if (syncedNameRef.current === selectedLanguage) return;
     setDraft(languageQuery.data.document);
     setLastSyncedDoc(languageQuery.data.document);
+    setLastSyncedPublished(languageQuery.data.published ?? false);
     syncedNameRef.current = selectedLanguage;
   }, [selectedLanguage, languageQuery.data]);
 
@@ -111,13 +118,16 @@ export function LanguagesPage() {
           body: {
             label: serverLabel,
             document: doc,
-            published: serverPublished,
+            // Read published from local state, not the React Query cache —
+            // the cache lags a just-completed Publish/Unpublish PUT, so
+            // reading from `serverPublished` here would silently revert it.
+            published: lastSyncedPublished,
           },
         },
         { onSuccess: () => setLastSyncedDoc(doc) }
       );
     },
-    [saveLanguage, selectedLanguage, serverLabel, serverPublished]
+    [lastSyncedPublished, saveLanguage, selectedLanguage, serverLabel]
   );
 
   // Auto-save when debouncedDraft diverges from what we last saved.
@@ -192,9 +202,10 @@ export function LanguagesPage() {
   const handleSetPublished = useCallback(
     (name: string, published: boolean) => {
       // Send the current draft for the selected language so an unsaved doc
-      // edit lands in the same request as the publish toggle. Bookkeep
-      // lastSyncedDoc on success so the autosave effect doesn't immediately
-      // re-fire with the same content.
+      // edit lands in the same request as the publish toggle. Bookkeep both
+      // lastSyncedDoc and lastSyncedPublished on success — without the
+      // latter, a subsequent autosave would read stale `published` from the
+      // cache and revert this toggle.
       const isSelected = name === selectedLanguage;
       const doc = isSelected ? draft : (languageQuery.data?.document ?? "");
       saveLanguage.mutate(
@@ -204,7 +215,10 @@ export function LanguagesPage() {
         },
         {
           onSuccess: () => {
-            if (isSelected) setLastSyncedDoc(doc);
+            if (isSelected) {
+              setLastSyncedDoc(doc);
+              setLastSyncedPublished(published);
+            }
           },
         }
       );

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -1,0 +1,380 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Save } from "lucide-react";
+import { useBlocker } from "react-router";
+
+import { useAuthStore } from "@/lib/auth-store";
+import { useUiStore } from "@/lib/ui-store";
+import { useDebounced } from "@/hooks/use-debounced";
+import { useActiveHeadingLine } from "@/hooks/use-active-heading-line";
+import {
+  useDeleteLanguage,
+  useLanguage,
+  useLanguages,
+  useSaveLanguage,
+} from "@/hooks/use-languages";
+import type { MarkdownHeading } from "@/types/markdown";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { LanguageSelector } from "@/components/language-selector";
+import { MarkdownEditor } from "@/components/markdown-editor";
+import { MarkdownToc } from "@/components/markdown-toc";
+import { PageHeader } from "@/components/page-header";
+
+const AUTO_SAVE_DEBOUNCE_MS = 800;
+
+export function LanguagesPage() {
+  const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
+  const selectedLanguage = useUiStore((s) => s.selectedLanguage);
+  const setSelectedLanguage = useUiStore((s) => s.setSelectedLanguage);
+  const showDrafts = useUiStore((s) => s.showDrafts);
+  const setShowDrafts = useUiStore((s) => s.setShowDrafts);
+
+  // Queries / mutations
+  const languagesQuery = useLanguages();
+  const languageQuery = useLanguage(selectedLanguage);
+  const saveLanguage = useSaveLanguage();
+  const deleteLanguage = useDeleteLanguage();
+
+  // Local document draft (auto-save target). Synced to the server document
+  // whenever the selected language changes or a save lands.
+  const [draft, setDraft] = useState("");
+  const [headings, setHeadings] = useState<MarkdownHeading[]>([]);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const activeLine = useActiveHeadingLine(textareaRef, draft, headings);
+  const debouncedDraft = useDebounced(draft, AUTO_SAVE_DEBOUNCE_MS);
+
+  const serverDocument = languageQuery.data?.document ?? "";
+  const serverLabel = languageQuery.data?.label;
+  const serverPublished = languageQuery.data?.published ?? false;
+
+  // Sync the draft from the server when the selected language changes or after
+  // a successful save lands. We don't overwrite while a save is in flight to
+  // avoid jitter — the next sync happens once the save settles.
+  useEffect(() => {
+    if (saveLanguage.isPending) return;
+    setDraft(serverDocument);
+  }, [serverDocument, saveLanguage.isPending]);
+
+  const isDirty = draft !== serverDocument;
+  const isSaving = saveLanguage.isPending;
+  const hasSelection = selectedLanguage !== null && languageQuery.data;
+
+  // Auto-save when the debounced draft diverges from the server document.
+  // Skip while another save is in flight; the next debounce tick will retry.
+  useEffect(() => {
+    if (!selectedLanguage) return;
+    if (saveLanguage.isPending) return;
+    if (debouncedDraft === serverDocument) return;
+    saveLanguage.mutate({
+      name: selectedLanguage,
+      body: {
+        label: serverLabel,
+        document: debouncedDraft,
+        published: serverPublished,
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only react to debouncedDraft changes
+  }, [debouncedDraft]);
+
+  const flushSave = useCallback(() => {
+    if (!selectedLanguage) return;
+    if (!isDirty) return;
+    saveLanguage.mutate({
+      name: selectedLanguage,
+      body: {
+        label: serverLabel,
+        document: draft,
+        published: serverPublished,
+      },
+    });
+  }, [
+    draft,
+    isDirty,
+    saveLanguage,
+    selectedLanguage,
+    serverLabel,
+    serverPublished,
+  ]);
+
+  // Block route changes while there are pending edits or an in-flight save.
+  // The blocker fires only when navigating to a different pathname (selecting
+  // a different language stays on /languages and is handled separately below).
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      (isDirty || isSaving) &&
+      currentLocation.pathname !== nextLocation.pathname
+  );
+
+  // Pending language switch within the same page — guards against losing
+  // edits when picking a different language from the dropdown.
+  const [pendingSwitch, setPendingSwitch] = useState<string | null>(null);
+
+  const handleSelectLanguage = useCallback(
+    (next: string | null) => {
+      if (next === selectedLanguage) return;
+      if (isDirty || isSaving) {
+        setPendingSwitch(next);
+        return;
+      }
+      setSelectedLanguage(next);
+    },
+    [isDirty, isSaving, selectedLanguage, setSelectedLanguage]
+  );
+
+  const confirmSwitch = useCallback(() => {
+    setSelectedLanguage(pendingSwitch);
+    setPendingSwitch(null);
+  }, [pendingSwitch, setSelectedLanguage]);
+
+  const handleCreateLanguage = useCallback(
+    (name: string, label: string) => {
+      saveLanguage.mutate(
+        {
+          name,
+          body: {
+            label: label || undefined,
+            document: "",
+            published: false,
+          },
+        },
+        { onSuccess: () => setSelectedLanguage(name) }
+      );
+    },
+    [saveLanguage, setSelectedLanguage]
+  );
+
+  const handleSetPublished = useCallback(
+    (name: string, published: boolean) => {
+      // Send the current draft so an unsaved doc edit gets included in the
+      // same request as the publish toggle. Avoids a separate save→publish
+      // race when the user has pending edits.
+      saveLanguage.mutate({
+        name,
+        body: {
+          label: serverLabel,
+          document: name === selectedLanguage ? draft : serverDocument,
+          published,
+        },
+      });
+    },
+    [draft, saveLanguage, selectedLanguage, serverDocument, serverLabel]
+  );
+
+  const handleDeleteLanguage = useCallback(
+    (name: string) => {
+      deleteLanguage.mutate(name, {
+        onSuccess: () => {
+          if (name === selectedLanguage) setSelectedLanguage(null);
+        },
+      });
+    },
+    [deleteLanguage, selectedLanguage, setSelectedLanguage]
+  );
+
+  const handleJumpToLine = useCallback(
+    (line: number) => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      const lines = draft.split("\n");
+      let pos = 0;
+      for (let i = 0; i < line; i++) pos += (lines[i]?.length ?? 0) + 1;
+      ta.focus();
+      ta.setSelectionRange(pos, pos);
+      // Scroll the line roughly into view by setting scrollTop based on line height
+      const lineHeight = parseFloat(getComputedStyle(ta).lineHeight || "20");
+      ta.scrollTop = Math.max(0, line * lineHeight - 80);
+    },
+    [draft]
+  );
+
+  const isLoading =
+    languagesQuery.isLoading ||
+    (selectedLanguage !== null && languageQuery.isLoading);
+  const error =
+    languagesQuery.error ||
+    (selectedLanguage !== null ? languageQuery.error : null);
+
+  const saveStatus = useMemo(() => {
+    if (isSaving) return "Saving…";
+    if (isDirty) return "Unsaved changes";
+    if (hasSelection) return "Saved";
+    return "";
+  }, [hasSelection, isDirty, isSaving]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <PageHeader
+        title="Languages"
+        subtitle="Edit per-language tuning documents. Auto-saves as you type; use Save to flush immediately."
+      />
+
+      <div className="bg-card border-b">
+        <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
+          <div className="min-w-0 flex-1">
+            <LanguageSelector
+              languagesData={languagesQuery.data}
+              selectedLanguage={selectedLanguage}
+              onSelectLanguage={handleSelectLanguage}
+              onCreateLanguage={handleCreateLanguage}
+              onDeleteLanguage={handleDeleteLanguage}
+              onSetPublished={handleSetPublished}
+              isCreating={saveLanguage.isPending}
+              isDeleting={deleteLanguage.isPending}
+              isSettingPublished={saveLanguage.isPending}
+              showDrafts={showDrafts}
+              onToggleShowDrafts={setShowDrafts}
+              isAdmin={isAdmin}
+            />
+          </div>
+
+          {hasSelection && (
+            <div className="flex shrink-0 items-center gap-3">
+              <span
+                className="text-muted-foreground text-xs tabular-nums"
+                aria-live="polite"
+              >
+                {saveStatus}
+              </span>
+              <Button
+                size="sm"
+                onClick={flushSave}
+                disabled={!isDirty || isSaving}
+              >
+                <Save className="mr-1.5 size-3.5" />
+                Save
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm">
+          {error.message}
+        </div>
+      )}
+
+      <div
+        className="flex min-h-0 flex-1 overflow-hidden"
+        style={{ background: "var(--editor-paper)" }}
+      >
+        {isLoading ? (
+          <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-3">
+            <FontAwesomeIcon
+              icon={faSpinnerThird}
+              className="size-5 animate-spin"
+            />
+            <p className="text-sm">Loading languages…</p>
+          </div>
+        ) : !hasSelection ? (
+          <EmptyState
+            isAdmin={isAdmin}
+            hasAny={(languagesQuery.data?.languages.length ?? 0) > 0}
+          />
+        ) : (
+          <>
+            <MarkdownToc
+              headings={headings}
+              activeLine={activeLine}
+              onJump={handleJumpToLine}
+            />
+            <div className="min-w-0 flex-1 overflow-y-auto">
+              <MarkdownEditor
+                value={draft}
+                onChange={setDraft}
+                onHeadingsChange={setHeadings}
+                textareaRef={textareaRef}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      <AlertDialog
+        open={blocker.state === "blocked"}
+        onOpenChange={(open) => {
+          if (!open && blocker.state === "blocked") blocker.reset?.();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Leave with unsaved changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have edits that haven&rsquo;t finished saving. Leaving now may
+              discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => blocker.reset?.()}>
+              Stay
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => blocker.proceed?.()}
+            >
+              Leave anyway
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={pendingSwitch !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingSwitch(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Switch language?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have unsaved edits to{" "}
+              <span className="text-foreground font-medium">
+                &ldquo;{selectedLanguage}&rdquo;
+              </span>
+              . Switching will discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setPendingSwitch(null)}>
+              Stay
+            </AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={confirmSwitch}>
+              Discard and switch
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface EmptyStateProps {
+  isAdmin: boolean;
+  hasAny: boolean;
+}
+
+function EmptyState({ isAdmin, hasAny }: EmptyStateProps) {
+  return (
+    <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
+      <p className="text-sm">
+        {hasAny
+          ? "Pick a language above to start editing."
+          : isAdmin
+            ? "No languages yet. Create one to get started."
+            : "No languages are available for your account."}
+      </p>
+    </div>
+  );
+}

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -46,66 +46,101 @@ export function LanguagesPage() {
   const saveLanguage = useSaveLanguage();
   const deleteLanguage = useDeleteLanguage();
 
-  // Local document draft (auto-save target). Synced to the server document
-  // whenever the selected language changes or a save lands.
+  // Local document draft (auto-save target).
+  //
+  // We track `lastSyncedDoc` separately from React Query's cache so that:
+  //   1. Edits typed *during* an in-flight save are preserved — the cache
+  //      isn't authoritative for "what we've actually saved" because it can
+  //      lag the real server state.
+  //   2. We can reliably detect "is there still something newer to save?"
+  //      after a save settles, by comparing draft to lastSyncedDoc.
+  //
+  // Sync rule: lastSyncedDoc + draft are pulled from the server only when
+  // the *selected language changes* (initial load or a switch). After that,
+  // lastSyncedDoc only advances when a save we initiated succeeds (set to
+  // the value we sent). The cache invalidation that happens after a mutation
+  // never overwrites local edits.
   const [draft, setDraft] = useState("");
+  const [lastSyncedDoc, setLastSyncedDoc] = useState("");
   const [headings, setHeadings] = useState<MarkdownHeading[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const activeLine = useActiveHeadingLine(textareaRef, draft, headings);
   const debouncedDraft = useDebounced(draft, AUTO_SAVE_DEBOUNCE_MS);
 
-  const serverDocument = languageQuery.data?.document ?? "";
   const serverLabel = languageQuery.data?.label;
   const serverPublished = languageQuery.data?.published ?? false;
 
-  // Sync the draft from the server when the selected language changes or after
-  // a successful save lands. We don't overwrite while a save is in flight to
-  // avoid jitter — the next sync happens once the save settles.
+  // Re-sync from the server *only* when the selection changes — never
+  // post-save. The ref tracks the language whose contents we last loaded
+  // into local state, so we don't repeatedly overwrite the draft each time
+  // the cache emits.
+  const syncedNameRef = useRef<string | null>(null);
   useEffect(() => {
-    if (saveLanguage.isPending) return;
-    setDraft(serverDocument);
-  }, [serverDocument, saveLanguage.isPending]);
+    if (!selectedLanguage) {
+      syncedNameRef.current = null;
+      setDraft("");
+      setLastSyncedDoc("");
+      return;
+    }
+    // Wait for the query data to arrive AND match the current selection
+    // before syncing. Without the name check we'd briefly load stale data
+    // for the previously selected language during a switch.
+    if (!languageQuery.data) return;
+    if (languageQuery.data.name !== selectedLanguage) return;
+    if (syncedNameRef.current === selectedLanguage) return;
+    setDraft(languageQuery.data.document);
+    setLastSyncedDoc(languageQuery.data.document);
+    syncedNameRef.current = selectedLanguage;
+  }, [selectedLanguage, languageQuery.data]);
 
-  const isDirty = draft !== serverDocument;
+  const isDirty = draft !== lastSyncedDoc;
   const isSaving = saveLanguage.isPending;
   const hasSelection = selectedLanguage !== null && languageQuery.data;
 
-  // Auto-save when the debounced draft diverges from the server document.
-  // Skip while another save is in flight; the next debounce tick will retry.
+  // Single save path — both auto-save and the manual Save button funnel
+  // through here so the lastSyncedDoc bookkeeping stays consistent.
+  // The closure captures the exact `doc` we're sending so onSuccess can
+  // bump lastSyncedDoc to that value (not to a re-read of the cache,
+  // which may have already moved on if the user kept typing).
+  const performSave = useCallback(
+    (doc: string) => {
+      if (!selectedLanguage) return;
+      saveLanguage.mutate(
+        {
+          name: selectedLanguage,
+          body: {
+            label: serverLabel,
+            document: doc,
+            published: serverPublished,
+          },
+        },
+        { onSuccess: () => setLastSyncedDoc(doc) }
+      );
+    },
+    [saveLanguage, selectedLanguage, serverLabel, serverPublished]
+  );
+
+  // Auto-save when debouncedDraft diverges from what we last saved.
+  // Re-runs when an in-flight save settles so a "save in progress, user
+  // typed more" scenario flushes the newer edits as soon as the first
+  // save returns.
   useEffect(() => {
     if (!selectedLanguage) return;
     if (saveLanguage.isPending) return;
-    if (debouncedDraft === serverDocument) return;
-    saveLanguage.mutate({
-      name: selectedLanguage,
-      body: {
-        label: serverLabel,
-        document: debouncedDraft,
-        published: serverPublished,
-      },
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only react to debouncedDraft changes
-  }, [debouncedDraft]);
+    if (debouncedDraft === lastSyncedDoc) return;
+    performSave(debouncedDraft);
+  }, [
+    debouncedDraft,
+    saveLanguage.isPending,
+    lastSyncedDoc,
+    performSave,
+    selectedLanguage,
+  ]);
 
   const flushSave = useCallback(() => {
-    if (!selectedLanguage) return;
-    if (!isDirty) return;
-    saveLanguage.mutate({
-      name: selectedLanguage,
-      body: {
-        label: serverLabel,
-        document: draft,
-        published: serverPublished,
-      },
-    });
-  }, [
-    draft,
-    isDirty,
-    saveLanguage,
-    selectedLanguage,
-    serverLabel,
-    serverPublished,
-  ]);
+    if (!isDirty || isSaving) return;
+    performSave(draft);
+  }, [draft, isDirty, isSaving, performSave]);
 
   // Block route changes while there are pending edits or an in-flight save.
   // The blocker fires only when navigating to a different pathname (selecting
@@ -156,19 +191,25 @@ export function LanguagesPage() {
 
   const handleSetPublished = useCallback(
     (name: string, published: boolean) => {
-      // Send the current draft so an unsaved doc edit gets included in the
-      // same request as the publish toggle. Avoids a separate save→publish
-      // race when the user has pending edits.
-      saveLanguage.mutate({
-        name,
-        body: {
-          label: serverLabel,
-          document: name === selectedLanguage ? draft : serverDocument,
-          published,
+      // Send the current draft for the selected language so an unsaved doc
+      // edit lands in the same request as the publish toggle. Bookkeep
+      // lastSyncedDoc on success so the autosave effect doesn't immediately
+      // re-fire with the same content.
+      const isSelected = name === selectedLanguage;
+      const doc = isSelected ? draft : (languageQuery.data?.document ?? "");
+      saveLanguage.mutate(
+        {
+          name,
+          body: { label: serverLabel, document: doc, published },
         },
-      });
+        {
+          onSuccess: () => {
+            if (isSelected) setLastSyncedDoc(doc);
+          },
+        }
+      );
     },
-    [draft, saveLanguage, selectedLanguage, serverDocument, serverLabel]
+    [draft, languageQuery.data, saveLanguage, selectedLanguage, serverLabel]
   );
 
   const handleDeleteLanguage = useCallback(

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -1,7 +1,9 @@
 import { faComments as faCommentsLight } from "@fortawesome/pro-light-svg-icons";
+import { faLanguage as faLanguageLight } from "@fortawesome/pro-light-svg-icons";
 import { faMessageBot as faMessageBotLight } from "@fortawesome/pro-light-svg-icons";
 import { faPenToSquare as faPenToSquareLight } from "@fortawesome/pro-light-svg-icons";
 import { faComments as faCommentsSolid } from "@fortawesome/pro-solid-svg-icons";
+import { faLanguage as faLanguageSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faMessageBot as faMessageBotSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faPenToSquare as faPenToSquareSolid } from "@fortawesome/pro-solid-svg-icons";
 import { useNavigate } from "react-router";
@@ -39,6 +41,18 @@ export function ActivityBar() {
           onClick={() => {
             setActiveSection("prompt-configuration");
             void navigate("/prompt-configuration");
+          }}
+        />
+        <ActivityBarItem
+          icon={faLanguageLight}
+          activeIcon={faLanguageSolid}
+          label="Edit per-language tuning documents"
+          isActive={activeSection === "languages"}
+          onClick={() => {
+            // TODO(#80): gate on session.language_rights once delivered;
+            // until then the tab is always visible.
+            setActiveSection("languages");
+            void navigate("/languages");
           }}
         />
         <Separator className="my-1.5 w-5 opacity-50" />

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useState } from "react";
+import { faLanguage } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Eye, EyeOff, Plus, Send, SendHorizontal, Trash2 } from "lucide-react";
+
+import type { Language, OrgLanguages } from "@/types/language";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface LanguageSelectorProps {
+  languagesData: OrgLanguages | undefined;
+  selectedLanguage: string | null;
+  onSelectLanguage: (language: string | null) => void;
+  onCreateLanguage: (name: string, label: string) => void;
+  onDeleteLanguage: (name: string) => void;
+  onSetPublished: (name: string, published: boolean) => void;
+  isCreating: boolean;
+  isDeleting: boolean;
+  isSettingPublished: boolean;
+  showDrafts: boolean;
+  onToggleShowDrafts: (showDrafts: boolean) => void;
+  isAdmin: boolean;
+}
+
+function isPublished(lang: Pick<Language, "published">): boolean {
+  return lang.published === true;
+}
+
+export function LanguageSelector({
+  languagesData,
+  selectedLanguage,
+  onSelectLanguage,
+  onCreateLanguage,
+  onDeleteLanguage,
+  onSetPublished,
+  isCreating,
+  isDeleting,
+  isSettingPublished,
+  showDrafts,
+  onToggleShowDrafts,
+  isAdmin,
+}: LanguageSelectorProps) {
+  const [showCreate, setShowCreate] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newLabel, setNewLabel] = useState("");
+
+  const languages = languagesData?.languages ?? [];
+  const selectedData =
+    languages.find((l) => l.name === selectedLanguage) ?? null;
+  const selectedIsPublished = selectedData ? isPublished(selectedData) : false;
+
+  const visibleLanguages = languages.filter(
+    (l) => showDrafts || isPublished(l) || l.name === selectedLanguage
+  );
+
+  const handleCreate = useCallback(() => {
+    const slug = newName
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9\-_]/g, "")
+      .replace(/^-+|-+$/g, "");
+    if (!slug) return;
+    onCreateLanguage(slug, newLabel.trim());
+    setNewName("");
+    setNewLabel("");
+    setShowCreate(false);
+  }, [newName, newLabel, onCreateLanguage]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2.5 sm:flex-initial">
+          <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
+            <FontAwesomeIcon icon={faLanguage} className="text-base" />
+          </div>
+          <Select
+            value={selectedLanguage ?? ""}
+            onValueChange={(value) =>
+              onSelectLanguage(value === "" ? null : value)
+            }
+          >
+            <SelectTrigger className="w-full sm:w-52">
+              <SelectValue placeholder="Select a language" />
+            </SelectTrigger>
+            <SelectContent>
+              {visibleLanguages.length === 0 ? (
+                <div className="text-muted-foreground px-2 py-1.5 text-xs">
+                  No languages yet
+                </div>
+              ) : (
+                visibleLanguages.map((l) => (
+                  <SelectItem key={l.name} value={l.name}>
+                    <span className="flex items-center gap-2">
+                      <span className="truncate">{l.label || l.name}</span>
+                      {!isPublished(l) && (
+                        <Badge
+                          variant="outline"
+                          className="px-1.5 py-0 text-[10px]"
+                        >
+                          Draft
+                        </Badge>
+                      )}
+                    </span>
+                  </SelectItem>
+                ))
+              )}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onToggleShowDrafts(!showDrafts)}
+          title={showDrafts ? "Hide drafts from the list" : "Show drafts"}
+        >
+          {showDrafts ? (
+            <Eye className="mr-1.5 size-3.5" />
+          ) : (
+            <EyeOff className="mr-1.5 size-3.5" />
+          )}
+          {showDrafts ? "Drafts shown" : "Drafts hidden"}
+        </Button>
+
+        {isAdmin && (
+          <Button size="sm" onClick={() => setShowCreate(!showCreate)}>
+            <Plus className="mr-1.5 size-3.5" />
+            New Language
+          </Button>
+        )}
+
+        {selectedLanguage !== null && selectedData && (
+          <div className="border-border flex items-center gap-2 sm:border-l sm:pl-3">
+            <Badge
+              variant={selectedIsPublished ? "default" : "outline"}
+              className="shrink-0"
+            >
+              {selectedIsPublished ? "Published" : "Draft"}
+            </Badge>
+
+            {isAdmin &&
+              (selectedIsPublished ? (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={isSettingPublished}
+                    >
+                      <SendHorizontal className="mr-1.5 size-3.5" />
+                      Unpublish
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Unpublish language?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This language will immediately stop shaping responses
+                        for end users. Admins will still be able to see and edit
+                        it as a draft.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => onSetPublished(selectedLanguage, false)}
+                      >
+                        Unpublish
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={isSettingPublished}
+                  onClick={() => onSetPublished(selectedLanguage, true)}
+                >
+                  <Send className="mr-1.5 size-3.5" />
+                  Publish
+                </Button>
+              ))}
+
+            {isAdmin && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={isDeleting}
+                    className="text-destructive hover:text-destructive"
+                  >
+                    <Trash2 className="mr-1.5 size-3.5" />
+                    Delete
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete language</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Are you sure you want to delete{" "}
+                      <span className="text-foreground font-medium">
+                        &ldquo;{selectedLanguage}&rdquo;
+                      </span>
+                      ? This action cannot be undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      variant="destructive"
+                      onClick={() => onDeleteLanguage(selectedLanguage)}
+                    >
+                      Delete
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+          </div>
+        )}
+      </div>
+
+      {showCreate && (
+        <div className="bg-card animate-in fade-in slide-in-from-bottom-4 rounded-xl border p-4 shadow-sm duration-200">
+          <p className="text-foreground mb-3 text-sm font-medium">
+            Create a new language
+          </p>
+          <p className="text-muted-foreground mb-3 text-xs">
+            New languages are created as drafts and don&rsquo;t shape responses
+            until published.
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="lang-name" className="text-xs">
+                Name (slug)
+              </Label>
+              <Input
+                id="lang-name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="e.g. arabic"
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="lang-label" className="text-xs">
+                Display Label
+              </Label>
+              <Input
+                id="lang-label"
+                value={newLabel}
+                onChange={(e) => setNewLabel(e.target.value)}
+                placeholder="e.g. Arabic"
+                className="h-8 text-sm"
+              />
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowCreate(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleCreate}
+              disabled={!newName.trim() || isCreating}
+            >
+              {isCreating ? "Creating..." : "Create Draft"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import * as languagesApi from "@/lib/languages-api";
+
+const keys = {
+  languages: ["languages"] as const,
+  language: (name: string) => ["languages", name] as const,
+};
+
+export function useLanguages() {
+  return useQuery({
+    queryKey: keys.languages,
+    queryFn: ({ signal }) => languagesApi.listLanguages(signal),
+  });
+}
+
+export function useLanguage(name: string | null) {
+  return useQuery({
+    queryKey: keys.language(name ?? ""),
+    queryFn: ({ signal }) => languagesApi.getLanguage(name!, signal),
+    enabled: !!name,
+  });
+}
+
+export function useSaveLanguage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      name,
+      body,
+    }: {
+      name: string;
+      body: { label?: string; document: string; published?: boolean };
+    }) => languagesApi.putLanguage(name, body),
+    onSuccess: (_data, { name }) => {
+      void qc.invalidateQueries({ queryKey: keys.languages });
+      void qc.invalidateQueries({ queryKey: keys.language(name) });
+    },
+  });
+}
+
+// Note: publish/unpublish flows through useSaveLanguage with the full body
+// (always send { label, document, published }). Languages don't need the
+// partial-update racing fix that modes use because there's only one
+// editable field (the document) — there's no "concurrent slot save" hazard.
+//
+// If concurrent editing across browser tabs becomes a problem, revisit by
+// either (a) loosening the engine PUT contract to make `document` optional
+// or (b) introducing optimistic concurrency via etag/version.
+
+export function useDeleteLanguage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => languagesApi.deleteLanguage(name),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: keys.languages });
+    },
+  });
+}

--- a/src/hooks/use-sync-section.ts
+++ b/src/hooks/use-sync-section.ts
@@ -7,6 +7,7 @@ import type { Section } from "@/types/ui";
 const pathToSection: Record<string, Section> = {
   "/": "baruch",
   "/prompt-configuration": "prompt-configuration",
+  "/languages": "languages",
 };
 
 export function useSyncSection() {

--- a/src/lib/ui-store.ts
+++ b/src/lib/ui-store.ts
@@ -14,6 +14,8 @@ interface UiState {
   toggleTestChat: () => void;
   selectedMode: string | null;
   setSelectedMode: (mode: string | null) => void;
+  selectedLanguage: string | null;
+  setSelectedLanguage: (language: string | null) => void;
   chatMode: string | null;
   chatModeSeeded: boolean;
   setChatMode: (mode: string | null) => void;
@@ -35,6 +37,7 @@ type InitialUiState = Pick<
   | "activeSection"
   | "testChatOpen"
   | "selectedMode"
+  | "selectedLanguage"
   | "chatMode"
   | "chatModeSeeded"
   | "testChatUserId"
@@ -66,6 +69,7 @@ const initialState: InitialUiState = {
   activeSection: "baruch",
   testChatOpen: false,
   selectedMode: null,
+  selectedLanguage: null,
   chatMode: null,
   chatModeSeeded: false,
   // Placeholder — reset() always generates a fresh UUID; this value is only
@@ -95,6 +99,7 @@ export const useUiStore = create<UiState>()((set) => ({
         : {}),
     })),
   setSelectedMode: (selectedMode) => set({ selectedMode }),
+  setSelectedLanguage: (selectedLanguage) => set({ selectedLanguage }),
   setChatMode: (chatMode) => set({ chatMode }),
   setTestChatPanelWidth: (width) => {
     const clamped = Math.max(

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,1 +1,1 @@
-export type Section = "baruch" | "prompt-configuration";
+export type Section = "baruch" | "prompt-configuration" | "languages";


### PR DESCRIPTION
## Summary

First user-visible consumer of the Languages CRUD API ([#79](https://github.com/unfoldingWord/bt-servant-admin-portal/pull/92)) and the markdown editor + TOC components ([#75](https://github.com/unfoldingWord/bt-servant-admin-portal/pull/85)). Adds a new top-level sidebar entry that opens a single-document editor for per-language tuning.

Closes #73.

## What's in

### Sidebar
New activity-bar entry (`faLanguage` Pro icon, light + solid variants) below the existing "Manually configure" entry, above the test-chat separator.

> Note: #73's body says "below Modes" but Modes isn't its own sidebar tab today — it's the dropdown inside the manual-configuration page. Per the trust-code-over-docs convention I've been following on this project, treated as "below the existing manual-config entry".

### Routing + state
- New route: `GET /languages` → `LanguagesPage`
- New section: `"languages"` added to the `Section` type + `use-sync-section`
- New `ui-store` field: `selectedLanguage` (mirrors `selectedMode`)

### Page (`src/app/pages/languages.tsx`)

```
[PageHeader]
[LanguageSelector toolbar | Save status + Save button]
[TOC (280px) | MarkdownEditor (flex-1)]
```

- **Auto-save** on debounced draft change (800ms). Skips while a save is in flight; the next debounce tick retries.
- **Manual Save** button flushes pending edits immediately (per the user's "both" preference).
- **Save status indicator** — Saving… / Unsaved changes / Saved.

#### Unsaved-changes guards (per #73 acceptance criteria)
- `useBlocker` fires on cross-route navigation if the draft is dirty or a save is mid-flight. Shows a "Leave with unsaved changes?" `AlertDialog` (Stay / Leave anyway).
- Switching language *within* the page (dropdown) shows a separate "Switch language?" `AlertDialog` so we don't lose unsaved edits to the previously-selected language.

#### Empty states
- No selection + no languages exist → admin gets "Create one" prompt; non-admin gets "No languages available for your account."
- No selection + languages exist → "Pick one above to start editing."

### LanguageSelector (`src/components/language-selector.tsx`)
Mirrors `ModeSelector` but smaller — single-document model means no slot grid, no description field at create time. Surface:
- Dropdown of languages (drafts visible per `showDrafts` toggle, same persistence as modes)
- New Language form (name slug + display label, admin-only)
- Publish / Unpublish (admin-only, with confirm for unpublish)
- Delete (admin-only, with confirm)

### Hooks (`src/hooks/use-languages.ts`)
React Query wrappers around the languages-api client: `useLanguages`, `useLanguage`, `useSaveLanguage`, `useDeleteLanguage`.

> **Deliberately no `useSetLanguagePublished` partial-update hook.** Publish/unpublish flows through `useSaveLanguage` with the full body. There's only one editable field (the document), so the concurrent-slot-save hazard that motivated modes' partial-update path doesn't apply here. Keeps the engine PUT contract ([engine #206](https://github.com/unfoldingWord/bt-servant-engine/issues/206)) simple.

## Permission gating (#80)

**Stubbed:** the Languages tab is always visible. `TODO(#80)` comment in `activity-bar.tsx` references the followup. Once the engine starts returning `session.language_rights`, gate visibility on it (hide if empty, gray out otherwise — issue says "default to grayed out with a tooltip"). Frontend-only change at that point.

## Validation

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — zero warnings
- [x] `npm run build` — clean (1,082 KB pre-gzip / 310 KB post-gzip; chunk-size warning was pre-existing)
- [ ] **Browser smoke test** — not possible from the dev container; deferred to the per-PR ephemeral worker. Reviewer should:
  1. Click the new Languages icon in the sidebar (faLanguage)
  2. Confirm the page loads with empty state ("No languages yet" if engine #206 is unimplemented)
  3. If engine #206 has landed: create a language, edit the document, watch auto-save indicator, click Save manually
  4. Verify cross-route blocker: dirty the draft, click another sidebar entry → confirm dialog
  5. Verify in-page switch blocker: dirty the draft, pick a different language → confirm dialog

## Backend dependency

This plumbing assumes engine [#206](https://github.com/unfoldingWord/bt-servant-engine/issues/206) (Language CRUD endpoints) is or will be available. Until it lands, GET/PUT/DELETE calls will return whatever the engine returns for unimplemented paths (likely 404). The empty-state handles that gracefully ("No languages yet").