### PR TITLE
feat: dual-auth + org-scoping on /api/admin/users (#96 backend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Type check (TypeScript)
         run: npm run typecheck
 
+      - name: Test (Vitest worker pool)
+        run: npm test
+
       - name: Security audit
         run: npm audit --omit=dev --audit-level=moderate
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.10.0",
+        "@cloudflare/vitest-pool-workers": "^0.16.3",
         "@cloudflare/workers-types": "^4.20250620.0",
         "@tailwindcss/postcss": "^4",
         "@types/react": "^19",
@@ -46,6 +47,7 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.34.0",
         "vite": "^6.3.5",
+        "vitest": "^4.1.5",
         "wrangler": "^4.62.0"
       }
     },
@@ -591,6 +593,519 @@
       "peerDependencies": {
         "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
         "wrangler": "^4.90.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.3.tgz",
+      "integrity": "sha512-cnxtKBWoP5uhO78Z9zlCexj7oIs6zYoIH4GCEFS0Z6bepFDdnxtuMGxmWaDg84cy9teoh5CLA/OEN6XLSKcnWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "^1.2.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260507.1",
+        "wrangler": "4.90.0",
+        "zod": "^3.25.76"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -4434,6 +4949,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
@@ -4827,6 +5349,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -4835,6 +5368,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -5263,6 +5803,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5441,6 +6094,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types": {
@@ -5674,6 +6337,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5730,6 +6403,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -6410,6 +7090,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6686,6 +7373,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6761,6 +7458,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -9715,6 +10422,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -11145,6 +11863,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -11225,6 +11950,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -11234,6 +11966,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -11448,6 +12187,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -11473,6 +12219,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -12058,6 +12814,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -12082,6 +12928,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc -b",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky",
     "deploy": "wrangler deploy",
     "deploy:staging": "wrangler deploy --env staging"
@@ -47,6 +49,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.10.0",
+    "@cloudflare/vitest-pool-workers": "^0.16.3",
     "@cloudflare/workers-types": "^4.20250620.0",
     "@tailwindcss/postcss": "^4",
     "@types/react": "^19",
@@ -64,6 +67,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.0",
     "vite": "^6.3.5",
+    "vitest": "^4.1.5",
     "wrangler": "^4.62.0"
   }
 }

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -1,0 +1,467 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { handleAdmin } from "../worker/admin";
+import { generateSalt, hashPassword } from "../worker/crypto";
+import type { LanguageRights, SessionData, StoredUser } from "../worker/types";
+
+const ADMIN_SECRET = "test-admin-secret";
+
+interface SeedUserInput {
+  id?: string;
+  email: string;
+  name: string;
+  org: string;
+  isAdmin?: boolean;
+  language_rights?: LanguageRights;
+}
+
+async function seedUser(input: SeedUserInput): Promise<StoredUser> {
+  const salt = generateSalt();
+  const passwordHash = await hashPassword("test-password", salt);
+  const stored: StoredUser = {
+    id: input.id ?? crypto.randomUUID(),
+    email: input.email,
+    name: input.name,
+    org: input.org,
+    passwordHash,
+    salt,
+    isAdmin: input.isAdmin ?? false,
+    language_rights: input.language_rights,
+  };
+  await env.AUTH_KV.put(`user:${input.email}`, JSON.stringify(stored));
+  return stored;
+}
+
+async function seedSession(user: StoredUser): Promise<string> {
+  const sessionId = crypto.randomUUID();
+  const session: SessionData = {
+    userId: user.id,
+    email: user.email,
+    name: user.name,
+    org: user.org,
+    isAdmin: user.isAdmin ?? false,
+    createdAt: new Date().toISOString(),
+    language_rights: user.language_rights,
+  };
+  await env.AUTH_KV.put(`session:${sessionId}`, JSON.stringify(session));
+  return sessionId;
+}
+
+interface MakeReqOpts {
+  method: string;
+  pathname: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  sessionId?: string;
+}
+
+function makeRequest(opts: MakeReqOpts): Request {
+  const headers = new Headers(opts.headers ?? {});
+  if (opts.sessionId) {
+    const existing = headers.get("Cookie");
+    headers.set(
+      "Cookie",
+      existing
+        ? `${existing}; session=${opts.sessionId}`
+        : `session=${opts.sessionId}`
+    );
+  }
+  if (opts.body !== undefined) {
+    headers.set("Content-Type", "application/json");
+  }
+  return new Request(`https://portal.example.test${opts.pathname}`, {
+    method: opts.method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+}
+
+async function call(
+  opts: MakeReqOpts
+): Promise<{ status: number; body: unknown }> {
+  const res = await handleAdmin(makeRequest(opts), env, opts.pathname);
+  // Parse body if there is one. errorResponse returns JSON; jsonResponse too.
+  const text = await res.text();
+  const body = text ? JSON.parse(text) : null;
+  return { status: res.status, body };
+}
+
+beforeEach(async () => {
+  // Wipe AUTH_KV between tests so seed state doesn't leak.
+  let cursor: string | undefined;
+  do {
+    const list = await env.AUTH_KV.list({ cursor });
+    for (const key of list.keys) {
+      await env.AUTH_KV.delete(key.name);
+    }
+    cursor = list.list_complete ? undefined : list.cursor;
+  } while (cursor);
+});
+
+// ---------------------------------------------------------------------------
+// X-Admin-Secret path (super scope)
+// ---------------------------------------------------------------------------
+
+describe("admin auth — X-Admin-Secret (super scope)", () => {
+  it("valid secret → 200, lists users from all orgs", async () => {
+    await seedUser({ email: "alice@acme.com", name: "Alice", org: "acme" });
+    await seedUser({ email: "bob@other.com", name: "Bob", org: "other" });
+
+    const { status, body } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+    });
+
+    expect(status).toBe(200);
+    const users = (body as { users: { org: string }[] }).users;
+    expect(users).toHaveLength(2);
+    expect(new Set(users.map((u) => u.org))).toEqual(
+      new Set(["acme", "other"])
+    );
+  });
+
+  it("invalid secret + no XHR header → 403", async () => {
+    const { status } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Admin-Secret": "WRONG" },
+    });
+    expect(status).toBe(403);
+  });
+
+  it("no auth at all → 403", async () => {
+    const { status } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+    });
+    expect(status).toBe(403);
+  });
+
+  it("super scope can move user across orgs", async () => {
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: { org: "other" },
+    });
+
+    expect(status).toBe(200);
+    expect((body as { user: { org: string } }).user.org).toBe("other");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cookie path (org scope)
+// ---------------------------------------------------------------------------
+
+describe("admin auth — session cookie (org scope)", () => {
+  it("isAdmin + XHR → 200, list filtered to caller's org", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    await seedUser({ email: "bob@acme.com", name: "Bob", org: "acme" });
+    await seedUser({ email: "carol@other.com", name: "Carol", org: "other" });
+    const session = await seedSession(alice);
+
+    const { status, body } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(200);
+    const users = (body as { users: { email: string; org: string }[] }).users;
+    expect(users).toHaveLength(2);
+    expect(users.every((u) => u.org === "acme")).toBe(true);
+  });
+
+  it("isAdmin=false + XHR → 403", async () => {
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+      isAdmin: false,
+    });
+    const session = await seedSession(bob);
+
+    const { status } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(403);
+  });
+
+  it("isAdmin + missing XHR header → 403 (CSRF guard)", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const session = await seedSession(alice);
+
+    const { status } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      sessionId: session,
+    });
+
+    expect(status).toBe(403);
+  });
+
+  it("cross-org PUT → 404 (avoid enumeration)", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    await seedUser({ email: "carol@other.com", name: "Carol", org: "other" });
+    const session = await seedSession(alice);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: "/api/admin/users/carol@other.com",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { name: "Hacked" },
+    });
+
+    expect(status).toBe(404);
+  });
+
+  it("cross-org DELETE → 404 (avoid enumeration)", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    await seedUser({ email: "carol@other.com", name: "Carol", org: "other" });
+    const session = await seedSession(alice);
+
+    const { status } = await call({
+      method: "DELETE",
+      pathname: "/api/admin/users/carol@other.com",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(404);
+  });
+
+  it("attempt to move user to another org → 403", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    await seedUser({ email: "bob@acme.com", name: "Bob", org: "acme" });
+    const session = await seedSession(alice);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: "/api/admin/users/bob@acme.com",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { org: "other" },
+    });
+
+    expect(status).toBe(403);
+  });
+
+  it("attempt to create user in another org → 403", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const session = await seedSession(alice);
+
+    const { status } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: {
+        email: "newuser@other.com",
+        password: "pw",
+        name: "New",
+        org: "other",
+      },
+    });
+
+    expect(status).toBe(403);
+  });
+
+  it("create user in own org → 201", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const session = await seedSession(alice);
+
+    const { status, body } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: {
+        email: "newuser@acme.com",
+        password: "pw-newuser",
+        name: "New",
+        org: "acme",
+      },
+    });
+
+    expect(status).toBe(201);
+    expect((body as { user: { email: string } }).user.email).toBe(
+      "newuser@acme.com"
+    );
+  });
+
+  it("self-delete → 400", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const session = await seedSession(alice);
+
+    const { status } = await call({
+      method: "DELETE",
+      pathname: "/api/admin/users/alice@acme.com",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(400);
+    // User should still exist
+    const stillThere = await env.AUTH_KV.get("user:alice@acme.com");
+    expect(stillThere).not.toBeNull();
+  });
+
+  it("self-demote → 400", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const session = await seedSession(alice);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: "/api/admin/users/alice@acme.com",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { isAdmin: false },
+    });
+
+    expect(status).toBe(400);
+    // Should still be admin
+    const record = await env.AUTH_KV.get<StoredUser>("user:alice@acme.com", {
+      type: "json",
+    });
+    expect(record?.isAdmin).toBe(true);
+  });
+
+  it("can demote a different admin in same org", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+      isAdmin: true,
+    });
+    const session = await seedSession(alice);
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: "/api/admin/users/bob@acme.com",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { isAdmin: false },
+    });
+
+    expect(status).toBe(200);
+    expect((body as { user: { isAdmin: boolean } }).user.isAdmin).toBe(false);
+  });
+
+  it("can assign language_rights on a user in own org", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    await seedUser({ email: "bob@acme.com", name: "Bob", org: "acme" });
+    const session = await seedSession(alice);
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: "/api/admin/users/bob@acme.com",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { language_rights: ["es", "en"] },
+    });
+
+    expect(status).toBe(200);
+    expect(
+      (body as { user: { language_rights: LanguageRights } }).user
+        .language_rights
+    ).toEqual(["es", "en"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed paths
+// ---------------------------------------------------------------------------
+
+describe("admin auth — mixed paths", () => {
+  it("X-Admin-Secret wins even when caller's session is non-admin", async () => {
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+      isAdmin: false,
+    });
+    const session = await seedSession(bob);
+
+    const { status, body } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      sessionId: session,
+    });
+
+    expect(status).toBe(200);
+    // Super scope listed all (just Bob in this test)
+    expect((body as { users: unknown[] }).users).toHaveLength(1);
+  });
+});

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -20,7 +20,10 @@
     "noUncheckedIndexedAccess": true,
 
     /* Types */
-    "types": ["@cloudflare/workers-types"]
+    "types": [
+      "@cloudflare/workers-types",
+      "@cloudflare/vitest-pool-workers/types"
+    ]
   },
-  "include": ["worker"]
+  "include": ["worker", "tests", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,25 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      main: "./worker/index.ts",
+      miniflare: {
+        compatibilityDate: "2025-04-01",
+        compatibilityFlags: ["nodejs_compat"],
+        bindings: {
+          ADMIN_SECRET: "test-admin-secret",
+          ENGINE_BASE_URL: "https://engine.example.test",
+          ENGINE_API_KEY: "test-engine-key",
+          BARUCH_BASE_URL: "https://baruch.example.test",
+          BARUCH_API_KEY: "test-baruch-key",
+        },
+        kvNamespaces: ["AUTH_KV"],
+      },
+    }),
+  ],
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -1,3 +1,4 @@
+import { validateSession } from "./auth";
 import { generateSalt, hashPassword, timingSafeEqual } from "./crypto";
 import type { Env } from "./helpers";
 import { errorResponse, jsonResponse } from "./helpers";
@@ -40,19 +41,49 @@ function parseLanguageRights(
 }
 
 // ---------------------------------------------------------------------------
-// Admin secret guard
+// Auth — dual-mode
 // ---------------------------------------------------------------------------
+//
+// Two authentication paths are accepted:
+//
+//   1. **X-Admin-Secret** — a Cloudflare Worker secret. Cross-org "super"
+//      admin. Used by CLI/curl for bootstrap and recovery (creating the very
+//      first user, fixing a broken admin, etc.). Skips same-origin checks
+//      because the caller has no implicit credentials to abuse.
+//
+//   2. **Session cookie + isAdmin === true** — the browser path. Org-scoped:
+//      the caller can only manage users within their own session.org.
+//      Same-origin (`X-Requested-With: XMLHttpRequest`) is required to
+//      prevent CSRF abuse of the implicit cookie.
+//
+// Self-mutation guards (cookie path only): an org admin cannot delete or
+// demote themselves. The X-Admin-Secret path stays as the recovery escape.
 
-function requireAdminSecret(request: Request, env: Env): Response | null {
+type AdminScope =
+  | { kind: "super" }
+  | { kind: "org"; org: string; selfEmail: string };
+
+async function requireAdminAuth(
+  request: Request,
+  env: Env
+): Promise<AdminScope | Response> {
+  // Path 1: X-Admin-Secret (CLI / cross-org / bootstrap).
   const secret = request.headers.get("X-Admin-Secret");
-  if (
-    !env.ADMIN_SECRET ||
-    !secret ||
-    !timingSafeEqual(secret, env.ADMIN_SECRET)
-  ) {
+  if (env.ADMIN_SECRET && secret && timingSafeEqual(secret, env.ADMIN_SECRET)) {
+    return { kind: "super" };
+  }
+
+  // Path 2: session cookie + isAdmin (browser). Same-origin required.
+  if (request.headers.get("X-Requested-With") !== "XMLHttpRequest") {
     return errorResponse("Forbidden", 403);
   }
-  return null;
+
+  const session = await validateSession(request, env);
+  if (!session || !session.isAdmin) {
+    return errorResponse("Forbidden", 403);
+  }
+
+  return { kind: "org", org: session.org, selfEmail: session.email };
 }
 
 // ---------------------------------------------------------------------------
@@ -74,7 +105,11 @@ function safeUser(user: StoredUser) {
 // CRUD handlers
 // ---------------------------------------------------------------------------
 
-async function createUser(request: Request, env: Env): Promise<Response> {
+async function createUser(
+  request: Request,
+  env: Env,
+  scope: AdminScope
+): Promise<Response> {
   if (request.method !== "POST") {
     return errorResponse("Method not allowed", 405);
   }
@@ -100,6 +135,14 @@ async function createUser(request: Request, env: Env): Promise<Response> {
 
   if (!email || !password || !name || !org) {
     return errorResponse("email, password, name, and org are required", 400);
+  }
+
+  // Org-scoped admins can only create users in their own org.
+  if (scope.kind === "org" && org !== scope.org) {
+    return errorResponse(
+      `Cannot create user outside your org (${scope.org})`,
+      403
+    );
   }
 
   const rightsResult = parseLanguageRights(body.language_rights);
@@ -130,7 +173,11 @@ async function createUser(request: Request, env: Env): Promise<Response> {
   return jsonResponse({ user: safeUser(user) }, 201);
 }
 
-async function listUsers(request: Request, env: Env): Promise<Response> {
+async function listUsers(
+  request: Request,
+  env: Env,
+  scope: AdminScope
+): Promise<Response> {
   if (request.method !== "GET") {
     return errorResponse("Method not allowed", 405);
   }
@@ -148,7 +195,10 @@ async function listUsers(request: Request, env: Env): Promise<Response> {
       const user = await env.AUTH_KV.get<StoredUser>(key.name, {
         type: "json",
       });
-      return user ? safeUser(user) : null;
+      if (!user) return null;
+      // Org-scoped admins only see users in their own org.
+      if (scope.kind === "org" && user.org !== scope.org) return null;
+      return safeUser(user);
     })
   );
 
@@ -158,7 +208,8 @@ async function listUsers(request: Request, env: Env): Promise<Response> {
 async function updateUser(
   request: Request,
   env: Env,
-  email: string
+  email: string,
+  scope: AdminScope
 ): Promise<Response> {
   if (request.method !== "PUT") {
     return errorResponse("Method not allowed", 405);
@@ -168,6 +219,12 @@ async function updateUser(
     type: "json",
   });
   if (!user) {
+    return errorResponse("User not found", 404);
+  }
+
+  // Org-scoped admins can only see/edit users in their own org. Return 404
+  // (not 403) on cross-org targets to avoid leaking existence.
+  if (scope.kind === "org" && user.org !== scope.org) {
     return errorResponse("User not found", 404);
   }
 
@@ -182,6 +239,26 @@ async function updateUser(
     body = (await request.json()) as typeof body;
   } catch {
     return errorResponse("Invalid JSON", 400);
+  }
+
+  // Org-scoped admins cannot move users to another org. Allow no-op
+  // (org === scope.org) so PUTs that include the current org are fine.
+  if (
+    body.org !== undefined &&
+    scope.kind === "org" &&
+    body.org.trim() !== scope.org
+  ) {
+    return errorResponse("Cannot move user to another org", 403);
+  }
+
+  // Self-demote guard (cookie path only). The X-Admin-Secret CLI is the
+  // recovery path if a self-demote is genuinely needed.
+  if (
+    scope.kind === "org" &&
+    scope.selfEmail === email &&
+    body.isAdmin === false
+  ) {
+    return errorResponse("Cannot demote yourself", 400);
   }
 
   if (body.name !== undefined) {
@@ -221,14 +298,27 @@ async function updateUser(
 async function deleteUser(
   request: Request,
   env: Env,
-  email: string
+  email: string,
+  scope: AdminScope
 ): Promise<Response> {
   if (request.method !== "DELETE") {
     return errorResponse("Method not allowed", 405);
   }
 
-  const existing = await env.AUTH_KV.get(`user:${email}`);
-  if (!existing) {
+  // Self-delete guard (cookie path only). The X-Admin-Secret CLI is the
+  // recovery path if a self-delete is genuinely needed.
+  if (scope.kind === "org" && scope.selfEmail === email) {
+    return errorResponse("Cannot delete yourself", 400);
+  }
+
+  // Need the full record to enforce the org-scope check before deleting.
+  const user = await env.AUTH_KV.get<StoredUser>(`user:${email}`, {
+    type: "json",
+  });
+  if (!user) {
+    return errorResponse("User not found", 404);
+  }
+  if (scope.kind === "org" && user.org !== scope.org) {
     return errorResponse("User not found", 404);
   }
 
@@ -246,20 +336,22 @@ export async function handleAdmin(
   env: Env,
   pathname: string
 ): Promise<Response> {
-  const blocked = requireAdminSecret(request, env);
-  if (blocked) return blocked;
+  const auth = await requireAdminAuth(request, env);
+  if (auth instanceof Response) return auth;
 
   if (pathname === "/api/admin/users") {
-    if (request.method === "POST") return createUser(request, env);
-    if (request.method === "GET") return listUsers(request, env);
+    if (request.method === "POST") return createUser(request, env, auth);
+    if (request.method === "GET") return listUsers(request, env, auth);
     return errorResponse("Method not allowed", 405);
   }
 
   const match = pathname.match(/^\/api\/admin\/users\/(.+)$/);
   if (match?.[1]) {
     const email = decodeURIComponent(match[1]).toLowerCase();
-    if (request.method === "PUT") return updateUser(request, env, email);
-    if (request.method === "DELETE") return deleteUser(request, env, email);
+    if (request.method === "PUT") return updateUser(request, env, email, auth);
+    if (request.method === "DELETE") {
+      return deleteUser(request, env, email, auth);
+    }
     return errorResponse("Method not allowed", 405);
   }
 

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -1,0 +1,8 @@
+import type { Env as WorkerEnv } from "./helpers";
+
+declare global {
+  namespace Cloudflare {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    interface Env extends WorkerEnv {}
+  }
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -46,7 +46,8 @@ export default {
       return errorResponse("Not found", 404);
     }
 
-    // Admin endpoints — admin secret required, no same-origin check
+    // Admin endpoints — dual-auth (X-Admin-Secret OR session-cookie + isAdmin).
+    // handleAdmin enforces same-origin internally only on the cookie path.
     if (url.pathname.startsWith("/api/admin/")) {
       return handleAdmin(request, env, url.pathname);
     }


### PR DESCRIPTION
## Summary

PR A of #96. Adds session-cookie + \`isAdmin\` as a second authentication path on \`/api/admin/users\`, alongside the existing \`X-Admin-Secret\` CLI/curl path. The session-cookie path is **org-scoped** so an org admin can only manage users in their own org.

This is the foundation that lets a browser UI call \`/api/admin/users\` without exposing \`ADMIN_SECRET\` to the client. **PR B will build the Users admin page on top.**

## Auth model

| Path | Use case | Org boundary | Same-origin required |
| --- | --- | --- | --- |
| \`X-Admin-Secret\` | CLI/curl, bootstrap, recovery | Cross-org (super) | No (caller has no implicit creds) |
| Session cookie + \`isAdmin\` | Browser UI | Own \`session.org\` only | Yes (\`X-Requested-With: XMLHttpRequest\`) |

If both are present, \`X-Admin-Secret\` wins.

\`\`\`ts
type AdminScope =
  | { kind: \"super\" }
  | { kind: \"org\"; org: string; selfEmail: string };
\`\`\`

The scope is threaded through \`createUser\`, \`listUsers\`, \`updateUser\`, \`deleteUser\` so each can apply the right boundary.

## Org-scope enforcement (cookie path)

| Op | Behavior |
| --- | --- |
| \`listUsers\` | Filters out users not in \`scope.org\` |
| \`createUser\` | 403 if \`body.org !== scope.org\` |
| \`updateUser\` | 404 if target user not in \`scope.org\` (avoid enumeration); 403 if attempting to move user to another org |
| \`deleteUser\` | 404 if target user not in \`scope.org\` |

## Self-mutation guards (cookie path only)

\`X-Admin-Secret\` remains the recovery path for genuinely-needed self-mutations.

| Action | Behavior |
| --- | --- |
| Self-demote (\`PUT /api/admin/users/{self} { isAdmin: false }\`) | 400 |
| Self-delete (\`DELETE /api/admin/users/{self}\`) | 400 |

Without these, an org admin in a one-admin org could lock themselves out of management via the UI.

## What changed

- \`worker/admin.ts\` — \`requireAdminSecret\` replaced by \`requireAdminAuth\` returning \`AdminScope | Response\`. All four CRUD handlers updated.
- \`worker/index.ts\` — comment updated to reflect dual-auth (no behavior change; routing untouched).

## Behavior matrix

| Caller | Auth header | XHR header | Outcome |
| --- | --- | --- | --- |
| \`curl -H \"X-Admin-Secret: \$VALID\"\` | ✓ | — | Super (cross-org) |
| \`curl -H \"X-Admin-Secret: WRONG\"\` | ✗ | — | 403 (no XHR header → cookie path also fails) |
| Browser, isAdmin=true, same-origin XHR | — | ✓ | Org-scoped to \`session.org\` |
| Browser, isAdmin=false | — | ✓ | 403 |
| External site (no XHR header) | — | ✗ | 403 |
| Both X-Admin-Secret AND cookie | ✓ | — | Super (secret wins) |

## Test plan

- [ ] \`curl -H \"X-Admin-Secret: \$ADMIN_SECRET\" /api/admin/users\` → returns all users (no org filter)
- [ ] Login as org admin, \`fetch('/api/admin/users', { headers: { 'X-Requested-With': 'XMLHttpRequest' } })\` → returns only own-org users
- [ ] Same fetch from a non-admin user → 403
- [ ] Same fetch from another origin (no XHR header) → 403
- [ ] PUT \`/api/admin/users/{otherOrgUser}\` with cookie → 404 (cross-org enumeration blocked)
- [ ] PUT \`/api/admin/users/{ownOrgUser} { org: \"differentOrg\" }\` with cookie → 403
- [ ] DELETE \`/api/admin/users/{self}\` with cookie → 400
- [ ] PUT \`/api/admin/users/{self} { isAdmin: false }\` with cookie → 400

## Notes

No frontend changes in this PR. PR B (#96 follow-up) builds the Users admin page that consumes this.