### PR TITLE
feat: wire test chat to active mode + language selection (#81)

### DIFF
--- a/src/components/test-chat-panel.tsx
+++ b/src/components/test-chat-panel.tsx
@@ -42,6 +42,11 @@ export function TestChatPanel() {
   const chatMode = useUiStore((s) => s.chatMode);
   const setChatMode = useUiStore((s) => s.setChatMode);
   const testChatUserId = useUiStore((s) => s.testChatUserId);
+  // Mirrors the active editor-tab selections; the chip below the header
+  // surfaces these so the user knows exactly which trigger is about to be
+  // prepended on the next send (#81).
+  const selectedMode = useUiStore((s) => s.selectedMode);
+  const selectedLanguage = useUiStore((s) => s.selectedLanguage);
   const theme = useThemeStore((s) => s.theme);
   const modesQuery = useModes();
   const { mutate: setUserModeMutate } = useSetUserMode();
@@ -191,6 +196,11 @@ export function TestChatPanel() {
         </div>
       </div>
 
+      {/* Active-trigger strip — shows exactly what will be prepended to the
+          next outgoing message as a per-turn override. Reflects the editor
+          tabs' current selection live. */}
+      <ActiveTriggerStrip mode={selectedMode} language={selectedLanguage} />
+
       {/* Messages area */}
       <div
         ref={scrollRef}
@@ -289,6 +299,33 @@ export function TestChatPanel() {
           </div>
         </form>
       </div>
+    </div>
+  );
+}
+
+interface ActiveTriggerStripProps {
+  mode: string | null;
+  language: string | null;
+}
+
+function ActiveTriggerStrip({ mode, language }: ActiveTriggerStripProps) {
+  const hasOverride = mode !== null || language !== null;
+  return (
+    <div className="border-border/50 bg-muted/40 flex h-7 shrink-0 items-center gap-2 border-b px-4">
+      <span className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
+        Active
+      </span>
+      {hasOverride ? (
+        <code className="text-foreground/80 font-mono text-xs">
+          {mode !== null && <span>#{mode}</span>}
+          {mode !== null && language !== null && " "}
+          {language !== null && <span>@{language}</span>}
+        </code>
+      ) : (
+        <span className="text-muted-foreground text-xs italic">
+          Default — no override
+        </span>
+      )}
     </div>
   );
 }

--- a/src/hooks/use-test-chat.ts
+++ b/src/hooks/use-test-chat.ts
@@ -7,9 +7,14 @@ import {
   streamChat,
 } from "@/lib/chat-api";
 import { consumeSSEStream } from "@/lib/sse-stream";
+import { useUiStore } from "@/lib/ui-store";
 import type { ChatHistoryEntry, ChatMessage } from "@/types/chat";
 
 export function useTestChat(userId: string) {
+  // Track the editor-tab selections so the next outgoing message carries
+  // `#<mode> @<language>` as a per-turn trigger override (#81 + worker #211).
+  const selectedMode = useUiStore((s) => s.selectedMode);
+  const selectedLanguage = useUiStore((s) => s.selectedLanguage);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(true);
@@ -114,7 +119,11 @@ export function useTestChat(userId: string) {
       setStatusMessage(null);
 
       try {
-        const response = await streamChat(trimmed, userId, controller.signal);
+        const response = await streamChat(trimmed, userId, {
+          mode: selectedMode,
+          language: selectedLanguage,
+          signal: controller.signal,
+        });
 
         const { finalText, hadStreaming } = await consumeSSEStream(response, {
           onStatus: (msg) => setStatusMessage(msg),
@@ -156,7 +165,7 @@ export function useTestChat(userId: string) {
         setStatusMessage(null);
       }
     },
-    [isLoading, userId]
+    [isLoading, selectedLanguage, selectedMode, userId]
   );
 
   const clearMessages = useCallback(() => {

--- a/src/lib/chat-api.ts
+++ b/src/lib/chat-api.ts
@@ -4,16 +4,54 @@ const SAME_ORIGIN_HEADERS = {
   "X-Requested-With": "XMLHttpRequest",
 } as const;
 
+export interface StreamChatOptions {
+  /**
+   * Active mode slug to prepend as `#<mode>` to the outgoing message.
+   * The worker's deterministic classifier parses leading trigger tokens
+   * and applies them as a per-turn override (bt-servant-worker #199 / #211).
+   */
+  mode?: string | null;
+  /** Active language slug to prepend as `@<language>`. */
+  language?: string | null;
+  signal?: AbortSignal;
+}
+
+/**
+ * Build the wire message: prepend `#<mode>` and/or `@<language>` to the
+ * user's text so the worker classifier applies them as a per-turn override.
+ * Strings only — both falsy means no prefix is added.
+ */
+export function applyTriggerPrefix(
+  message: string,
+  mode?: string | null,
+  language?: string | null
+): string {
+  const parts: string[] = [];
+  if (mode) parts.push(`#${mode}`);
+  if (language) parts.push(`@${language}`);
+  if (parts.length === 0) return message;
+  return `${parts.join(" ")} ${message}`;
+}
+
 export async function streamChat(
   message: string,
   userId: string,
-  signal?: AbortSignal
+  options: StreamChatOptions = {}
 ): Promise<Response> {
+  const wireMessage = applyTriggerPrefix(
+    message,
+    options.mode,
+    options.language
+  );
   const res = await fetch("/api/chat/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
-    body: JSON.stringify({ message, message_type: "text", user_id: userId }),
-    signal,
+    body: JSON.stringify({
+      message: wireMessage,
+      message_type: "text",
+      user_id: userId,
+    }),
+    signal: options.signal,
   });
 
   if (!res.ok) {

--- a/tests/chat-api.test.ts
+++ b/tests/chat-api.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { applyTriggerPrefix } from "../src/lib/chat-api";
+
+describe("applyTriggerPrefix", () => {
+  it("returns the message unchanged when both mode and language are null", () => {
+    expect(applyTriggerPrefix("hello", null, null)).toBe("hello");
+  });
+
+  it("returns the message unchanged when both mode and language are undefined", () => {
+    expect(applyTriggerPrefix("hello", undefined, undefined)).toBe("hello");
+  });
+
+  it("treats an empty string as no override (no stray '#' / '@' prefix)", () => {
+    expect(applyTriggerPrefix("hello", "", "")).toBe("hello");
+  });
+
+  it("prepends `#<mode>` when only mode is set", () => {
+    expect(applyTriggerPrefix("hello", "spoken", null)).toBe("#spoken hello");
+  });
+
+  it("prepends `@<language>` when only language is set", () => {
+    expect(applyTriggerPrefix("hello", null, "arabic")).toBe("@arabic hello");
+  });
+
+  it("prepends `#<mode> @<language>` (in that order, single space) when both are set", () => {
+    expect(applyTriggerPrefix("hello", "spoken", "arabic")).toBe(
+      "#spoken @arabic hello"
+    );
+  });
+
+  it("preserves the original message text exactly (no trimming, no escaping)", () => {
+    expect(applyTriggerPrefix("  hello   world  ", "spoken", "arabic")).toBe(
+      "#spoken @arabic   hello   world  "
+    );
+  });
+
+  it("does not double-prepend when the message already contains a trigger", () => {
+    // Worker classifier iterates all leading tokens; the last match wins, so
+    // a user-typed trigger correctly overrides the editor's selection. This
+    // test pins the wire format so power-user override stays intact.
+    expect(
+      applyTriggerPrefix("#dbs-coach @english hi", "spoken", "arabic")
+    ).toBe("#spoken @arabic #dbs-coach @english hi");
+  });
+
+  it("handles an empty message", () => {
+    expect(applyTriggerPrefix("", "spoken", "arabic")).toBe("#spoken @arabic ");
+  });
+});

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -23,7 +23,16 @@
     "types": [
       "@cloudflare/workers-types",
       "@cloudflare/vitest-pool-workers/types"
-    ]
+    ],
+
+    /* Path alias for tests that exercise pure functions from src/.
+       Files reached via this alias are pulled into worker typecheck on
+       demand — keep transitively-imported src/ modules free of DOM/JSX
+       types so the worker tsconfig can resolve them. */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["worker", "tests", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary

Pre-pends `#<mode> @<language>` from the editor-tab selections to the outgoing test-chat message so the worker classifier applies them as a per-turn override. **Closes #81**, supports the June 9 demo target (`#spoken @arabic` end-to-end without leaving the editor).

## Why prepending (not a new wire field)

bt-servant-worker shipped #199 / #211 (PR #212, merged today 2026-05-11 13:35) as a deterministic three-tier cascade (exact → unique prefix → unique Levenshtein ≤ 2) that parses trigger tokens inline from the leading characters of the user message. The worker strips both matched and unmatched tokens before history, so the prepended trigger never pollutes the stored conversation. **No worker contract change needed.**

The issue body's "header or body field" suggestion is outdated — written before the trigger-syntax model landed. Per CLAUDE.md "Trust code over docs/issues".

## Changes

- **`lib/chat-api.ts`**: Extract `applyTriggerPrefix(message, mode, language)` pure function. `streamChat` now takes a `StreamChatOptions` object with `mode`, `language`, and `signal`. Pure function is exported so tests and future callers (e.g. Baruch chat, if it ever gains per-turn triggers) can reuse it.
- **`hooks/use-test-chat.ts`**: Reads `selectedMode` and `selectedLanguage` from `ui-store` and forwards them on each send. The values update live — picking a new mode/language in the editor tabs is reflected on the next send.
- **`components/test-chat-panel.tsx`**: New `<ActiveTriggerStrip>` row below the header. Renders the literal trigger that will be prepended (e.g. `#spoken @arabic`) in monospace, or *Default — no override* italic muted when neither is set. Reads the same store fields so the strip updates live as the user navigates tabs.

## Out of scope (deliberately)

- The existing per-test-user **mode dropdown** + `setUserMode` mutation are unchanged. That's a different concept (persistent per-test-user default mode) from the per-turn trigger override. The chip + trigger sit alongside it without conflict. Removing the dropdown is a separate cleanup that may come later if we decide the test-chat UX is too cluttered.
- **#50** (textarea dedup between test-chat-panel and baruch-chat-pane) — Seth's cross-reference. Same surface, but the right way to consolidate is its own refactor PR, not bundled with feature work.
- **Engine integration verification** — worker #212 has 572 passing tests; relying on those + staging behavior rather than spinning up the engine locally.

## Acceptance criteria

- [x] Selecting a mode in the Modes tab updates the active selection used by the chat
- [x] Same for language in the Languages tab
- [x] Test-chat requests include both (as the inline trigger prefix)
- [x] The header chip is visible, updates live, and shows "Default" with no override prepended when neither is selected
- [x] Closing and reopening the test-chat preserves the active selection (trivial: the source of truth is ui-store, which already persists across panel open/close)

## Test plan

- [x] npm run typecheck clean
- [x] npm run lint clean (0 warnings)
- [x] npm run build clean
- [x] npm test — 17/17 passing
- [ ] **Manual (cannot do from sandbox — login required):**
  - Open the portal, navigate to Modes, pick "spoken", open the test chat → chip shows #spoken
  - Navigate to Languages, pick "arabic" → chip updates live to #spoken @arabic
  - Send "How do I translate Genesis 1:1?" → DevTools Network shows request body message: "#spoken @arabic How do I translate Genesis 1:1?"
  - Engine response reflects the spoken-mode + Arabic-language prompt overrides
  - Clear both selections → chip shows "Default — no override", message body has no prefix
  - Type your own #dbs-coach @english Hello in the input → outgoing wire has #<editor-mode> @<editor-lang> #dbs-coach @english Hello; per worker cascade the LAST matching token wins, so dbs-coach + english override the editor's selection. (Power-user override path.)

## Notes for review

- The applyTriggerPrefix helper is exported so the same pattern can land in Baruch chat later (issue #50 + a separate "Baruch per-turn trigger" issue), but I deliberately didn't wire it there in this PR — Baruch is production chat for end-users and per-turn override there is a product decision, not a wire cleanup.
- The chip format \`#spoken @arabic\` is intentionally the exact wire text rather than "Mode: spoken · Language: arabic". Reasoning: this is a test chat for developers, and showing the literal trigger is the most useful debug affordance.