### PR TITLE
feat: gate Languages tab on language_rights (closes #80)

### DIFF
--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -291,14 +291,16 @@ export function LanguagesPage() {
   // Separate forbidden errors from generic errors so we can render a
   // permission-specific inline message rather than the raw save-failed text.
   const saveError = saveLanguage.error;
+  const deleteError = deleteLanguage.error;
   const loadError =
     languagesQuery.error ||
     (selectedLanguage !== null ? languageQuery.error : null);
   const forbiddenError = useMemo<LanguageForbiddenError | null>(() => {
     if (saveError instanceof LanguageForbiddenError) return saveError;
+    if (deleteError instanceof LanguageForbiddenError) return deleteError;
     if (loadError instanceof LanguageForbiddenError) return loadError;
     return null;
-  }, [saveError, loadError]);
+  }, [saveError, deleteError, loadError]);
   const error = forbiddenError ? null : loadError;
 
   const saveStatus = useMemo(() => {

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -5,6 +5,12 @@ import { Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
+import { LanguageForbiddenError } from "@/lib/languages-api";
+import {
+  filterAuthorizedLanguages,
+  hasAnyLanguageRights,
+  hasLanguageRights,
+} from "@/lib/permissions";
 import { useUiStore } from "@/lib/ui-store";
 import { useDebounced } from "@/hooks/use-debounced";
 import { useActiveHeadingLine } from "@/hooks/use-active-heading-line";
@@ -35,6 +41,8 @@ const AUTO_SAVE_DEBOUNCE_MS = 800;
 
 export function LanguagesPage() {
   const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
+  const languageRights = useAuthStore((s) => s.user?.language_rights);
+  const hasAccess = hasAnyLanguageRights(languageRights);
   const selectedLanguage = useUiStore((s) => s.selectedLanguage);
   const setSelectedLanguage = useUiStore((s) => s.setSelectedLanguage);
   const showDrafts = useUiStore((s) => s.showDrafts);
@@ -45,6 +53,20 @@ export function LanguagesPage() {
   const languageQuery = useLanguage(selectedLanguage);
   const saveLanguage = useSaveLanguage();
   const deleteLanguage = useDeleteLanguage();
+
+  // Filter the language list to only those the user has rights to. Engine
+  // #207 will eventually filter server-side too, but until then this is the
+  // primary gate against showing forbidden entries in the dropdown.
+  const authorizedLanguagesData = useMemo(() => {
+    if (!languagesQuery.data) return languagesQuery.data;
+    return {
+      ...languagesQuery.data,
+      languages: filterAuthorizedLanguages(
+        languagesQuery.data.languages,
+        languageRights
+      ),
+    };
+  }, [languagesQuery.data, languageRights]);
 
   // Local document draft (auto-save target).
   //
@@ -177,6 +199,15 @@ export function LanguagesPage() {
     [isDirty, isSaving, selectedLanguage, setSelectedLanguage]
   );
 
+  // If the persisted selection is no longer authorized (e.g. an admin
+  // revoked rights mid-session, or rights changed since last login), drop
+  // it so we don't render an editor for a language the user can't read.
+  useEffect(() => {
+    if (selectedLanguage === null) return;
+    if (hasLanguageRights(languageRights, selectedLanguage)) return;
+    setSelectedLanguage(null);
+  }, [languageRights, selectedLanguage, setSelectedLanguage]);
+
   const confirmSwitch = useCallback(() => {
     setSelectedLanguage(pendingSwitch);
     setPendingSwitch(null);
@@ -256,9 +287,19 @@ export function LanguagesPage() {
   const isLoading =
     languagesQuery.isLoading ||
     (selectedLanguage !== null && languageQuery.isLoading);
-  const error =
+
+  // Separate forbidden errors from generic errors so we can render a
+  // permission-specific inline message rather than the raw save-failed text.
+  const saveError = saveLanguage.error;
+  const loadError =
     languagesQuery.error ||
     (selectedLanguage !== null ? languageQuery.error : null);
+  const forbiddenError = useMemo<LanguageForbiddenError | null>(() => {
+    if (saveError instanceof LanguageForbiddenError) return saveError;
+    if (loadError instanceof LanguageForbiddenError) return loadError;
+    return null;
+  }, [saveError, loadError]);
+  const error = forbiddenError ? null : loadError;
 
   const saveStatus = useMemo(() => {
     if (isSaving) return "Saving…";
@@ -278,7 +319,7 @@ export function LanguagesPage() {
         <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
           <div className="min-w-0 flex-1">
             <LanguageSelector
-              languagesData={languagesQuery.data}
+              languagesData={authorizedLanguagesData}
               selectedLanguage={selectedLanguage}
               onSelectLanguage={handleSelectLanguage}
               onCreateLanguage={handleCreateLanguage}
@@ -320,11 +361,26 @@ export function LanguagesPage() {
         </div>
       )}
 
+      {forbiddenError && (
+        <div
+          className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm"
+          role="alert"
+        >
+          {forbiddenError.operation === "write"
+            ? `You don't have permission to edit "${forbiddenError.languageName}". Contact your admin to request access.`
+            : forbiddenError.operation === "delete"
+              ? `You don't have permission to delete "${forbiddenError.languageName}".`
+              : `You don't have permission to view "${forbiddenError.languageName}".`}
+        </div>
+      )}
+
       <div
         className="flex min-h-0 flex-1 overflow-hidden"
         style={{ background: "var(--editor-paper)" }}
       >
-        {isLoading ? (
+        {!hasAccess ? (
+          <NoAccessState />
+        ) : isLoading ? (
           <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-3">
             <FontAwesomeIcon
               icon={faSpinnerThird}
@@ -335,7 +391,7 @@ export function LanguagesPage() {
         ) : !hasSelection ? (
           <EmptyState
             isAdmin={isAdmin}
-            hasAny={(languagesQuery.data?.languages.length ?? 0) > 0}
+            hasAny={(authorizedLanguagesData?.languages.length ?? 0) > 0}
           />
         ) : (
           <>
@@ -429,6 +485,17 @@ function EmptyState({ isAdmin, hasAny }: EmptyStateProps) {
           : isAdmin
             ? "No languages yet. Create one to get started."
             : "No languages are available for your account."}
+      </p>
+    </div>
+  );
+}
+
+function NoAccessState() {
+  return (
+    <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
+      <p className="text-sm">
+        You don&rsquo;t have access to any languages. Contact your admin to
+        request language-shepherd permissions.
       </p>
     </div>
   );

--- a/src/components/activity-bar-item.tsx
+++ b/src/components/activity-bar-item.tsx
@@ -15,6 +15,8 @@ interface ActivityBarItemProps {
   label: string;
   isActive: boolean;
   onClick: () => void;
+  disabled?: boolean;
+  disabledLabel?: string;
 }
 
 export function ActivityBarItem({
@@ -23,31 +25,38 @@ export function ActivityBarItem({
   label,
   isActive,
   onClick,
+  disabled = false,
+  disabledLabel,
 }: ActivityBarItemProps) {
+  const tooltipText = disabled && disabledLabel ? disabledLabel : label;
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
           variant="ghost"
           size="icon"
-          onClick={onClick}
-          aria-label={label}
+          onClick={disabled ? undefined : onClick}
+          aria-label={tooltipText}
+          aria-disabled={disabled}
+          data-disabled={disabled || undefined}
           className={cn(
             "text-muted-foreground relative size-10 rounded-md transition-all",
-            "hover:bg-accent hover:text-foreground hover:shadow-sm",
-            "active:scale-95",
             "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2",
+            !disabled &&
+              "hover:bg-accent hover:text-foreground hover:shadow-sm active:scale-95",
+            disabled && "cursor-not-allowed opacity-40",
             isActive &&
+              !disabled &&
               "text-foreground before:bg-primary before:absolute before:inset-y-1.5 before:-left-1 before:w-0.5 before:rounded-full before:transition-all"
           )}
         >
           <FontAwesomeIcon
-            icon={isActive ? activeIcon : icon}
+            icon={isActive && !disabled ? activeIcon : icon}
             className="text-xl"
           />
         </Button>
       </TooltipTrigger>
-      <TooltipContent side="right">{label}</TooltipContent>
+      <TooltipContent side="right">{tooltipText}</TooltipContent>
     </Tooltip>
   );
 }

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -8,6 +8,8 @@ import { faMessageBot as faMessageBotSolid } from "@fortawesome/pro-solid-svg-ic
 import { faPenToSquare as faPenToSquareSolid } from "@fortawesome/pro-solid-svg-icons";
 import { useNavigate } from "react-router";
 
+import { useAuthStore } from "@/lib/auth-store";
+import { hasAnyLanguageRights } from "@/lib/permissions";
 import { useUiStore } from "@/lib/ui-store";
 import { Separator } from "@/components/ui/separator";
 import { ActivityBarItem } from "@/components/activity-bar-item";
@@ -19,6 +21,8 @@ export function ActivityBar() {
   const setActiveSection = useUiStore((s) => s.setActiveSection);
   const testChatOpen = useUiStore((s) => s.testChatOpen);
   const toggleTestChat = useUiStore((s) => s.toggleTestChat);
+  const languageRights = useAuthStore((s) => s.user?.language_rights);
+  const canAccessLanguages = hasAnyLanguageRights(languageRights);
 
   return (
     <div className="bg-card relative z-10 flex h-full w-12 flex-col items-center py-3 shadow-[2px_0_12px_rgba(0,0,0,0.2)]">
@@ -49,11 +53,11 @@ export function ActivityBar() {
           label="Edit per-language tuning documents"
           isActive={activeSection === "languages"}
           onClick={() => {
-            // TODO(#80): gate on session.language_rights once delivered;
-            // until then the tab is always visible.
             setActiveSection("languages");
             void navigate("/languages");
           }}
+          disabled={!canAccessLanguages}
+          disabledLabel="No language access — contact your admin"
         />
         <Separator className="my-1.5 w-5 opacity-50" />
         <ActivityBarItem

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -4,6 +4,19 @@ const SAME_ORIGIN_HEADERS = {
   "X-Requested-With": "XMLHttpRequest",
 } as const;
 
+// Thrown when the worker (or engine) returns 403 on a language operation.
+// Callers should catch this to render an inline permission message rather
+// than the generic save-failed error.
+export class LanguageForbiddenError extends Error {
+  constructor(
+    public readonly languageName: string,
+    public readonly operation: "read" | "write" | "delete"
+  ) {
+    super(`Forbidden: ${operation} on language "${languageName}"`);
+    this.name = "LanguageForbiddenError";
+  }
+}
+
 export async function listLanguages(
   signal?: AbortSignal
 ): Promise<OrgLanguages> {
@@ -29,6 +42,9 @@ export async function getLanguage(
     signal,
   });
 
+  if (res.status === 403) {
+    throw new LanguageForbiddenError(name, "read");
+  }
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Failed to load language (${res.status}): ${body}`);
@@ -60,6 +76,9 @@ export async function putLanguage(
     signal,
   });
 
+  if (res.status === 403) {
+    throw new LanguageForbiddenError(name, "write");
+  }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`Failed to save language (${res.status}): ${text}`);
@@ -78,6 +97,9 @@ export async function deleteLanguage(
     signal,
   });
 
+  if (res.status === 403) {
+    throw new LanguageForbiddenError(name, "delete");
+  }
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Failed to delete language (${res.status}): ${body}`);

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,27 @@
+import type { LanguageRights } from "@/types/auth";
+
+// `undefined` is the back-compat default until bt-servant-engine#207 lands —
+// treat it as full access so existing users aren't locked out.
+export function hasLanguageRights(
+  rights: LanguageRights | undefined,
+  name: string
+): boolean {
+  if (rights === undefined || rights === "*") return true;
+  return rights.includes(name);
+}
+
+export function hasAnyLanguageRights(
+  rights: LanguageRights | undefined
+): boolean {
+  if (rights === undefined || rights === "*") return true;
+  return rights.length > 0;
+}
+
+export function filterAuthorizedLanguages<T extends { name: string }>(
+  languages: T[],
+  rights: LanguageRights | undefined
+): T[] {
+  if (rights === undefined || rights === "*") return languages;
+  const allowed = new Set(rights);
+  return languages.filter((l) => allowed.has(l.name));
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,7 +1,14 @@
+// Language-shepherd permissions. `"*"` means full access (typically org admins);
+// a string array enumerates the language names the user is allowed to read/edit.
+// `undefined` means the engine has not yet populated this field — treated as
+// full access for back-compat until bt-servant-engine#207 ships.
+export type LanguageRights = string[] | "*";
+
 export interface AuthUser {
   id: string;
   email: string;
   name: string;
   org: string;
   isAdmin: boolean;
+  language_rights?: LanguageRights;
 }

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -1,7 +1,43 @@
 import { generateSalt, hashPassword, timingSafeEqual } from "./crypto";
 import type { Env } from "./helpers";
 import { errorResponse, jsonResponse } from "./helpers";
-import type { StoredUser } from "./types";
+import type { LanguageRights, StoredUser } from "./types";
+
+// Accepts `"*"` or an array of non-empty trimmed strings. Returns null if
+// the input is unset (caller should treat as "leave existing value alone")
+// or a validation error message if the shape is invalid.
+function parseLanguageRights(
+  value: unknown
+):
+  | { ok: true; value: LanguageRights | undefined }
+  | { ok: false; error: string } {
+  if (value === undefined) return { ok: true, value: undefined };
+  if (value === "*") return { ok: true, value: "*" };
+  if (Array.isArray(value)) {
+    const cleaned: string[] = [];
+    for (const entry of value) {
+      if (typeof entry !== "string") {
+        return {
+          ok: false,
+          error: "language_rights array entries must be strings",
+        };
+      }
+      const trimmed = entry.trim();
+      if (!trimmed) {
+        return {
+          ok: false,
+          error: "language_rights array entries must be non-empty",
+        };
+      }
+      cleaned.push(trimmed);
+    }
+    return { ok: true, value: cleaned };
+  }
+  return {
+    ok: false,
+    error: 'language_rights must be "*" or an array of strings',
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Admin secret guard
@@ -30,6 +66,7 @@ function safeUser(user: StoredUser) {
     name: user.name,
     org: user.org,
     isAdmin: user.isAdmin ?? false,
+    language_rights: user.language_rights,
   };
 }
 
@@ -48,6 +85,7 @@ async function createUser(request: Request, env: Env): Promise<Response> {
     name?: string;
     org?: string;
     isAdmin?: boolean;
+    language_rights?: unknown;
   };
   try {
     body = (await request.json()) as typeof body;
@@ -62,6 +100,11 @@ async function createUser(request: Request, env: Env): Promise<Response> {
 
   if (!email || !password || !name || !org) {
     return errorResponse("email, password, name, and org are required", 400);
+  }
+
+  const rightsResult = parseLanguageRights(body.language_rights);
+  if (!rightsResult.ok) {
+    return errorResponse(rightsResult.error, 400);
   }
 
   const existing = await env.AUTH_KV.get(`user:${email}`);
@@ -79,6 +122,7 @@ async function createUser(request: Request, env: Env): Promise<Response> {
     passwordHash,
     salt,
     isAdmin: body.isAdmin ?? false,
+    language_rights: rightsResult.value,
   };
 
   await env.AUTH_KV.put(`user:${email}`, JSON.stringify(user));
@@ -132,6 +176,7 @@ async function updateUser(
     org?: string;
     password?: string;
     isAdmin?: boolean;
+    language_rights?: unknown;
   };
   try {
     body = (await request.json()) as typeof body;
@@ -159,6 +204,13 @@ async function updateUser(
   if (body.password) {
     user.salt = generateSalt();
     user.passwordHash = await hashPassword(body.password, user.salt);
+  }
+  if (body.language_rights !== undefined) {
+    const rightsResult = parseLanguageRights(body.language_rights);
+    if (!rightsResult.ok) {
+      return errorResponse(rightsResult.error, 400);
+    }
+    user.language_rights = rightsResult.value;
   }
 
   await env.AUTH_KV.put(`user:${email}`, JSON.stringify(user));

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -148,6 +148,7 @@ export async function handleLogin(
       name: user.name,
       org: user.org,
       isAdmin: user.isAdmin ?? false,
+      language_rights: sessionData.language_rights,
     },
   });
   response.headers.set("Set-Cookie", sessionCookie(sessionId, request.url));
@@ -189,6 +190,7 @@ export async function handleMe(request: Request, env: Env): Promise<Response> {
       name: session.name,
       org: session.org,
       isAdmin: session.isAdmin ?? false,
+      language_rights: session.language_rights,
     },
   });
 }

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -74,14 +74,25 @@ export async function validateSession(
   });
   if (!data) return null;
 
-  // Ensure the user still exists (e.g. not deleted by admin)
-  const userExists = await env.AUTH_KV.get(`user:${data.email}`);
-  if (!userExists) {
+  // Hydrate live authorization fields from the user record so revocations
+  // take effect on the next request rather than waiting for the 7-day
+  // session to expire. Without this, an admin demoting a user or trimming
+  // their language_rights wouldn't take effect until logout/expiry — the
+  // boring kind of bug security incidents enjoy. Also serves as the
+  // "user still exists" check (returns null + clears session if deleted).
+  const user = await env.AUTH_KV.get<StoredUser>(`user:${data.email}`, {
+    type: "json",
+  });
+  if (!user) {
     await env.AUTH_KV.delete(`session:${sessionId}`);
     return null;
   }
 
-  return data;
+  return {
+    ...data,
+    isAdmin: user.isAdmin ?? false,
+    language_rights: user.language_rights,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -74,12 +74,15 @@ export async function validateSession(
   });
   if (!data) return null;
 
-  // Hydrate live authorization fields from the user record so revocations
-  // take effect on the next request rather than waiting for the 7-day
-  // session to expire. Without this, an admin demoting a user or trimming
-  // their language_rights wouldn't take effect until logout/expiry — the
-  // boring kind of bug security incidents enjoy. Also serves as the
-  // "user still exists" check (returns null + clears session if deleted).
+  // Hydrate from the live user record so admin changes (org moves,
+  // privilege grants/revocations, renames) take effect on the next
+  // request rather than waiting for the 7-day session to expire. Only
+  // userId and createdAt are session-immutable; everything else —
+  // including org, which is the authorization boundary on every engine
+  // path — is derived live. Without this, a user moved between orgs
+  // could keep operating against the old org until session expiry, with
+  // newly granted privileges to boot. Email is the KV key so a stale
+  // email self-corrects via the user-not-found branch below.
   const user = await env.AUTH_KV.get<StoredUser>(`user:${data.email}`, {
     type: "json",
   });
@@ -89,7 +92,11 @@ export async function validateSession(
   }
 
   return {
-    ...data,
+    userId: data.userId,
+    createdAt: data.createdAt,
+    email: user.email,
+    name: user.name,
+    org: user.org,
     isAdmin: user.isAdmin ?? false,
     language_rights: user.language_rights,
   };

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -135,6 +135,7 @@ export async function handleLogin(
     org: user.org,
     isAdmin: user.isAdmin ?? false,
     createdAt: new Date().toISOString(),
+    language_rights: user.language_rights,
   };
 
   await env.AUTH_KV.put(`session:${sessionId}`, JSON.stringify(sessionData), {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -1,6 +1,17 @@
 import type { Env } from "./helpers";
 import { errorResponse } from "./helpers";
-import type { SessionData } from "./types";
+import type { LanguageRights, SessionData } from "./types";
+
+// Worker-side defense-in-depth check. `undefined` is back-compat until
+// bt-servant-engine#207 lands — treat as full access. Engine remains the
+// source of truth.
+function hasLanguageRights(
+  rights: LanguageRights | undefined,
+  name: string
+): boolean {
+  if (rights === undefined || rights === "*") return true;
+  return rights.includes(name);
+}
 
 const UUID_V4_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -84,6 +95,9 @@ export async function handleConfig(
   const languageMatch = pathname.match(/^\/api\/config\/languages\/(.+)$/);
   if (languageMatch?.[1]) {
     const languageName = decodeURIComponent(languageMatch[1]);
+    if (!hasLanguageRights(session.language_rights, languageName)) {
+      return errorResponse("Forbidden", 403);
+    }
     return proxyToEngine(
       request,
       env,

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -2,9 +2,11 @@ import type { Env } from "./helpers";
 import { errorResponse } from "./helpers";
 import type { LanguageRights, SessionData } from "./types";
 
-// Worker-side defense-in-depth check. `undefined` is back-compat until
-// bt-servant-engine#207 lands — treat as full access. Engine remains the
-// source of truth.
+// Sole authorization gate for per-language access. Engine is a
+// trusted-portal model (single shared ADMIN_API_TOKEN, no user identity
+// on admin paths), so this check is the only thing standing between a
+// portal user and an engine call. `undefined` is the back-compat default
+// for users predating language_rights — treated as full access.
 function hasLanguageRights(
   rights: LanguageRights | undefined,
   name: string

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -2,6 +2,12 @@
 // Shared worker types
 // ---------------------------------------------------------------------------
 
+// Language-shepherd permissions. `"*"` means full access (typically org admins);
+// a string array enumerates the language names the user is allowed to read/edit.
+// `undefined` means rights have not been assigned — treated as full access for
+// back-compat so existing pre-permission users aren't locked out.
+export type LanguageRights = string[] | "*";
+
 export interface StoredUser {
   id: string;
   email: string;
@@ -10,13 +16,8 @@ export interface StoredUser {
   passwordHash: string;
   salt: string;
   isAdmin: boolean;
+  language_rights?: LanguageRights;
 }
-
-// Language-shepherd permissions. `"*"` means full access (typically org admins);
-// a string array enumerates the language names the user is allowed to read/edit.
-// `undefined` means the engine has not yet populated this field — treated as
-// full access for back-compat until bt-servant-engine#207 ships.
-export type LanguageRights = string[] | "*";
 
 export interface SessionData {
   userId: string;

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -12,6 +12,12 @@ export interface StoredUser {
   isAdmin: boolean;
 }
 
+// Language-shepherd permissions. `"*"` means full access (typically org admins);
+// a string array enumerates the language names the user is allowed to read/edit.
+// `undefined` means the engine has not yet populated this field — treated as
+// full access for back-compat until bt-servant-engine#207 ships.
+export type LanguageRights = string[] | "*";
+
 export interface SessionData {
   userId: string;
   email: string;
@@ -19,4 +25,5 @@ export interface SessionData {
   org: string;
   isAdmin: boolean;
   createdAt: string;
+  language_rights?: LanguageRights;
 }


### PR DESCRIPTION
## Summary

Adds language-shepherd permission gating across the worker BFF, frontend, and Languages editor. Closes #80.

**Updated 2026-05-08 (post Frank review):** original design assumed engine controls session payloads — code reading showed that's wrong. Engine is a trusted-portal model (single shared `ADMIN_API_TOKEN`, no user identity on admin paths). Portal is the sole gate. [bt-servant-engine#207](https://github.com/unfoldingWord/bt-servant-engine/issues/207) closed as wontfix-by-design; [#96](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/96) filed for the assignment UX.

## Contract

```
language_rights: string[] | "*" | undefined
```

| Value | Meaning |
| --- | --- |
| `string[]` | Explicit list of language names the user can read/edit |
| `"*"` | Full access (typically org admins) |
| `undefined` | Field never assigned — **treated as full access** for back-compat so existing pre-permission users aren't locked out |

Source path: `StoredUser.language_rights` (set via `/api/admin/users` POST/PUT) → `SessionData.language_rights` (copied at login) → `AuthUser.language_rights` (returned by `/api/auth/me`). The chain is fully portal-owned.

## What changed

**Worker (sole policy enforcement point — engine is trusted-portal)**
- `worker/types.ts` — `LanguageRights = string[] | "*"`; `StoredUser` and `SessionData` gain `language_rights?: LanguageRights`
- `worker/admin.ts` — `createUser` and `updateUser` accept `language_rights` in the body. New `parseLanguageRights` validator: must be `"*"` or array of non-empty trimmed strings; absent on update = leave existing alone. `safeUser()` returns it.
- `worker/auth.ts` — `handleLogin` copies `user.language_rights` → `sessionData.language_rights`. `handleLogin` and `handleMe` include it in the response.
- `worker/config.ts` — `/api/config/languages/{name}` (GET/PUT/DELETE) returns 403 when rights don't include the target. List endpoint stays pass-through (engine returns the full list; portal filters client-side).

**Frontend**
- `src/types/auth.ts` — `AuthUser` gains the field
- `src/lib/permissions.ts` (new) — `hasLanguageRights`, `hasAnyLanguageRights`, `filterAuthorizedLanguages` helpers, all treating undefined as full access
- `src/components/activity-bar.tsx` — Languages tab uses the new disabled-with-tooltip variant when rights is `[]`. Removes prior `TODO(#80)` stub.
- `src/components/activity-bar-item.tsx` — adds `disabled` + `disabledLabel` props (grayed + tooltip + click-noop). Existing call-sites unchanged.
- `src/lib/languages-api.ts` — new `LanguageForbiddenError` typed exception thrown from `getLanguage` / `putLanguage` / `deleteLanguage` on 403.
- `src/app/pages/languages.tsx` — filters dropdown via `filterAuthorizedLanguages`; `forbiddenError` memo combines `saveLanguage.error`, `deleteLanguage.error`, and `loadError` (per Frank P2); renders an **inline** permission-specific message per #80 AC; auto-deselects a persisted selection if rights changed mid-session; new `NoAccessState` for URL-hacked navigation when the user has zero rights.

## Behavior summary

| Rights value | Activity-bar tab | Dropdown contents | PUT/DELETE a forbidden language |
| --- | --- | --- | --- |
| `undefined` (existing users) | Visible, clickable | All languages | Worker 200 (back-compat) |
| `"*"` | Visible, clickable | All languages | Worker 200 |
| `["es"]` | Visible, clickable | Only `es` | Worker 403, inline banner |
| `[]` | Grayed + tooltip "No language access — contact your admin" | N/A (URL-hack → `NoAccessState`) | Worker 403, inline banner |

## Test plan

- [ ] Verify dev deploy: tab still visible + clickable for current users (back-compat default — should be a no-op for everyone today since no `StoredUser` records have `language_rights` set yet).
- [ ] `curl -X PUT /api/admin/users/{email} -H "X-Admin-Secret: ..." -d '{"language_rights": ["es"]}'` then re-login → confirm dropdown filters to `es` only and other languages 403 if URL-hacked. Confirm save 403s on a forbidden language render the inline message (not toast).
- [ ] Same flow with `"language_rights": []` → confirm activity-bar grayed with tooltip + URL-hack to `/languages` shows `NoAccessState`.
- [ ] Same flow with `"language_rights": "*"` → confirm full access (parity with undefined).
- [ ] Confirm existing flows (publish, unpublish, create, delete) still gated on `isAdmin` independently of the new rights axis.
- [ ] Force `deleteLanguage.error` to a `LanguageForbiddenError` (e.g. via DevTools mock) → confirm delete-variant inline banner renders (Frank P2 verification).

## Notes

- Engine is a trusted-portal model (verified in engine codebase). All policy enforcement happens in the worker BFF before calling engine. There's no engine-side enforcement to coordinate with.
- The existing `isAdmin` permission axis (controls create/delete/publish) remains independent of `language_rights` per #80.
- Follow-up #96 covers the missing admin UI to actually assign rights (currently only via `X-Admin-Secret` CLI/curl).