### PR TITLE
feat: pre-load structural scaffold for new language documents (#74)

### DIFF
--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -217,18 +217,20 @@ export function LanguagesPage() {
 
   const handleCreateLanguage = useCallback(
     (name: string, label: string) => {
-      // Pre-populate the new language with the org's structural scaffold so
-      // shepherds don't start from a blank textarea (#74). The scaffold is
-      // fetched eagerly when the page mounts; if it hasn't arrived yet or
-      // the fetch failed, fall back to an empty document — losing the
-      // scaffold is a UX regression, not a correctness failure.
-      const scaffoldDoc = scaffoldQuery.data?.document ?? "";
+      // Hard gate: never save a blank document. The create button in the
+      // selector is also disabled when scaffold isn't ready, but defense
+      // in depth — if anything ever programmatically triggers create
+      // before scaffold loads (keyboard shortcut, test, debugger), we
+      // refuse to save instead of silently committing an empty doc
+      // (Frank P2 on PR #106).
+      const scaffold = scaffoldQuery.data;
+      if (!scaffold) return;
       saveLanguage.mutate(
         {
           name,
           body: {
             label: label || undefined,
-            document: scaffoldDoc,
+            document: scaffold.document,
             published: false,
           },
         },
@@ -342,6 +344,8 @@ export function LanguagesPage() {
               showDrafts={showDrafts}
               onToggleShowDrafts={setShowDrafts}
               isAdmin={isAdmin}
+              isScaffoldReady={scaffoldQuery.isSuccess}
+              scaffoldError={scaffoldQuery.isError}
             />
           </div>
 

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -20,6 +20,7 @@ import {
   useLanguages,
   useSaveLanguage,
 } from "@/hooks/use-languages";
+import { useLanguageScaffold } from "@/hooks/use-language-scaffold";
 import type { MarkdownHeading } from "@/types/markdown";
 import {
   AlertDialog,
@@ -53,6 +54,7 @@ export function LanguagesPage() {
   const languageQuery = useLanguage(selectedLanguage);
   const saveLanguage = useSaveLanguage();
   const deleteLanguage = useDeleteLanguage();
+  const scaffoldQuery = useLanguageScaffold();
 
   // Filter the language list to only those the user has rights to. Engine
   // #207 will eventually filter server-side too, but until then this is the
@@ -215,19 +217,25 @@ export function LanguagesPage() {
 
   const handleCreateLanguage = useCallback(
     (name: string, label: string) => {
+      // Pre-populate the new language with the org's structural scaffold so
+      // shepherds don't start from a blank textarea (#74). The scaffold is
+      // fetched eagerly when the page mounts; if it hasn't arrived yet or
+      // the fetch failed, fall back to an empty document — losing the
+      // scaffold is a UX regression, not a correctness failure.
+      const scaffoldDoc = scaffoldQuery.data?.document ?? "";
       saveLanguage.mutate(
         {
           name,
           body: {
             label: label || undefined,
-            document: "",
+            document: scaffoldDoc,
             published: false,
           },
         },
         { onSuccess: () => setSelectedLanguage(name) }
       );
     },
-    [saveLanguage, setSelectedLanguage]
+    [saveLanguage, scaffoldQuery.data, setSelectedLanguage]
   );
 
   const handleSetPublished = useCallback(

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -40,6 +40,11 @@ interface LanguageSelectorProps {
   showDrafts: boolean;
   onToggleShowDrafts: (showDrafts: boolean) => void;
   isAdmin: boolean;
+  /** Scaffold template must finish loading before create can fire — new
+      languages are pre-populated with the org's scaffold (#74), so creating
+      before the scaffold arrives would silently save a blank document. */
+  isScaffoldReady: boolean;
+  scaffoldError: boolean;
 }
 
 function isPublished(lang: Pick<Language, "published">): boolean {
@@ -59,6 +64,8 @@ export function LanguageSelector({
   showDrafts,
   onToggleShowDrafts,
   isAdmin,
+  isScaffoldReady,
+  scaffoldError,
 }: LanguageSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -278,6 +285,21 @@ export function LanguageSelector({
               />
             </div>
           </div>
+          {!isScaffoldReady && (
+            <p
+              className={
+                scaffoldError
+                  ? "text-destructive mt-3 text-xs"
+                  : "text-muted-foreground mt-3 text-xs"
+              }
+              role={scaffoldError ? "alert" : undefined}
+              aria-live="polite"
+            >
+              {scaffoldError
+                ? "Couldn't load the language template. Refresh the page to try again."
+                : "Loading language template…"}
+            </p>
+          )}
           <div className="mt-4 flex justify-end gap-2">
             <Button
               variant="ghost"
@@ -289,7 +311,7 @@ export function LanguageSelector({
             <Button
               size="sm"
               onClick={handleCreate}
-              disabled={!newName.trim() || isCreating}
+              disabled={!newName.trim() || isCreating || !isScaffoldReady}
             >
               {isCreating ? "Creating..." : "Create Draft"}
             </Button>

--- a/src/hooks/use-language-scaffold.ts
+++ b/src/hooks/use-language-scaffold.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getLanguageScaffold } from "@/lib/language-scaffold-api";
+
+const keys = {
+  scaffold: ["language-scaffold"] as const,
+};
+
+export function useLanguageScaffold() {
+  return useQuery({
+    queryKey: keys.scaffold,
+    queryFn: ({ signal }) => getLanguageScaffold(signal),
+  });
+}

--- a/src/lib/language-scaffold-api.ts
+++ b/src/lib/language-scaffold-api.ts
@@ -1,0 +1,29 @@
+import type { LanguageScaffold } from "@/types/language-scaffold";
+
+const SAME_ORIGIN_HEADERS = {
+  "X-Requested-With": "XMLHttpRequest",
+} as const;
+
+export async function getLanguageScaffold(
+  signal?: AbortSignal
+): Promise<LanguageScaffold> {
+  const res = await fetch("/api/config/language-scaffold", {
+    headers: SAME_ORIGIN_HEADERS,
+    signal,
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Failed to load language scaffold (${res.status}): ${body}`
+    );
+  }
+
+  const data = (await res.json()) as Record<string, unknown>;
+
+  // Worker wraps as { org, scaffold }.
+  if ("scaffold" in data && typeof data.scaffold === "object") {
+    return data.scaffold as LanguageScaffold;
+  }
+  return data as unknown as LanguageScaffold;
+}

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -84,7 +84,14 @@ export async function putLanguage(
     throw new Error(`Failed to save language (${res.status}): ${text}`);
   }
 
-  return (await res.json()) as Language;
+  const data = (await res.json()) as Record<string, unknown>;
+
+  // Worker wraps PUT response as { org, language, message }. Unwrap to
+  // match getLanguage so callers consistently get a Language object.
+  if ("language" in data && typeof data.language === "object") {
+    return data.language as Language;
+  }
+  return data as unknown as Language;
 }
 
 export async function deleteLanguage(

--- a/src/types/language-scaffold.ts
+++ b/src/types/language-scaffold.ts
@@ -1,0 +1,3 @@
+export interface LanguageScaffold {
+  document: string;
+}

--- a/tests/language-scaffold-api.test.ts
+++ b/tests/language-scaffold-api.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getLanguageScaffold } from "../src/lib/language-scaffold-api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchOnce(status: number, body: unknown): void {
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+}
+
+describe("getLanguageScaffold", () => {
+  it("unwraps the wrapped worker response `{ org, scaffold }`", async () => {
+    mockFetchOnce(200, {
+      org: "uw",
+      scaffold: { document: "## Tone & Register\n\nGuidance here." },
+    });
+    await expect(getLanguageScaffold()).resolves.toEqual({
+      document: "## Tone & Register\n\nGuidance here.",
+    });
+  });
+
+  it("returns an already-unwrapped response unchanged (back-compat)", async () => {
+    // If the worker contract ever flips to returning the scaffold object
+    // directly, the client should still return a valid LanguageScaffold.
+    mockFetchOnce(200, { document: "## Section\n\nBody." });
+    await expect(getLanguageScaffold()).resolves.toEqual({
+      document: "## Section\n\nBody.",
+    });
+  });
+
+  it("calls the BFF path (`/api/config/language-scaffold`) with same-origin header", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ scaffold: { document: "" } }), {
+        status: 200,
+      })
+    );
+    await getLanguageScaffold();
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [url, init] = spy.mock.calls[0]!;
+    expect(url).toBe("/api/config/language-scaffold");
+    const headers = (init as RequestInit | undefined)?.headers as
+      | Record<string, string>
+      | undefined;
+    expect(headers?.["X-Requested-With"]).toBe("XMLHttpRequest");
+  });
+
+  it("throws with status and body when the response is not ok", async () => {
+    mockFetchOnce(500, "engine unavailable");
+    await expect(getLanguageScaffold()).rejects.toThrow(
+      /Failed to load language scaffold \(500\)/
+    );
+  });
+
+  it("forwards the AbortSignal to fetch", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ scaffold: { document: "" } }))
+      );
+    const controller = new AbortController();
+    await getLanguageScaffold(controller.signal);
+    expect(spy.mock.calls[0]![1]).toMatchObject({ signal: controller.signal });
+  });
+});

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LanguageForbiddenError, putLanguage } from "../src/lib/languages-api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchOnce(status: number, body: unknown): void {
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+}
+
+describe("putLanguage", () => {
+  it("unwraps the wrapped worker response `{ org, language, message }`", async () => {
+    // Before this PR the function cast the wrapped envelope directly as
+    // `Language`, so `result.name` was undefined. The unwrap brings PUT in
+    // line with GET (which already unwrapped `{ org, language }`).
+    mockFetchOnce(200, {
+      org: "uw",
+      language: {
+        name: "arabic",
+        label: "Arabic",
+        document: "## Tone\n",
+        published: false,
+      },
+      message: "Language saved",
+    });
+
+    const result = await putLanguage("arabic", {
+      label: "Arabic",
+      document: "## Tone\n",
+      published: false,
+    });
+
+    expect(result).toEqual({
+      name: "arabic",
+      label: "Arabic",
+      document: "## Tone\n",
+      published: false,
+    });
+  });
+
+  it("returns an already-unwrapped response unchanged (back-compat)", async () => {
+    mockFetchOnce(200, {
+      name: "arabic",
+      label: "Arabic",
+      document: "## Tone\n",
+      published: false,
+    });
+
+    const result = await putLanguage("arabic", {
+      label: "Arabic",
+      document: "## Tone\n",
+      published: false,
+    });
+
+    expect(result.name).toBe("arabic");
+  });
+
+  it("throws LanguageForbiddenError on 403", async () => {
+    mockFetchOnce(403, { error: "Forbidden" });
+    await expect(
+      putLanguage("arabic", { document: "x" })
+    ).rejects.toBeInstanceOf(LanguageForbiddenError);
+  });
+
+  it("encodes the language name in the URL path", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ language: { name: "haitian-creole", document: "" } })
+        )
+      );
+    await putLanguage("haitian-creole", { document: "" });
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/languages/haitian-creole");
+  });
+
+  it("sends the body as JSON with PUT method", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ language: { name: "arabic", document: "" } })
+        )
+      );
+    const body = { label: "Arabic", document: "## Tone\n", published: true };
+    await putLanguage("arabic", body);
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual(body);
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json"
+    );
+  });
+});

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -25,7 +25,7 @@
       "@cloudflare/vitest-pool-workers/types"
     ],
 
-    /* Path alias for tests that exercise pure functions from src/.
+    /* Path alias for tests that exercise functions from src/.
        Files reached via this alias are pulled into worker typecheck on
        demand — keep transitively-imported src/ modules free of DOM/JSX
        types so the worker tsconfig can resolve them. */

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -152,5 +152,18 @@ export async function handleConfig(
     ]);
   }
 
+  // /api/config/language-scaffold → GET (org-scope; worker returns
+  // a bundled default if no override is stored). PUT/DELETE are not
+  // wired yet — there's no UI for editing the template, and exposing
+  // mutation paths without admin gating would be unsafe.
+  if (pathname === "/api/config/language-scaffold") {
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${org}/language-scaffold`,
+      ["GET"]
+    );
+  }
+
   return errorResponse("Not found", 404);
 }


### PR DESCRIPTION
## Summary

Wires the portal to bt-servant-worker's new per-org **language-scaffold** endpoint (worker #198, shipped 2026-05-09 in PR #205). When a shepherd creates a new language, the document is pre-populated with the org's configured structural scaffold — or the bundled default (5 H2 sections with `%%` Ulysses guidance comments) — instead of opening to an empty textarea.

Closes #74.

## Changes

- New `useLanguageScaffold` query hook + `getLanguageScaffold` API client + `LanguageScaffold` type, mirroring the existing `languages-api` pattern.
- New BFF proxy route at `/api/config/language-scaffold` → engine `/api/v1/admin/orgs/:org/language-scaffold`. **GET only;** PUT/DELETE are not exposed yet because there's no UI for editing the template and exposing mutation paths without admin gating would be unsafe (deferred to a future issue).
- `LanguagesPage.handleCreateLanguage` now reads the cached scaffold and uses it as the initial document. Falls back to empty if the scaffold hasn't loaded yet or the fetch failed — losing the scaffold is a UX regression, not a correctness failure.
- **Drive-by fix:** `putLanguage` now unwraps `{ org, language, message }` to match `getLanguage`. The mutation result was being discarded so this was harmless in practice, but the type was a lie. Surfaced during the contract validation done before this PR.

## Acceptance criteria

- [x] New language documents load with a configurable default scaffold
- [x] The scaffold is editable in the markdown editor once inserted
- [x] The scaffold template lives in worker config (default in code, per-org override in `${org}:language-scaffold` KV) — no portal redeploy required to change it
- [x] Existing documents are not overwritten (the scaffold path only fires inside `handleCreateLanguage`)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 warnings)
- [x] `npm run build` clean
- [x] `npm test` — 17/17 passing
- [ ] Manual: open the dev portal, click "Add language", confirm the new document opens with the scaffold rather than an empty textarea
- [ ] Manual: confirm an existing language with content opens unchanged

## Notes for review

- The scaffold fetch is unconditional on page mount. The endpoint is cheap (small KV read or bundled default) and the response is small, so this is fine. If we ever decide to make it lazy, the hook is the only place to change.
- Future issue: an admin UI for customizing the per-org scaffold template (would expose PUT/DELETE on the BFF route with an admin gate).