### PR TITLE
docs: route all Node tooling through uw-sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,17 @@ Admin portal for managing bt-servant-worker configurations.
 
 ## Commands
 
+Run all project commands that execute Node/npm tooling inside the `uw-sandbox`
+container from `/workspace/bt-servant-admin-portal`. Do not run `npm`,
+`npx`, `vite`, `wrangler`, `tsc`, ESLint, Prettier, or Husky/pre-commit checks
+directly on the host for this project.
+
+Example:
+
+```bash
+docker exec uw-sandbox bash -lc 'cd /workspace/bt-servant-admin-portal && npm run typecheck'
+```
+
 ```bash
 npm run dev          # Start Vite dev server
 npm run build        # Production build


### PR DESCRIPTION
## Summary

- Adds a note at the top of `AGENTS.md` Commands section directing all Node/npm tooling — `npm`, `npx`, `vite`, `wrangler`, `tsc`, ESLint, Prettier, Husky/pre-commit — through `docker exec uw-sandbox` from `/workspace/bt-servant-admin-portal`.
- Prevents host/container toolchain drift; keeps the project's pinned Node/npm versions authoritative.

## Test plan

- [ ] Verify rendered markdown looks correct on GitHub.
- [ ] Confirm Codex sessions pick up the new instruction on next read.