### PR TITLE
feat: brand-color context accents for mode/language editor pages (#78)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,6 +91,13 @@
   --editor-active: oklch(0.55 0.2 35);
   --editor-active-soft: oklch(0.55 0.2 35 / 0.2);
   --editor-active-pulse: oklch(0.55 0.2 35 / 0.16);
+
+  /* Brand context accents (issue #78) — Inspire blue for Modes, Cultivate
+     teal for Languages. Used for subtle context differentiation between
+     mode-editing and language-editing surfaces so authors don't confuse
+     which document they're editing. */
+  --brand-modes: oklch(0.71 0.108 226);
+  --brand-languages: oklch(0.78 0.054 195);
 }
 
 .dark {
@@ -138,6 +145,9 @@
   --editor-active: oklch(0.72 0.18 35);
   --editor-active-soft: oklch(0.72 0.18 35 / 0.22);
   --editor-active-pulse: oklch(0.72 0.18 35 / 0.18);
+
+  --brand-modes: oklch(0.74 0.13 225);
+  --brand-languages: oklch(0.8 0.07 195);
 }
 
 @layer base {

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -315,6 +315,7 @@ export function LanguagesPage() {
       <PageHeader
         title="Languages"
         subtitle="Edit per-language tuning documents. Auto-saves as you type; use Save to flush immediately."
+        variant="languages"
       />
 
       <div className="bg-card border-b">

--- a/src/app/pages/manual-config.tsx
+++ b/src/app/pages/manual-config.tsx
@@ -118,6 +118,7 @@ export function ManualConfigPage() {
       <PageHeader
         title="Prompt Configuration"
         subtitle="Manage prompt overrides for each slot at the org level or per mode."
+        variant="modes"
       />
 
       {/* Grid area — dot grid + subtle radial glow */}

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,15 +1,32 @@
 import { useAuthStore } from "@/lib/auth-store";
+import { cn } from "@/lib/utils";
 
 interface PageHeaderProps {
   title: string;
   subtitle: string;
+  // Subtle context accent: tints a 3px top strip with a brand color so authors
+  // can tell at a glance which kind of document they're editing (issue #78).
+  variant?: "modes" | "languages";
 }
 
-export function PageHeader({ title, subtitle }: PageHeaderProps) {
+export function PageHeader({ title, subtitle, variant }: PageHeaderProps) {
   const orgName = useAuthStore((s) => s.user?.org);
 
+  const accentColor =
+    variant === "modes"
+      ? "var(--brand-modes)"
+      : variant === "languages"
+        ? "var(--brand-languages)"
+        : undefined;
+
   return (
-    <div className="config-header border-border/50 shrink-0 border-b px-4 py-4 shadow-[0_2px_8px_rgba(0,0,0,0.06)] sm:px-6 sm:py-5 dark:shadow-[0_2px_8px_rgba(0,0,0,0.2)]">
+    <div
+      className={cn(
+        "config-header border-border/50 shrink-0 border-b px-4 py-4 shadow-[0_2px_8px_rgba(0,0,0,0.06)] sm:px-6 sm:py-5 dark:shadow-[0_2px_8px_rgba(0,0,0,0.2)]",
+        accentColor && "border-t-[3px]"
+      )}
+      style={accentColor ? { borderTopColor: accentColor } : undefined}
+    >
       <h1 className="text-foreground text-lg font-semibold tracking-tight">
         {title}
       </h1>


### PR DESCRIPTION
## Summary

- Adds a subtle 3px top accent strip on \`PageHeader\` driven by an optional \`variant\` prop. Inspire blue tints the Prompt Configuration (Modes) page; Cultivate teal tints the Languages page. Other \`PageHeader\` consumers (Baruch, Admin Users) remain neutral.
- Lands brand tokens \`--brand-modes\` and \`--brand-languages\` in \`src/app/globals.css\` (light + dark variants), positioned alongside the existing editor surface tokens for thematic consistency.
- Closes #78.

## Why

Mode and Language editing surfaces are visually near-identical (same \`PageHeader\`, same chrome). Without a context cue, authors can pick the wrong tab and edit the wrong document. A thin accent strip keyed to brand color gives an at-a-glance signal without disrupting the existing aesthetic.

## Design choices

- **3px strip, not a tinted gradient.** A modified \`.config-header\` gradient was the second-best option but invasive — the existing gradient is carefully tuned and used across all pages, including the neutral consumers. Per-instance accent stays scoped.
- **CSS variable carries the color, not a Tailwind class.** Tokens go in \`globals.css\` so future theme work can re-tune without touching the component.
- **Variant prop, not route-detection inside PageHeader.** The component stays free of router coupling; consumers opt in.

## Test plan

- [ ] Visit \`/prompt-configuration\` — top of header should show a thin Inspire blue strip
- [ ] Visit \`/languages\` — top of header should show a thin Cultivate teal strip
- [ ] Visit \`/\` (Baruch) and \`/admin/users\` — no strip; existing chrome unchanged
- [ ] Toggle dark mode — strips remain perceivable on the darker header gradient
- [ ] Resize / mobile widths — strip spans full header width without breaking layout

## Files changed

- \`src/app/globals.css\` — new tokens \`--brand-modes\`, \`--brand-languages\` (light + dark)
- \`src/components/page-header.tsx\` — new optional \`variant\` prop
- \`src/app/pages/manual-config.tsx\` — \`variant="modes"\`
- \`src/app/pages/languages.tsx\` — \`variant="languages"\`