### PR TITLE
fix: replace AlertDialogAction with Button + manual close (#102)

### DIFF
--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -241,39 +241,33 @@ export function LanguagesPage() {
   );
 
   const handleSetPublished = useCallback(
-    (name: string, published: boolean) => {
+    async (name: string, published: boolean) => {
       // Send the current draft for the selected language so an unsaved doc
       // edit lands in the same request as the publish toggle. Bookkeep both
       // lastSyncedDoc and lastSyncedPublished on success — without the
       // latter, a subsequent autosave would read stale `published` from the
       // cache and revert this toggle.
+      //
+      // mutateAsync so the selector's destructive-confirmation dialog can
+      // await + render inline errors (#102).
       const isSelected = name === selectedLanguage;
       const doc = isSelected ? draft : (languageQuery.data?.document ?? "");
-      saveLanguage.mutate(
-        {
-          name,
-          body: { label: serverLabel, document: doc, published },
-        },
-        {
-          onSuccess: () => {
-            if (isSelected) {
-              setLastSyncedDoc(doc);
-              setLastSyncedPublished(published);
-            }
-          },
-        }
-      );
+      await saveLanguage.mutateAsync({
+        name,
+        body: { label: serverLabel, document: doc, published },
+      });
+      if (isSelected) {
+        setLastSyncedDoc(doc);
+        setLastSyncedPublished(published);
+      }
     },
     [draft, languageQuery.data, saveLanguage, selectedLanguage, serverLabel]
   );
 
   const handleDeleteLanguage = useCallback(
-    (name: string) => {
-      deleteLanguage.mutate(name, {
-        onSuccess: () => {
-          if (name === selectedLanguage) setSelectedLanguage(null);
-        },
-      });
+    async (name: string) => {
+      await deleteLanguage.mutateAsync(name);
+      if (name === selectedLanguage) setSelectedLanguage(null);
     },
     [deleteLanguage, selectedLanguage, setSelectedLanguage]
   );

--- a/src/app/pages/manual-config.tsx
+++ b/src/app/pages/manual-config.tsx
@@ -86,17 +86,18 @@ export function ManualConfigPage() {
   );
 
   const handleSetPublished = useCallback(
-    (name: string, published: boolean) => {
-      setModePublished.mutate({ name, published });
+    async (name: string, published: boolean) => {
+      // mutateAsync so the selector's destructive-confirmation dialog can
+      // await + render inline errors (#102).
+      await setModePublished.mutateAsync({ name, published });
     },
     [setModePublished]
   );
 
   const handleDeleteMode = useCallback(
-    (name: string) => {
-      deleteMode.mutate(name, {
-        onSuccess: () => setSelectedMode(null),
-      });
+    async (name: string) => {
+      await deleteMode.mutateAsync(name);
+      setSelectedMode(null);
     },
     [deleteMode, setSelectedMode]
   );

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -3,10 +3,10 @@ import { faLanguage } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Eye, EyeOff, Plus, Send, SendHorizontal, Trash2 } from "lucide-react";
 
+import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import type { Language, OrgLanguages } from "@/types/language";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -32,8 +32,11 @@ interface LanguageSelectorProps {
   selectedLanguage: string | null;
   onSelectLanguage: (language: string | null) => void;
   onCreateLanguage: (name: string, label: string) => void;
-  onDeleteLanguage: (name: string) => void;
-  onSetPublished: (name: string, published: boolean) => void;
+  /** Must return a promise that rejects on error — the destructive
+      confirmation dialogs render inline error UI on the rejection path
+      and stay open so the user can read it (#102). */
+  onDeleteLanguage: (name: string) => Promise<void>;
+  onSetPublished: (name: string, published: boolean) => Promise<void>;
   isCreating: boolean;
   isDeleting: boolean;
   isSettingPublished: boolean;
@@ -70,6 +73,35 @@ export function LanguageSelector({
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
   const [newLabel, setNewLabel] = useState("");
+
+  // Destructive-confirmation dialogs are controlled so we can keep them
+  // open on async failure and render the error inline (#102). Closing on
+  // success happens in the handlers below; the open-state setter is also
+  // wired to clear the per-dialog error when the user dismisses.
+  const [unpublishOpen, setUnpublishOpen] = useState(false);
+  const [unpublishError, setUnpublishError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const handleConfirmUnpublish = useCallback(() => {
+    if (selectedLanguage === null) return;
+    return runConfirmedAction(
+      () => onSetPublished(selectedLanguage, false),
+      setUnpublishError,
+      () => setUnpublishOpen(false),
+      "Failed to unpublish language."
+    );
+  }, [onSetPublished, selectedLanguage]);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (selectedLanguage === null) return;
+    return runConfirmedAction(
+      () => onDeleteLanguage(selectedLanguage),
+      setDeleteError,
+      () => setDeleteOpen(false),
+      "Failed to delete language."
+    );
+  }, [onDeleteLanguage, selectedLanguage]);
 
   const languages = languagesData?.languages ?? [];
   const selectedData =
@@ -168,7 +200,13 @@ export function LanguageSelector({
 
             {isAdmin &&
               (selectedIsPublished ? (
-                <AlertDialog>
+                <AlertDialog
+                  open={unpublishOpen}
+                  onOpenChange={(next) => {
+                    setUnpublishOpen(next);
+                    if (!next) setUnpublishError(null);
+                  }}
+                >
                   <AlertDialogTrigger asChild>
                     <Button
                       variant="ghost"
@@ -188,13 +226,25 @@ export function LanguageSelector({
                         it as a draft.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
+                    {unpublishError && (
+                      <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                        {unpublishError}
+                      </p>
+                    )}
                     <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={() => onSetPublished(selectedLanguage, false)}
+                      <AlertDialogCancel disabled={isSettingPublished}>
+                        Cancel
+                      </AlertDialogCancel>
+                      {/* Plain Button — AlertDialogAction auto-closes the
+                          dialog before onError can render the inline message
+                          (#102). Close happens manually in
+                          handleConfirmUnpublish on success. */}
+                      <Button
+                        onClick={handleConfirmUnpublish}
+                        disabled={isSettingPublished}
                       >
-                        Unpublish
-                      </AlertDialogAction>
+                        {isSettingPublished ? "Unpublishing…" : "Unpublish"}
+                      </Button>
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
@@ -203,7 +253,9 @@ export function LanguageSelector({
                   variant="ghost"
                   size="sm"
                   disabled={isSettingPublished}
-                  onClick={() => onSetPublished(selectedLanguage, true)}
+                  onClick={() => {
+                    void onSetPublished(selectedLanguage, true);
+                  }}
                 >
                   <Send className="mr-1.5 size-3.5" />
                   Publish
@@ -211,7 +263,13 @@ export function LanguageSelector({
               ))}
 
             {isAdmin && (
-              <AlertDialog>
+              <AlertDialog
+                open={deleteOpen}
+                onOpenChange={(next) => {
+                  setDeleteOpen(next);
+                  if (!next) setDeleteError(null);
+                }}
+              >
                 <AlertDialogTrigger asChild>
                   <Button
                     variant="ghost"
@@ -234,14 +292,23 @@ export function LanguageSelector({
                       ? This action cannot be undone.
                     </AlertDialogDescription>
                   </AlertDialogHeader>
+                  {deleteError && (
+                    <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                      {deleteError}
+                    </p>
+                  )}
                   <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
+                    <AlertDialogCancel disabled={isDeleting}>
+                      Cancel
+                    </AlertDialogCancel>
+                    {/* Plain Button — see comment in Unpublish dialog above. */}
+                    <Button
                       variant="destructive"
-                      onClick={() => onDeleteLanguage(selectedLanguage)}
+                      onClick={handleConfirmDelete}
+                      disabled={isDeleting}
                     >
-                      Delete
-                    </AlertDialogAction>
+                      {isDeleting ? "Deleting…" : "Delete"}
+                    </Button>
                   </AlertDialogFooter>
                 </AlertDialogContent>
               </AlertDialog>

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -254,7 +254,16 @@ export function LanguageSelector({
                   size="sm"
                   disabled={isSettingPublished}
                   onClick={() => {
-                    void onSetPublished(selectedLanguage, true);
+                    // No confirmation dialog on the publish path, so no
+                    // inline UI to render an error into. Catch the
+                    // rejection here purely to avoid an unhandled-rejection
+                    // warning — the parent's mutation state (forbidden
+                    // errors via saveLanguage.error → forbiddenError
+                    // banner) handles user-visible surfacing of 403s; other
+                    // failures remain silent, matching pre-#102 behavior
+                    // when the parent used `mutate` instead of
+                    // `mutateAsync`.
+                    onSetPublished(selectedLanguage, true).catch(() => {});
                   }}
                 >
                   <Send className="mr-1.5 size-3.5" />

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -3,10 +3,10 @@ import { faLayerGroup } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Eye, EyeOff, Plus, Send, SendHorizontal, Trash2 } from "lucide-react";
 
+import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import type { OrgModes, PromptMode } from "@/types/prompt-override";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -34,8 +34,11 @@ interface ModeSelectorProps {
   selectedMode: string | null;
   onSelectMode: (mode: string | null) => void;
   onCreateMode: (name: string, label: string, description: string) => void;
-  onDeleteMode: (name: string) => void;
-  onSetPublished: (name: string, published: boolean) => void;
+  /** Must return a promise that rejects on error — the destructive
+      confirmation dialogs render inline error UI on the rejection path
+      and stay open so the user can read it (#102). */
+  onDeleteMode: (name: string) => Promise<void>;
+  onSetPublished: (name: string, published: boolean) => Promise<void>;
   isCreating: boolean;
   isDeleting: boolean;
   isSettingPublished: boolean;
@@ -66,6 +69,35 @@ export function ModeSelector({
   const [newName, setNewName] = useState("");
   const [newLabel, setNewLabel] = useState("");
   const [newDescription, setNewDescription] = useState("");
+
+  // Destructive-confirmation dialogs are controlled so we can keep them
+  // open on async failure and render the error inline (#102). Closing on
+  // success happens in the handlers below; the open-state setter is also
+  // wired to clear the per-dialog error when the user dismisses.
+  const [unpublishOpen, setUnpublishOpen] = useState(false);
+  const [unpublishError, setUnpublishError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const handleConfirmUnpublish = useCallback(() => {
+    if (selectedMode === null) return;
+    return runConfirmedAction(
+      () => onSetPublished(selectedMode, false),
+      setUnpublishError,
+      () => setUnpublishOpen(false),
+      "Failed to unpublish mode."
+    );
+  }, [onSetPublished, selectedMode]);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (selectedMode === null) return;
+    return runConfirmedAction(
+      () => onDeleteMode(selectedMode),
+      setDeleteError,
+      () => setDeleteOpen(false),
+      "Failed to delete mode."
+    );
+  }, [onDeleteMode, selectedMode]);
 
   const modes = modesData?.modes ?? [];
   const selectedModeData = modes.find((m) => m.name === selectedMode) ?? null;
@@ -167,7 +199,13 @@ export function ModeSelector({
 
             {isAdmin &&
               (selectedIsPublished ? (
-                <AlertDialog>
+                <AlertDialog
+                  open={unpublishOpen}
+                  onOpenChange={(next) => {
+                    setUnpublishOpen(next);
+                    if (!next) setUnpublishError(null);
+                  }}
+                >
                   <AlertDialogTrigger asChild>
                     <Button
                       variant="ghost"
@@ -186,13 +224,25 @@ export function ModeSelector({
                         Admins will still be able to see and edit it as a draft.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
+                    {unpublishError && (
+                      <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                        {unpublishError}
+                      </p>
+                    )}
                     <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={() => onSetPublished(selectedMode, false)}
+                      <AlertDialogCancel disabled={isSettingPublished}>
+                        Cancel
+                      </AlertDialogCancel>
+                      {/* Plain Button — AlertDialogAction auto-closes the
+                          dialog before onError can render the inline message
+                          (#102). Close happens manually in
+                          handleConfirmUnpublish on success. */}
+                      <Button
+                        onClick={handleConfirmUnpublish}
+                        disabled={isSettingPublished}
                       >
-                        Unpublish
-                      </AlertDialogAction>
+                        {isSettingPublished ? "Unpublishing…" : "Unpublish"}
+                      </Button>
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
@@ -201,14 +251,22 @@ export function ModeSelector({
                   variant="ghost"
                   size="sm"
                   disabled={isSettingPublished}
-                  onClick={() => onSetPublished(selectedMode, true)}
+                  onClick={() => {
+                    void onSetPublished(selectedMode, true);
+                  }}
                 >
                   <Send className="mr-1.5 size-3.5" />
                   Publish
                 </Button>
               ))}
 
-            <AlertDialog>
+            <AlertDialog
+              open={deleteOpen}
+              onOpenChange={(next) => {
+                setDeleteOpen(next);
+                if (!next) setDeleteError(null);
+              }}
+            >
               <AlertDialogTrigger asChild>
                 <Button
                   variant="ghost"
@@ -231,14 +289,23 @@ export function ModeSelector({
                     ? This action cannot be undone.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
+                {deleteError && (
+                  <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                    {deleteError}
+                  </p>
+                )}
                 <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
+                  <AlertDialogCancel disabled={isDeleting}>
+                    Cancel
+                  </AlertDialogCancel>
+                  {/* Plain Button — see comment in Unpublish dialog above. */}
+                  <Button
                     variant="destructive"
-                    onClick={() => onDeleteMode(selectedMode)}
+                    onClick={handleConfirmDelete}
+                    disabled={isDeleting}
                   >
-                    Delete
-                  </AlertDialogAction>
+                    {isDeleting ? "Deleting…" : "Delete"}
+                  </Button>
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -252,7 +252,13 @@ export function ModeSelector({
                   size="sm"
                   disabled={isSettingPublished}
                   onClick={() => {
-                    void onSetPublished(selectedMode, true);
+                    // No confirmation dialog on the publish path, so no
+                    // inline UI to render an error into. Catch the
+                    // rejection here purely to avoid an unhandled-rejection
+                    // warning — failures remain silent, matching pre-#102
+                    // behavior when the parent used `mutate` instead of
+                    // `mutateAsync`.
+                    onSetPublished(selectedMode, true).catch(() => {});
                   }}
                 >
                   <Send className="mr-1.5 size-3.5" />

--- a/src/components/user-memory-dialog.tsx
+++ b/src/components/user-memory-dialog.tsx
@@ -3,12 +3,12 @@ import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ChevronDown, ChevronRight, Pin, Search, Trash2 } from "lucide-react";
 
+import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import { cn } from "@/lib/utils";
 import { useDeleteUserMemory, useUserMemory } from "@/hooks/use-user-memory";
 import type { MemoryEntry, MemoryResponse } from "@/types/memory";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -192,42 +192,67 @@ interface ClearMemoryButtonProps {
 
 function ClearMemoryButton({ userId }: ClearMemoryButtonProps) {
   const deleteMutation = useDeleteUserMemory();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = useCallback(
+    () =>
+      runConfirmedAction(
+        () => deleteMutation.mutateAsync(userId),
+        setError,
+        () => setOpen(false),
+        "Failed to clear memory."
+      ),
+    [deleteMutation, userId]
+  );
 
   return (
-    <div className="space-y-2">
-      <AlertDialog>
-        <AlertDialogTrigger asChild>
-          <Button variant="destructive" size="sm">
-            <Trash2 className="mr-1 size-3" />
-            Clear Memory
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setError(null);
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          <Trash2 className="mr-1 size-3" />
+          Clear Memory
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Clear all memory?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete all memory entries for this user. This
+            action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && (
+          <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+            {error}
+          </p>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteMutation.isPending}>
+            Cancel
+          </AlertDialogCancel>
+          {/*
+            Plain Button (not AlertDialogAction) — Radix's Action closes the
+            dialog on click, which dismisses the inline error before the
+            async mutation's onError can render it. We close manually in
+            handleConfirm's success branch instead (#102).
+          */}
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? "Clearing..." : "Clear Memory"}
           </Button>
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Clear all memory?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete all memory entries for this user.
-              This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={() => deleteMutation.mutate(userId)}
-              disabled={deleteMutation.isPending}
-            >
-              {deleteMutation.isPending ? "Clearing..." : "Clear Memory"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-      {deleteMutation.isError && (
-        <p className="text-destructive text-xs">
-          Failed to clear memory. Please try again.
-        </p>
-      )}
-    </div>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 

--- a/src/lib/run-confirmed-action.ts
+++ b/src/lib/run-confirmed-action.ts
@@ -1,0 +1,33 @@
+/**
+ * Run a destructive action from a confirmation dialog and route the
+ * outcome to dialog-local UI state.
+ *
+ * Used by the AlertDialog destructive-confirm flow (#102). The dialog
+ * stays open across `action()` so an error message can render inline;
+ * `onSuccess` is the only path that closes it. `setError(null)` runs
+ * up-front to clear any stale error from a previous attempt.
+ *
+ * @param action     The async work to perform (typically a TanStack
+ *                   `mutateAsync` call). Must reject on failure so the
+ *                   error path triggers.
+ * @param setError   Local-state setter for the dialog's inline error.
+ *                   Receives `null` before the call, the error message
+ *                   string on rejection.
+ * @param onSuccess  Called when `action` resolves. Typical use: close
+ *                   the dialog and clean up any local state.
+ * @param fallbackMessage Used when the thrown value isn't an `Error`.
+ */
+export async function runConfirmedAction(
+  action: () => Promise<unknown>,
+  setError: (message: string | null) => void,
+  onSuccess: () => void,
+  fallbackMessage = "Action failed."
+): Promise<void> {
+  setError(null);
+  try {
+    await action();
+    onSuccess();
+  } catch (err) {
+    setError(err instanceof Error ? err.message : fallbackMessage);
+  }
+}

--- a/tests/run-confirmed-action.test.ts
+++ b/tests/run-confirmed-action.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runConfirmedAction } from "../src/lib/run-confirmed-action";
+
+describe("runConfirmedAction", () => {
+  it("clears the error, runs the action, then calls onSuccess on resolve", async () => {
+    const setError = vi.fn();
+    const onSuccess = vi.fn();
+    const action = vi.fn(() => Promise.resolve("ok"));
+
+    await runConfirmedAction(action, setError, onSuccess);
+
+    expect(setError).toHaveBeenCalledTimes(1);
+    expect(setError).toHaveBeenNthCalledWith(1, null);
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("never calls onSuccess if the action rejects (dialog must stay open)", async () => {
+    const setError = vi.fn();
+    const onSuccess = vi.fn();
+    const action = () => Promise.reject(new Error("boom"));
+
+    await runConfirmedAction(action, setError, onSuccess);
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("sets the Error's message on rejection", async () => {
+    const setError = vi.fn();
+    const action = () => Promise.reject(new Error("permission denied"));
+
+    await runConfirmedAction(action, setError, () => {});
+
+    // First call clears, second call records the failure message.
+    expect(setError).toHaveBeenNthCalledWith(2, "permission denied");
+  });
+
+  it("uses the fallback message when the thrown value is not an Error", async () => {
+    const setError = vi.fn();
+    const action = () => Promise.reject("string thrown, not Error");
+
+    await runConfirmedAction(action, setError, () => {}, "Custom fallback.");
+
+    expect(setError).toHaveBeenNthCalledWith(2, "Custom fallback.");
+  });
+
+  it("uses the default fallback message when none is provided", async () => {
+    const setError = vi.fn();
+    const action = () => Promise.reject({ weird: "object" });
+
+    await runConfirmedAction(action, setError, () => {});
+
+    expect(setError).toHaveBeenNthCalledWith(2, "Action failed.");
+  });
+
+  it("does not swallow the resolve order — onSuccess only runs after action settles", async () => {
+    const events: string[] = [];
+    const action = () =>
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          events.push("action-settled");
+          resolve();
+        }, 5);
+      });
+    const setError = () => events.push("setError");
+    const onSuccess = () => events.push("onSuccess");
+
+    await runConfirmedAction(action, setError, onSuccess);
+
+    expect(events).toEqual(["setError", "action-settled", "onSuccess"]);
+  });
+});


### PR DESCRIPTION
## Summary

Sweep the five remaining `AlertDialogAction` uses where the click handler is async and can fail. Radix's primitive auto-closes the parent dialog on click, racing the async resolution — `onError` callbacks fire after the dialog has already unmounted, so users never see the error.

The fix matches the precedent set in `src/app/pages/admin-users.tsx` (PR #100, commit `fff8366`) and is documented in the project's memory under `feedback_alertdialogaction_async.md`.

**Closes #102.**

## Touched dialogs

| File | Dialog(s) |
|---|---|
| `src/components/language-selector.tsx` | Unpublish, Delete |
| `src/components/mode-selector.tsx` | Unpublish, Delete |
| `src/components/user-memory-dialog.tsx` (ClearMemoryButton) | Clear Memory |

## The policy as a named helper

The policy — *clear error → await action → close on success, set error and stay open on failure* — is now a single helper in `src/lib/run-confirmed-action.ts`. All five call sites express the policy identically (one-liner each), and a future reviewer can verify correctness in one place rather than five.

The helper is unit-tested at `tests/run-confirmed-action.test.ts` for:
- happy path: `setError(null)` → action runs → `onSuccess` called, in that order
- rejection: `onSuccess` never fires (the failure mode that motivated this whole sweep)
- `Error` message extracted on rejection
- Non-`Error` rejection falls back to the fallback message
- Default fallback when caller doesn't provide one
- Temporal ordering: setError → action settles → onSuccess

## Wire shape changes

Selector callback props are now `Promise<void>`-returning so the dialog can `await` + render inline errors:

- `LanguageSelectorProps.onDeleteLanguage` / `.onSetPublished`
- `ModeSelectorProps.onDeleteMode` / `.onSetPublished`

Parents (`languages.tsx`, `manual-config.tsx`) use `mutateAsync` instead of `mutate` so the rejection path flows. The non-destructive publish click (synchronous from the dialog's perspective) keeps the same UX — just `void`-discards the unused promise.

## Out of scope

- `languages.tsx:435, 466` — navigation guard dialogs (Stay / Leave / Discard-and-switch). Verified safe: actions are synchronous router calls (`blocker.proceed()`, `setSelectedLanguage()`); dialog auto-close is fine. No async error path to render.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 warnings)
- [x] `npm run build` clean
- [x] `npm test` — 42 passing (added 6 for `runConfirmedAction`)
- [ ] **Manual (login required):**
  - Force a Delete failure (e.g. revoke permissions, then click Delete) → confirm dialog stays open with inline error message
  - Same for Unpublish and Clear Memory paths
  - Success cases: dialog closes cleanly, list updates