### PR TITLE
feat: Users admin page (#96)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,7 +11,9 @@ import { useSyncSection } from "@/hooks/use-sync-section";
 import { useAuthInit } from "@/hooks/use-auth-init";
 import { useSessionGuard } from "@/hooks/use-session-guard";
 import { AppShell } from "@/components/app-shell";
+import { RequireAdmin } from "@/components/require-admin";
 import { RequireAuth } from "@/components/require-auth";
+import { AdminUsersPage } from "@/app/pages/admin-users";
 import { BaruchPage } from "@/app/pages/baruch";
 import { LanguagesPage } from "@/app/pages/languages";
 import { LoginPage } from "@/app/pages/login";
@@ -46,6 +48,14 @@ const router = createBrowserRouter([
           { index: true, element: <BaruchPage /> },
           { path: "prompt-configuration", element: <ManualConfigPage /> },
           { path: "languages", element: <LanguagesPage /> },
+          {
+            path: "admin/users",
+            element: (
+              <RequireAdmin>
+                <AdminUsersPage />
+              </RequireAdmin>
+            ),
+          },
         ],
       },
       { path: "*", element: <Navigate to="/" replace /> },

--- a/src/app/pages/admin-users.tsx
+++ b/src/app/pages/admin-users.tsx
@@ -13,7 +13,6 @@ import { useAdminUsers, useDeleteAdminUser } from "@/hooks/use-admin-users";
 import { useLanguages } from "@/hooks/use-languages";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -193,13 +192,19 @@ export function AdminUsersPage() {
             <AlertDialogCancel disabled={deleteUser.isPending}>
               Cancel
             </AlertDialogCancel>
-            <AlertDialogAction
+            {/*
+              Plain Button (not AlertDialogAction) — Radix's Action closes the
+              dialog on click, which would dismiss the inline error before the
+              async mutation's onError can render it. Closing happens manually
+              in handleConfirmDelete's onSuccess.
+            */}
+            <Button
               variant="destructive"
               onClick={handleConfirmDelete}
               disabled={deleteUser.isPending}
             >
               {deleteUser.isPending ? "Deleting…" : "Delete user"}
-            </AlertDialogAction>
+            </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/app/pages/admin-users.tsx
+++ b/src/app/pages/admin-users.tsx
@@ -1,0 +1,293 @@
+import { useMemo, useState } from "react";
+import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Plus, Trash2, UserPen } from "lucide-react";
+
+import type { AdminUser } from "@/types/admin-users";
+import {
+  AdminUsersForbiddenError,
+  AdminUsersRequestError,
+} from "@/lib/admin-users-api";
+import { useAuthStore } from "@/lib/auth-store";
+import { useAdminUsers, useDeleteAdminUser } from "@/hooks/use-admin-users";
+import { useLanguages } from "@/hooks/use-languages";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { AdminUserCreateDialog } from "@/components/admin-user-create-dialog";
+import { AdminUserEditDialog } from "@/components/admin-user-edit-dialog";
+import { PageHeader } from "@/components/page-header";
+
+export function AdminUsersPage() {
+  const callerEmail = useAuthStore((s) => s.user?.email ?? "");
+  const callerOrg = useAuthStore((s) => s.user?.org ?? "");
+
+  const usersQuery = useAdminUsers();
+  const languagesQuery = useLanguages();
+  const deleteUser = useDeleteAdminUser();
+
+  const [editingEmail, setEditingEmail] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [confirmDeleteEmail, setConfirmDeleteEmail] = useState<string | null>(
+    null
+  );
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const editingUser = useMemo(
+    () => usersQuery.data?.find((u) => u.email === editingEmail) ?? null,
+    [usersQuery.data, editingEmail]
+  );
+  const confirmDeleteUser = useMemo(
+    () => usersQuery.data?.find((u) => u.email === confirmDeleteEmail) ?? null,
+    [usersQuery.data, confirmDeleteEmail]
+  );
+
+  const handleConfirmDelete = () => {
+    if (!confirmDeleteUser) return;
+    setDeleteError(null);
+    deleteUser.mutate(confirmDeleteUser.email, {
+      onSuccess: () => {
+        setConfirmDeleteEmail(null);
+      },
+      onError: (err) => {
+        if (err instanceof AdminUsersForbiddenError) {
+          setDeleteError(err.serverMessage ?? "You don't have permission.");
+        } else if (err instanceof AdminUsersRequestError) {
+          setDeleteError(err.serverMessage ?? `Failed (${err.status}).`);
+        } else {
+          setDeleteError(err.message);
+        }
+      },
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <PageHeader
+        title="Users"
+        subtitle={`Manage users in the ${callerOrg} organization. Assign org admin and language-shepherd permissions here.`}
+      />
+
+      <div className="bg-card border-b">
+        <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
+          <div className="flex-1" />
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-1.5 size-3.5" />
+            New user
+          </Button>
+        </div>
+      </div>
+
+      {usersQuery.error && (
+        <div className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm">
+          {usersQuery.error.message}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        {usersQuery.isLoading ? (
+          <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-3">
+            <FontAwesomeIcon
+              icon={faSpinnerThird}
+              className="size-5 animate-spin"
+            />
+            <p className="text-sm">Loading users…</p>
+          </div>
+        ) : !usersQuery.data || usersQuery.data.length === 0 ? (
+          <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+            <p className="text-sm">
+              No users yet. Click &ldquo;New user&rdquo; to add the first one.
+            </p>
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-muted-foreground sticky top-0 text-xs tracking-wide uppercase">
+              <tr>
+                <th className="px-6 py-3 text-left font-medium">Name</th>
+                <th className="px-6 py-3 text-left font-medium">Email</th>
+                <th className="px-6 py-3 text-left font-medium">Role</th>
+                <th className="px-6 py-3 text-left font-medium">
+                  Language access
+                </th>
+                <th className="px-6 py-3 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {usersQuery.data.map((u) => (
+                <UserRow
+                  key={u.email}
+                  user={u}
+                  isSelf={u.email === callerEmail}
+                  onEdit={() => setEditingEmail(u.email)}
+                  onDelete={() => {
+                    setDeleteError(null);
+                    setConfirmDeleteEmail(u.email);
+                  }}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <AdminUserCreateDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        callerOrg={callerOrg}
+        availableLanguages={languagesQuery.data?.languages}
+      />
+
+      <AdminUserEditDialog
+        user={editingUser}
+        open={editingEmail !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingEmail(null);
+        }}
+        callerEmail={callerEmail}
+        availableLanguages={languagesQuery.data?.languages}
+      />
+
+      <AlertDialog
+        open={confirmDeleteEmail !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmDeleteEmail(null);
+            setDeleteError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete user?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmDeleteUser ? (
+                <>
+                  This will permanently remove{" "}
+                  <span className="text-foreground font-medium">
+                    {confirmDeleteUser.name}
+                  </span>{" "}
+                  ({confirmDeleteUser.email}) from {confirmDeleteUser.org}.
+                  Their existing sessions stop validating on the next request.
+                  This action cannot be undone.
+                </>
+              ) : (
+                "This action cannot be undone."
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {deleteError && (
+            <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+              {deleteError}
+            </p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteUser.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleConfirmDelete}
+              disabled={deleteUser.isPending}
+            >
+              {deleteUser.isPending ? "Deleting…" : "Delete user"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface UserRowProps {
+  user: AdminUser;
+  isSelf: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+function UserRow({ user, isSelf, onEdit, onDelete }: UserRowProps) {
+  return (
+    <tr className="hover:bg-muted/30 transition-colors">
+      <td className="px-6 py-3">
+        <div className="font-medium">{user.name}</div>
+        {isSelf && <div className="text-muted-foreground text-xs">you</div>}
+      </td>
+      <td className="text-muted-foreground px-6 py-3 font-mono text-xs">
+        {user.email}
+      </td>
+      <td className="px-6 py-3">
+        {user.isAdmin ? (
+          <Badge>Admin</Badge>
+        ) : (
+          <Badge variant="outline">Member</Badge>
+        )}
+      </td>
+      <td className="px-6 py-3">
+        <LanguageRightsBadge value={user.language_rights} />
+      </td>
+      <td className="px-6 py-3 text-right">
+        <div className="flex justify-end gap-1">
+          <Button variant="ghost" size="sm" onClick={onEdit}>
+            <UserPen className="mr-1.5 size-3.5" />
+            Edit
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={isSelf}
+            title={isSelf ? "You cannot delete yourself" : "Delete user"}
+            onClick={onDelete}
+            className="text-destructive hover:text-destructive disabled:text-muted-foreground"
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function LanguageRightsBadge({
+  value,
+}: {
+  value: AdminUser["language_rights"];
+}) {
+  if (value === undefined) {
+    return (
+      <span className="text-muted-foreground text-xs">Default (full)</span>
+    );
+  }
+  if (value === "*") {
+    return <Badge>All languages</Badge>;
+  }
+  if (value.length === 0) {
+    return (
+      <Badge variant="outline" className="border-destructive text-destructive">
+        None
+      </Badge>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {value.slice(0, 4).map((name) => (
+        <Badge key={name} variant="outline" className="font-mono text-xs">
+          {name}
+        </Badge>
+      ))}
+      {value.length > 4 && (
+        <Badge variant="outline" className="text-xs">
+          +{value.length - 4}
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -2,10 +2,12 @@ import { faComments as faCommentsLight } from "@fortawesome/pro-light-svg-icons"
 import { faLanguage as faLanguageLight } from "@fortawesome/pro-light-svg-icons";
 import { faMessageBot as faMessageBotLight } from "@fortawesome/pro-light-svg-icons";
 import { faPenToSquare as faPenToSquareLight } from "@fortawesome/pro-light-svg-icons";
+import { faUsers as faUsersLight } from "@fortawesome/pro-light-svg-icons";
 import { faComments as faCommentsSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faLanguage as faLanguageSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faMessageBot as faMessageBotSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faPenToSquare as faPenToSquareSolid } from "@fortawesome/pro-solid-svg-icons";
+import { faUsers as faUsersSolid } from "@fortawesome/pro-solid-svg-icons";
 import { useNavigate } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
@@ -22,6 +24,7 @@ export function ActivityBar() {
   const testChatOpen = useUiStore((s) => s.testChatOpen);
   const toggleTestChat = useUiStore((s) => s.toggleTestChat);
   const languageRights = useAuthStore((s) => s.user?.language_rights);
+  const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
   const canAccessLanguages = hasAnyLanguageRights(languageRights);
 
   return (
@@ -59,6 +62,18 @@ export function ActivityBar() {
           disabled={!canAccessLanguages}
           disabledLabel="No language access — contact your admin"
         />
+        {isAdmin && (
+          <ActivityBarItem
+            icon={faUsersLight}
+            activeIcon={faUsersSolid}
+            label="Manage users in your org"
+            isActive={activeSection === "admin-users"}
+            onClick={() => {
+              setActiveSection("admin-users");
+              void navigate("/admin/users");
+            }}
+          />
+        )}
         <Separator className="my-1.5 w-5 opacity-50" />
         <ActivityBarItem
           icon={faCommentsLight}

--- a/src/components/admin-user-create-dialog.tsx
+++ b/src/components/admin-user-create-dialog.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+
+import type { Language } from "@/types/language";
+import type { LanguageRights } from "@/types/auth";
+import {
+  AdminUsersForbiddenError,
+  AdminUsersRequestError,
+} from "@/lib/admin-users-api";
+import { useCreateAdminUser } from "@/hooks/use-admin-users";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LanguageRightsSelector } from "@/components/language-rights-selector";
+
+interface CreateUserDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  // The caller's org. Pre-fills the form and is the only allowed value
+  // for org-scoped admins (the worker enforces this regardless).
+  callerOrg: string;
+  availableLanguages: Language[] | undefined;
+  onCreated?: (email: string) => void;
+}
+
+export function AdminUserCreateDialog({
+  open,
+  onOpenChange,
+  callerOrg,
+  availableLanguages,
+  onCreated,
+}: CreateUserDialogProps) {
+  const createUser = useCreateAdminUser();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [rights, setRights] = useState<LanguageRights>([]);
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  const reset = () => {
+    setEmail("");
+    setPassword("");
+    setName("");
+    setIsAdmin(false);
+    setRights([]);
+    setErrorText(null);
+    createUser.reset();
+  };
+
+  const handleClose = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorText(null);
+    const trimmedEmail = email.trim().toLowerCase();
+    const trimmedName = name.trim();
+
+    if (!trimmedEmail || !password || !trimmedName) {
+      setErrorText("Email, password, and name are required.");
+      return;
+    }
+    if (password.length < 8) {
+      setErrorText("Password must be at least 8 characters.");
+      return;
+    }
+
+    createUser.mutate(
+      {
+        email: trimmedEmail,
+        password,
+        name: trimmedName,
+        org: callerOrg,
+        isAdmin,
+        language_rights: rights,
+      },
+      {
+        onSuccess: (user) => {
+          onCreated?.(user.email);
+          reset();
+          onOpenChange(false);
+        },
+        onError: (err) => {
+          if (err instanceof AdminUsersForbiddenError) {
+            setErrorText(err.serverMessage ?? "You don't have permission.");
+          } else if (err instanceof AdminUsersRequestError) {
+            setErrorText(
+              err.serverMessage ?? `Request failed (${err.status}).`
+            );
+          } else {
+            setErrorText(err.message);
+          }
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Add a new user</DialogTitle>
+            <DialogDescription>
+              The user will be added to the{" "}
+              <span className="text-foreground font-medium">{callerOrg}</span>{" "}
+              organization. Share the password with them out-of-band; they can
+              change it after first sign-in.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="new-user-email">Email</Label>
+              <Input
+                id="new-user-email"
+                type="email"
+                autoComplete="off"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="user@example.com"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="new-user-name">Name</Label>
+              <Input
+                id="new-user-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Full name"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="new-user-password">Initial password</Label>
+              <Input
+                id="new-user-password"
+                type="text"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Min. 8 characters"
+                required
+              />
+              <p className="text-muted-foreground text-xs">
+                Visible deliberately so you can copy and share it. The user can
+                change it after first sign-in.
+              </p>
+            </div>
+
+            <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors">
+              <input
+                type="checkbox"
+                checked={isAdmin}
+                onChange={(e) => setIsAdmin(e.target.checked)}
+                className="mt-0.5"
+              />
+              <div className="space-y-0.5">
+                <div className="text-sm font-medium">Org admin</div>
+                <div className="text-muted-foreground text-xs">
+                  Can manage users in {callerOrg} (this surface). Independent of
+                  language access.
+                </div>
+              </div>
+            </label>
+
+            <LanguageRightsSelector
+              value={rights}
+              onChange={setRights}
+              availableLanguages={availableLanguages}
+            />
+
+            {errorText && (
+              <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                {errorText}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleClose(false)}
+              disabled={createUser.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createUser.isPending}>
+              {createUser.isPending ? "Creating…" : "Create user"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from "react";
+
+import type { AdminUser, UpdateUserBody } from "@/types/admin-users";
+import type { LanguageRights } from "@/types/auth";
+import type { Language } from "@/types/language";
+import {
+  AdminUsersForbiddenError,
+  AdminUsersRequestError,
+} from "@/lib/admin-users-api";
+import { useUpdateAdminUser } from "@/hooks/use-admin-users";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LanguageRightsSelector } from "@/components/language-rights-selector";
+
+interface EditUserDialogProps {
+  user: AdminUser | null;
+  // Indicates the dialog is open. Closing happens via setUser(null) in the
+  // parent — keeps a single source of truth (the selected user).
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  // Email of the currently logged-in admin. Used to disable self-mutation
+  // controls (the worker also enforces these — UI just prevents the obvious
+  // footgun before the request goes out).
+  callerEmail: string;
+  availableLanguages: Language[] | undefined;
+}
+
+export function AdminUserEditDialog({
+  user,
+  open,
+  onOpenChange,
+  callerEmail,
+  availableLanguages,
+}: EditUserDialogProps) {
+  const updateUser = useUpdateAdminUser();
+
+  const [name, setName] = useState("");
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [rights, setRights] = useState<LanguageRights | undefined>(undefined);
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  // Re-sync form state from the user prop whenever the target changes
+  // (or the dialog reopens with a different user).
+  useEffect(() => {
+    if (!user) return;
+    setName(user.name);
+    setIsAdmin(user.isAdmin);
+    setRights(user.language_rights);
+    setErrorText(null);
+    updateUser.reset();
+    // updateUser is a stable reference from React Query
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  const isSelf = user?.email === callerEmail;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+    setErrorText(null);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setErrorText("Name cannot be empty.");
+      return;
+    }
+
+    const body: UpdateUserBody = {};
+    if (trimmedName !== user.name) body.name = trimmedName;
+    if (isAdmin !== user.isAdmin) body.isAdmin = isAdmin;
+    // Send language_rights when the value differs. Comparing arrays needs
+    // a deep compare; we serialize.
+    const currentSerialized = JSON.stringify(user.language_rights ?? null);
+    const nextSerialized = JSON.stringify(rights ?? null);
+    if (currentSerialized !== nextSerialized && rights !== undefined) {
+      body.language_rights = rights;
+    }
+
+    if (Object.keys(body).length === 0) {
+      onOpenChange(false);
+      return;
+    }
+
+    updateUser.mutate(
+      { email: user.email, body },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+        },
+        onError: (err) => {
+          if (err instanceof AdminUsersForbiddenError) {
+            setErrorText(err.serverMessage ?? "You don't have permission.");
+          } else if (err instanceof AdminUsersRequestError) {
+            setErrorText(
+              err.serverMessage ?? `Request failed (${err.status}).`
+            );
+          } else {
+            setErrorText(err.message);
+          }
+        },
+      }
+    );
+  };
+
+  if (!user) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Edit user</DialogTitle>
+            <DialogDescription>
+              <span className="text-foreground font-medium">{user.email}</span>{" "}
+              · {user.org}
+              {isSelf && (
+                <>
+                  {" "}
+                  · <span className="font-medium">that&rsquo;s you</span>
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-user-name">Name</Label>
+              <Input
+                id="edit-user-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+            </div>
+
+            <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60">
+              <input
+                type="checkbox"
+                checked={isAdmin}
+                disabled={isSelf}
+                onChange={(e) => setIsAdmin(e.target.checked)}
+                className="mt-0.5"
+              />
+              <div className="space-y-0.5">
+                <div className="text-sm font-medium">Org admin</div>
+                <div className="text-muted-foreground text-xs">
+                  {isSelf
+                    ? "You cannot demote yourself. Use the X-Admin-Secret CLI if you really need to."
+                    : "Can manage users in this org. Independent of language access."}
+                </div>
+              </div>
+            </label>
+
+            <LanguageRightsSelector
+              value={rights}
+              onChange={setRights}
+              availableLanguages={availableLanguages}
+              showLegacyHint
+            />
+
+            {errorText && (
+              <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                {errorText}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={updateUser.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={updateUser.isPending}>
+              {updateUser.isPending ? "Saving…" : "Save changes"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/language-rights-selector.tsx
+++ b/src/components/language-rights-selector.tsx
@@ -1,0 +1,146 @@
+import { useMemo } from "react";
+
+import type { LanguageRights } from "@/types/auth";
+import type { Language } from "@/types/language";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+
+interface LanguageRightsSelectorProps {
+  value: LanguageRights | undefined;
+  onChange: (next: LanguageRights) => void;
+  availableLanguages: Language[] | undefined;
+  disabled?: boolean;
+  // When true, show a hint that undefined === full access (legacy users).
+  // Once the admin clicks anything the value becomes defined.
+  showLegacyHint?: boolean;
+}
+
+export function LanguageRightsSelector({
+  value,
+  onChange,
+  availableLanguages,
+  disabled = false,
+  showLegacyHint = false,
+}: LanguageRightsSelectorProps) {
+  const isFull = value === "*";
+  const isLegacy = value === undefined;
+  const selected = useMemo<Set<string>>(
+    () => (Array.isArray(value) ? new Set(value) : new Set()),
+    [value]
+  );
+
+  const toggleLanguage = (name: string) => {
+    if (disabled) return;
+    const next = new Set(selected);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    onChange([...next].sort());
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Language access</Label>
+        {isLegacy && showLegacyHint && (
+          <p className="text-muted-foreground text-xs">
+            This user predates the language-rights system. They currently have
+            full access by default. Picking any option below will lock that in
+            explicitly.
+          </p>
+        )}
+      </div>
+
+      <fieldset className="space-y-2" disabled={disabled}>
+        <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors">
+          <input
+            type="radio"
+            name="language-rights-mode"
+            checked={isFull}
+            onChange={() => onChange("*")}
+            className="mt-0.5"
+          />
+          <div className="space-y-0.5">
+            <div className="text-sm font-medium">Full access</div>
+            <div className="text-muted-foreground text-xs">
+              Can read and edit every language tuning document.
+            </div>
+          </div>
+        </label>
+
+        <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors">
+          <input
+            type="radio"
+            name="language-rights-mode"
+            checked={!isFull && !isLegacy}
+            onChange={() => onChange([...selected].sort())}
+            className="mt-0.5"
+          />
+          <div className="flex-1 space-y-2">
+            <div className="space-y-0.5">
+              <div className="text-sm font-medium">Specific languages</div>
+              <div className="text-muted-foreground text-xs">
+                Only the languages selected below. Leave all unchecked to deny
+                access entirely.
+              </div>
+            </div>
+
+            {!isFull && !isLegacy && (
+              <div className="flex flex-wrap gap-1.5">
+                {availableLanguages === undefined ? (
+                  <span className="text-muted-foreground text-xs">
+                    Loading languages…
+                  </span>
+                ) : availableLanguages.length === 0 ? (
+                  <span className="text-muted-foreground text-xs">
+                    No languages defined yet.
+                  </span>
+                ) : (
+                  availableLanguages.map((lang) => {
+                    const checked = selected.has(lang.name);
+                    return (
+                      <button
+                        key={lang.name}
+                        type="button"
+                        onClick={() => toggleLanguage(lang.name)}
+                        className={cn(
+                          "rounded-full border px-2.5 py-1 text-xs transition-colors",
+                          checked
+                            ? "bg-primary text-primary-foreground border-primary"
+                            : "bg-background hover:bg-accent"
+                        )}
+                      >
+                        {checked && (
+                          <span className="mr-1" aria-hidden="true">
+                            ✓
+                          </span>
+                        )}
+                        {lang.label || lang.name}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            )}
+          </div>
+        </label>
+      </fieldset>
+
+      {Array.isArray(value) && value.length > 0 && (
+        <p className="text-muted-foreground text-xs">
+          {value.length === 1
+            ? "1 language granted"
+            : `${value.length} languages granted`}
+        </p>
+      )}
+      {Array.isArray(value) && value.length === 0 && (
+        <Badge
+          variant="outline"
+          className="border-destructive text-destructive"
+        >
+          No access
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/src/components/require-admin.tsx
+++ b/src/components/require-admin.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+import { Navigate } from "react-router";
+
+import { useAuthStore } from "@/lib/auth-store";
+
+// Gates a route on session.isAdmin === true. The worker enforces this on
+// /api/admin/users regardless, but redirecting non-admins client-side
+// avoids a useless 403 round-trip and a broken-looking page. RequireAuth
+// (the parent gate) already handles the unauthenticated case.
+export function RequireAdmin({ children }: { children: ReactNode }) {
+  const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+  return children;
+}

--- a/src/hooks/use-admin-users.ts
+++ b/src/hooks/use-admin-users.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import * as api from "@/lib/admin-users-api";
+import type { CreateUserBody, UpdateUserBody } from "@/types/admin-users";
+
+const keys = {
+  users: ["admin-users"] as const,
+};
+
+export function useAdminUsers(enabled = true) {
+  return useQuery({
+    queryKey: keys.users,
+    queryFn: ({ signal }) => api.listAdminUsers(signal),
+    enabled,
+  });
+}
+
+export function useCreateAdminUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateUserBody) => api.createAdminUser(body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: keys.users });
+    },
+  });
+}
+
+export function useUpdateAdminUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ email, body }: { email: string; body: UpdateUserBody }) =>
+      api.updateAdminUser(email, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: keys.users });
+    },
+  });
+}
+
+export function useDeleteAdminUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (email: string) => api.deleteAdminUser(email),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: keys.users });
+    },
+  });
+}

--- a/src/hooks/use-sync-section.ts
+++ b/src/hooks/use-sync-section.ts
@@ -8,6 +8,7 @@ const pathToSection: Record<string, Section> = {
   "/": "baruch",
   "/prompt-configuration": "prompt-configuration",
   "/languages": "languages",
+  "/admin/users": "admin-users",
 };
 
 export function useSyncSection() {

--- a/src/lib/admin-users-api.ts
+++ b/src/lib/admin-users-api.ts
@@ -1,0 +1,105 @@
+import type {
+  AdminUser,
+  CreateUserBody,
+  UpdateUserBody,
+} from "@/types/admin-users";
+
+// X-Requested-With is the same-origin marker the worker requires on the
+// cookie-auth path (see worker/admin.ts requireAdminAuth). All admin user
+// requests from the browser must include it.
+const SAME_ORIGIN_HEADERS = {
+  "X-Requested-With": "XMLHttpRequest",
+} as const;
+
+// Thrown when the worker returns 403 on an admin user operation. Most
+// commonly this means the caller isn't isAdmin (or session expired) — but
+// also fires for cross-org create attempts and move-org refusals.
+export class AdminUsersForbiddenError extends Error {
+  constructor(public readonly serverMessage?: string) {
+    super(serverMessage ?? "Forbidden");
+    this.name = "AdminUsersForbiddenError";
+  }
+}
+
+// Thrown for 4xx that aren't 403 (e.g. 400 on self-demote/self-delete, 409
+// on duplicate email, 404 on cross-org or missing target). serverMessage
+// is the response body's `error` field if present.
+export class AdminUsersRequestError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly serverMessage?: string
+  ) {
+    super(serverMessage ?? `Request failed (${status})`);
+    this.name = "AdminUsersRequestError";
+  }
+}
+
+async function readErrorMessage(res: Response): Promise<string | undefined> {
+  try {
+    const body = (await res.json()) as { error?: string };
+    return body.error;
+  } catch {
+    return undefined;
+  }
+}
+
+async function throwForStatus(res: Response): Promise<never> {
+  const message = await readErrorMessage(res);
+  if (res.status === 403) throw new AdminUsersForbiddenError(message);
+  throw new AdminUsersRequestError(res.status, message);
+}
+
+export async function listAdminUsers(
+  signal?: AbortSignal
+): Promise<AdminUser[]> {
+  const res = await fetch("/api/admin/users", {
+    headers: SAME_ORIGIN_HEADERS,
+    signal,
+  });
+  if (!res.ok) await throwForStatus(res);
+  const data = (await res.json()) as { users: AdminUser[] };
+  return data.users;
+}
+
+export async function createAdminUser(
+  body: CreateUserBody,
+  signal?: AbortSignal
+): Promise<AdminUser> {
+  const res = await fetch("/api/admin/users", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) await throwForStatus(res);
+  const data = (await res.json()) as { user: AdminUser };
+  return data.user;
+}
+
+export async function updateAdminUser(
+  email: string,
+  body: UpdateUserBody,
+  signal?: AbortSignal
+): Promise<AdminUser> {
+  const res = await fetch(`/api/admin/users/${encodeURIComponent(email)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) await throwForStatus(res);
+  const data = (await res.json()) as { user: AdminUser };
+  return data.user;
+}
+
+export async function deleteAdminUser(
+  email: string,
+  signal?: AbortSignal
+): Promise<void> {
+  const res = await fetch(`/api/admin/users/${encodeURIComponent(email)}`, {
+    method: "DELETE",
+    headers: SAME_ORIGIN_HEADERS,
+    signal,
+  });
+  if (!res.ok) await throwForStatus(res);
+}

--- a/src/types/admin-users.ts
+++ b/src/types/admin-users.ts
@@ -1,0 +1,29 @@
+import type { LanguageRights } from "@/types/auth";
+
+// Mirrors the worker `safeUser` response shape from /api/admin/users.
+// Password fields are deliberately not in the API response.
+export interface AdminUser {
+  id: string;
+  email: string;
+  name: string;
+  org: string;
+  isAdmin: boolean;
+  language_rights?: LanguageRights;
+}
+
+export interface CreateUserBody {
+  email: string;
+  password: string;
+  name: string;
+  org: string;
+  isAdmin?: boolean;
+  language_rights?: LanguageRights;
+}
+
+export interface UpdateUserBody {
+  name?: string;
+  org?: string;
+  password?: string;
+  isAdmin?: boolean;
+  language_rights?: LanguageRights;
+}

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,1 +1,5 @@
-export type Section = "baruch" | "prompt-configuration" | "languages";
+export type Section =
+  | "baruch"
+  | "prompt-configuration"
+  | "languages"
+  | "admin-users";


### PR DESCRIPTION
## Summary

PR B of #96. The UI surface that consumes the dual-auth backend from PR A (#97, merged). Org admins can now manage their org's users — assign org admin status, set language_rights, create/delete users — from the browser instead of via X-Admin-Secret CLI.

Closes #96.

## What's in this PR

**Activity bar**
- New \"Users\" entry, gated on \`session.isAdmin\` (only admins see it). Uses \`faUsers\` Pro icon.

**Route**
- \`/admin/users\` wrapped in new \`<RequireAdmin>\` gate. Non-admins hitting the URL directly redirect to \`/\`. Worker still 403s independently — the gate just avoids a useless round-trip and broken page.

**Page** (\`src/app/pages/admin-users.tsx\`)
- Table view: Name · Email · Role badge · Language access · Actions
- Toolbar with \"+ New user\" button
- Click Edit → edit dialog. Click trash → confirm dialog.
- Self-row's delete button disabled with tooltip (worker also 400s on self-delete)

**Dialogs**
- \`AdminUserCreateDialog\` — email, name, initial password (visible deliberately for copy-paste sharing), isAdmin toggle, language_rights. Org pre-filled from \`session.org\` and not editable (worker would 403 a cross-org create anyway).
- \`AdminUserEditDialog\` — name, isAdmin toggle (disabled for self), language_rights, with explanatory copy. Diffs against the current record so a no-op save short-circuits.

**LanguageRightsSelector** (reusable)
- Three modeled states:
  - **Full access** → \`\"*\"\`
  - **Specific languages** → chip-style multi-select pulled from \`/api/config/languages\`
  - **Legacy/undefined** → explanation hint only; first interaction locks in an explicit value
- Admin can leave \"Specific\" with no chips checked → empty array → \"no access,\" which the worker 403s on every language operation.

**API client + hooks**
- \`src/lib/admin-users-api.ts\` — list/create/update/delete with typed errors: \`AdminUsersForbiddenError\` (403) and \`AdminUsersRequestError\` (other 4xx). Always sends \`X-Requested-With: XMLHttpRequest\` (the cookie path's CSRF guard).
- \`src/hooks/use-admin-users.ts\` — React Query hooks invalidating the list cache on every mutation.

## Out of scope (intentional)

**Password reset is NOT in this PR.** The backend PUT path accepts a \`password\` field but doesn't invalidate the target user's existing sessions (pre-existing behavior). Exposing it in the UI without invalidation would be a security footgun + misleading UX. **Filed [#99](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/99) to fix the backend; once that lands, the field can be re-added to \`AdminUserEditDialog\`.**

## Test plan

- [ ] As an org admin, navigate to /admin/users → users in own org appear in the table; cross-org users do not (PR A enforces server-side, this verifies the wiring)
- [ ] Click \"+ New user\" → dialog opens with org pre-filled. Submit creates a user; the new user appears in the table.
- [ ] Click Edit on a user → fields pre-fill; change name + isAdmin + language_rights, Save; reopen to verify persisted.
- [ ] Click Edit on yourself → isAdmin toggle is disabled; everything else editable.
- [ ] Click trash on yourself → button is disabled with tooltip.
- [ ] Click trash on someone else → confirm dialog → delete succeeds.
- [ ] Try creating a user with org=\"other\" via DevTools (force the body) → 403 inline.
- [ ] Try setting \`language_rights = \"*\"\` then switching to \"Specific\" with one language → save → verify Languages tab gating updates next time that user logs in.
- [ ] Log in as a non-admin → no Users entry in the activity bar; URL-hack to /admin/users redirects to /.

## Notes

- Section type extended: \`Section = ... | \"admin-users\"\`. Path-to-section map updated so the activity-bar entry highlights when on \`/admin/users\`.
- Path uses \`/admin/users\` (slash, not hyphen) to keep the door open for future \`/admin/*\` siblings without re-namespacing.
- All mutations rely on PR A's typed errors. Inline error display on dialogs and the delete confirm — no toasts.