### PR TITLE
feat: markdown editor + TOC for modes (#76, #82)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -18,6 +18,7 @@ import { BaruchPage } from "@/app/pages/baruch";
 import { LanguagesPage } from "@/app/pages/languages";
 import { LoginPage } from "@/app/pages/login";
 import { ManualConfigPage } from "@/app/pages/manual-config";
+import { ModesPage } from "@/app/pages/modes";
 
 const queryClient = new QueryClient();
 
@@ -46,6 +47,7 @@ const router = createBrowserRouter([
         ),
         children: [
           { index: true, element: <BaruchPage /> },
+          { path: "modes", element: <ModesPage /> },
           { path: "prompt-configuration", element: <ManualConfigPage /> },
           { path: "languages", element: <LanguagesPage /> },
           {

--- a/src/app/pages/manual-config.tsx
+++ b/src/app/pages/manual-config.tsx
@@ -3,159 +3,57 @@ import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { useAuthStore } from "@/lib/auth-store";
-import { useUiStore } from "@/lib/ui-store";
 import { PageHeader } from "@/components/page-header";
 import {
-  useDeleteMode,
-  useMode,
-  useModes,
   useOrgOverrides,
-  useSaveMode,
-  useSetModePublished,
   useUpdateOrgOverrides,
 } from "@/hooks/use-prompt-config";
-import type { PromptOverrides, PromptSlot } from "@/types/prompt-override";
+import type { PromptSlot } from "@/types/prompt-override";
 import { PROMPT_SLOTS } from "@/types/prompt-override";
-import { ModeSelector } from "@/components/mode-selector";
 import { PromptPanel } from "@/components/prompt-panel";
 import { UserMemoryDialog } from "@/components/user-memory-dialog";
 
 export function ManualConfigPage() {
   const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
-  const selectedMode = useUiStore((s) => s.selectedMode);
-  const setSelectedMode = useUiStore((s) => s.setSelectedMode);
-  const showDrafts = useUiStore((s) => s.showDrafts);
-  const setShowDrafts = useUiStore((s) => s.setShowDrafts);
   const [memoryDialogOpen, setMemoryDialogOpen] = useState(false);
 
-  // Queries
   const orgOverrides = useOrgOverrides();
-  const modesQuery = useModes();
-  const modeQuery = useMode(selectedMode);
-
-  // Mutations
   const updateOrg = useUpdateOrgOverrides();
-  const saveMode = useSaveMode();
-  const deleteMode = useDeleteMode();
-  const setModePublished = useSetModePublished();
 
-  // Current overrides based on selection
-  const currentOverrides = useMemo<PromptOverrides>(
-    () =>
-      selectedMode !== null
-        ? (modeQuery.data?.overrides ?? {})
-        : (orgOverrides.data ?? {}),
-    [selectedMode, modeQuery.data?.overrides, orgOverrides.data]
+  const currentOverrides = useMemo(
+    () => orgOverrides.data ?? {},
+    [orgOverrides.data]
   );
 
   const handleSaveSlot = useCallback(
     (slot: PromptSlot, value: string) => {
-      if (selectedMode !== null) {
-        // Partial update: only the one edited slot is sent. The engine merges
-        // overrides per-slot and preserves label/description/published when
-        // absent from the PUT. Sending the full cached object would race with
-        // a concurrent publish/unpublish (stale `published` flips it back) or
-        // another concurrent slot save (stale overrides clobber it).
-        saveMode.mutate({
-          name: selectedMode,
-          body: { overrides: { [slot]: value || undefined } },
-        });
-      } else {
-        updateOrg.mutate({ ...currentOverrides, [slot]: value || undefined });
-      }
+      updateOrg.mutate({ ...currentOverrides, [slot]: value || undefined });
     },
-    [currentOverrides, selectedMode, saveMode, updateOrg]
+    [currentOverrides, updateOrg]
   );
-
-  const handleCreateMode = useCallback(
-    (name: string, label: string, description: string) => {
-      saveMode.mutate(
-        {
-          name,
-          body: {
-            label: label || undefined,
-            description: description || undefined,
-            overrides: orgOverrides.data ?? {},
-            published: false,
-          },
-        },
-        { onSuccess: () => setSelectedMode(name) }
-      );
-    },
-    [saveMode, orgOverrides.data, setSelectedMode]
-  );
-
-  const handleSetPublished = useCallback(
-    async (name: string, published: boolean) => {
-      // mutateAsync so the selector's destructive-confirmation dialog can
-      // await + render inline errors (#102).
-      await setModePublished.mutateAsync({ name, published });
-    },
-    [setModePublished]
-  );
-
-  const handleDeleteMode = useCallback(
-    async (name: string) => {
-      await deleteMode.mutateAsync(name);
-      setSelectedMode(null);
-    },
-    [deleteMode, setSelectedMode]
-  );
-
-  const isLoading =
-    orgOverrides.isLoading ||
-    modesQuery.isLoading ||
-    (selectedMode !== null && modeQuery.isLoading);
-
-  const error =
-    orgOverrides.error ||
-    modesQuery.error ||
-    (selectedMode !== null ? modeQuery.error : null);
-
-  const isSaving = updateOrg.isPending || saveMode.isPending;
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <PageHeader
-        title="Prompt Configuration"
-        subtitle="Manage prompt overrides for each slot at the org level or per mode."
-        variant="modes"
+        title="Prompt Overrides"
+        subtitle="Org-wide defaults applied to every conversation unless a Mode overrides them."
       />
 
-      {/* Grid area — dot grid + subtle radial glow */}
       <div className="config-grid-bg min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="space-y-4 sm:space-y-6">
-          {/* Mode toolbar */}
-          <ModeSelector
-            modesData={modesQuery.data}
-            selectedMode={selectedMode}
-            onSelectMode={setSelectedMode}
-            onCreateMode={handleCreateMode}
-            onDeleteMode={handleDeleteMode}
-            onSetPublished={handleSetPublished}
-            isCreating={saveMode.isPending}
-            isDeleting={deleteMode.isPending}
-            isSettingPublished={setModePublished.isPending}
-            showDrafts={showDrafts}
-            onToggleShowDrafts={setShowDrafts}
-            isAdmin={isAdmin}
-          />
-
-          {/* Error banner */}
-          {error && (
+          {orgOverrides.error && (
             <div className="bg-destructive/10 text-destructive border-destructive rounded-lg border-l-2 px-4 py-3 text-sm">
-              {error.message}
+              {orgOverrides.error.message}
             </div>
           )}
 
-          {/* Slot grid */}
-          {isLoading ? (
+          {orgOverrides.isLoading ? (
             <div className="text-muted-foreground flex flex-col items-center justify-center gap-3 py-16">
               <FontAwesomeIcon
                 icon={faSpinnerThird}
                 className="size-5 animate-spin"
               />
-              <p className="text-sm">Loading configuration...</p>
+              <p className="text-sm">Loading overrides...</p>
             </div>
           ) : (
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -167,8 +65,8 @@ export function ManualConfigPage() {
                   slot={slot}
                   value={currentOverrides[slot]}
                   onSave={(value) => handleSaveSlot(slot, value)}
-                  isSaving={isSaving}
-                  readOnly={selectedMode === null && !isAdmin}
+                  isSaving={updateOrg.isPending}
+                  readOnly={!isAdmin}
                   onViewMemory={
                     slot === "memory_instructions"
                       ? () => setMemoryDialogOpen(true)

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -1,0 +1,395 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Save } from "lucide-react";
+import { useBlocker } from "react-router";
+
+import { useAuthStore } from "@/lib/auth-store";
+import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
+import { useUiStore } from "@/lib/ui-store";
+import { useDebounced } from "@/hooks/use-debounced";
+import { useActiveHeadingLine } from "@/hooks/use-active-heading-line";
+import {
+  useDeleteMode,
+  useMode,
+  useModes,
+  useSaveMode,
+} from "@/hooks/use-prompt-config";
+import type { MarkdownHeading } from "@/types/markdown";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { MarkdownEditor } from "@/components/markdown-editor";
+import { MarkdownToc } from "@/components/markdown-toc";
+import { ModeSelector } from "@/components/mode-selector";
+import { PageHeader } from "@/components/page-header";
+
+const AUTO_SAVE_DEBOUNCE_MS = 800;
+
+export function ModesPage() {
+  const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
+  const selectedMode = useUiStore((s) => s.selectedMode);
+  const setSelectedMode = useUiStore((s) => s.setSelectedMode);
+  const showDrafts = useUiStore((s) => s.showDrafts);
+  const setShowDrafts = useUiStore((s) => s.setShowDrafts);
+
+  const modesQuery = useModes();
+  const modeQuery = useMode(selectedMode);
+  const saveMode = useSaveMode();
+  const deleteMode = useDeleteMode();
+
+  // Local document draft (auto-save target).
+  //
+  // We track `lastSyncedDoc` / `lastSyncedPublished` separately from the
+  // React Query cache so that edits typed *during* an in-flight save are
+  // preserved, and so a subsequent autosave after Publish/Unpublish doesn't
+  // read stale `published` from the cache and silently revert the toggle.
+  // Sync rule: pulled from the server only on selection change; advanced on
+  // successful save with the value we sent (never re-read from the cache).
+  // See `src/app/pages/languages.tsx` for the parallel implementation —
+  // both pages share this pattern.
+  const [draft, setDraft] = useState("");
+  const [lastSyncedDoc, setLastSyncedDoc] = useState("");
+  const [lastSyncedPublished, setLastSyncedPublished] = useState(false);
+  const [headings, setHeadings] = useState<MarkdownHeading[]>([]);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const activeLine = useActiveHeadingLine(textareaRef, draft, headings);
+  const debouncedDraft = useDebounced(draft, AUTO_SAVE_DEBOUNCE_MS);
+
+  const serverLabel = modeQuery.data?.label;
+  const serverDescription = modeQuery.data?.description;
+
+  const syncedNameRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedMode) {
+      syncedNameRef.current = null;
+      setDraft("");
+      setLastSyncedDoc("");
+      setLastSyncedPublished(false);
+      return;
+    }
+    if (!modeQuery.data) return;
+    if (modeQuery.data.name !== selectedMode) return;
+    if (syncedNameRef.current === selectedMode) return;
+    setDraft(modeQuery.data.document);
+    setLastSyncedDoc(modeQuery.data.document);
+    setLastSyncedPublished(modeQuery.data.published ?? false);
+    syncedNameRef.current = selectedMode;
+  }, [selectedMode, modeQuery.data]);
+
+  const isDirty = draft !== lastSyncedDoc;
+  const isSaving = saveMode.isPending;
+  const hasSelection = selectedMode !== null && modeQuery.data;
+
+  const performSave = useCallback(
+    (doc: string) => {
+      if (!selectedMode) return;
+      saveMode.mutate(
+        {
+          name: selectedMode,
+          body: {
+            label: serverLabel,
+            description: serverDescription,
+            document: doc,
+            published: lastSyncedPublished,
+          },
+        },
+        { onSuccess: () => setLastSyncedDoc(doc) }
+      );
+    },
+    [
+      lastSyncedPublished,
+      saveMode,
+      selectedMode,
+      serverDescription,
+      serverLabel,
+    ]
+  );
+
+  useEffect(() => {
+    if (!selectedMode) return;
+    if (saveMode.isPending) return;
+    if (debouncedDraft === lastSyncedDoc) return;
+    performSave(debouncedDraft);
+  }, [
+    debouncedDraft,
+    saveMode.isPending,
+    lastSyncedDoc,
+    performSave,
+    selectedMode,
+  ]);
+
+  const flushSave = useCallback(() => {
+    if (!isDirty || isSaving) return;
+    performSave(draft);
+  }, [draft, isDirty, isSaving, performSave]);
+
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      (isDirty || isSaving) &&
+      currentLocation.pathname !== nextLocation.pathname
+  );
+
+  const [pendingSwitch, setPendingSwitch] = useState<string | null>(null);
+
+  const handleSelectMode = useCallback(
+    (next: string | null) => {
+      if (next === selectedMode) return;
+      if (isDirty || isSaving) {
+        setPendingSwitch(next);
+        return;
+      }
+      setSelectedMode(next);
+    },
+    [isDirty, isSaving, selectedMode, setSelectedMode]
+  );
+
+  const confirmSwitch = useCallback(() => {
+    setSelectedMode(pendingSwitch);
+    setPendingSwitch(null);
+  }, [pendingSwitch, setSelectedMode]);
+
+  const handleCreateMode = useCallback(
+    (name: string, label: string, description: string) => {
+      saveMode.mutate(
+        {
+          name,
+          body: {
+            label: label || undefined,
+            description: description || undefined,
+            document: MODE_DOCUMENT_SCAFFOLD,
+            published: false,
+          },
+        },
+        { onSuccess: () => setSelectedMode(name) }
+      );
+    },
+    [saveMode, setSelectedMode]
+  );
+
+  const handleSetPublished = useCallback(
+    async (name: string, published: boolean) => {
+      // Selector only renders publish/unpublish for the currently-selected
+      // mode, so we always send the current draft. The worker contract
+      // requires a `document` on every PUT — there's no partial-update path.
+      if (name !== selectedMode) return;
+      await saveMode.mutateAsync({
+        name,
+        body: {
+          label: serverLabel,
+          description: serverDescription,
+          document: draft,
+          published,
+        },
+      });
+      setLastSyncedDoc(draft);
+      setLastSyncedPublished(published);
+    },
+    [draft, saveMode, selectedMode, serverDescription, serverLabel]
+  );
+
+  const handleDeleteMode = useCallback(
+    async (name: string) => {
+      await deleteMode.mutateAsync(name);
+      if (name === selectedMode) setSelectedMode(null);
+    },
+    [deleteMode, selectedMode, setSelectedMode]
+  );
+
+  const handleJumpToLine = useCallback(
+    (line: number) => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      const lines = draft.split("\n");
+      let pos = 0;
+      for (let i = 0; i < line; i++) pos += (lines[i]?.length ?? 0) + 1;
+      ta.focus();
+      ta.setSelectionRange(pos, pos);
+      const lineHeight = parseFloat(getComputedStyle(ta).lineHeight || "20");
+      ta.scrollTop = Math.max(0, line * lineHeight - 80);
+    },
+    [draft]
+  );
+
+  const isLoading =
+    modesQuery.isLoading || (selectedMode !== null && modeQuery.isLoading);
+
+  const error =
+    modesQuery.error || (selectedMode !== null ? modeQuery.error : null);
+
+  const saveStatus = useMemo(() => {
+    if (isSaving) return "Saving…";
+    if (isDirty) return "Unsaved changes";
+    if (hasSelection) return "Saved";
+    return "";
+  }, [hasSelection, isDirty, isSaving]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <PageHeader
+        title="Modes"
+        subtitle="Edit prompt modes as a single markdown document. Auto-saves as you type; use Save to flush immediately."
+        variant="modes"
+      />
+
+      <div className="bg-card border-b">
+        <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
+          <div className="min-w-0 flex-1">
+            <ModeSelector
+              modesData={modesQuery.data}
+              selectedMode={selectedMode}
+              onSelectMode={handleSelectMode}
+              onCreateMode={handleCreateMode}
+              onDeleteMode={handleDeleteMode}
+              onSetPublished={handleSetPublished}
+              isCreating={saveMode.isPending}
+              isDeleting={deleteMode.isPending}
+              isSettingPublished={saveMode.isPending}
+              showDrafts={showDrafts}
+              onToggleShowDrafts={setShowDrafts}
+              isAdmin={isAdmin}
+            />
+          </div>
+
+          {hasSelection && (
+            <div className="flex shrink-0 items-center gap-3">
+              <span
+                className="text-muted-foreground text-xs tabular-nums"
+                aria-live="polite"
+              >
+                {saveStatus}
+              </span>
+              <Button
+                size="sm"
+                onClick={flushSave}
+                disabled={!isDirty || isSaving}
+              >
+                <Save className="mr-1.5 size-3.5" />
+                Save
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm">
+          {error.message}
+        </div>
+      )}
+
+      <div
+        className="flex min-h-0 flex-1 overflow-hidden"
+        style={{ background: "var(--editor-paper)" }}
+      >
+        {isLoading ? (
+          <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-3">
+            <FontAwesomeIcon
+              icon={faSpinnerThird}
+              className="size-5 animate-spin"
+            />
+            <p className="text-sm">Loading modes…</p>
+          </div>
+        ) : !hasSelection ? (
+          <EmptyState hasAny={(modesQuery.data?.modes.length ?? 0) > 0} />
+        ) : (
+          <>
+            <MarkdownToc
+              headings={headings}
+              activeLine={activeLine}
+              onJump={handleJumpToLine}
+            />
+            <div className="min-w-0 flex-1 overflow-y-auto">
+              <MarkdownEditor
+                value={draft}
+                onChange={setDraft}
+                onHeadingsChange={setHeadings}
+                textareaRef={textareaRef}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      <AlertDialog
+        open={blocker.state === "blocked"}
+        onOpenChange={(open) => {
+          if (!open && blocker.state === "blocked") blocker.reset?.();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Leave with unsaved changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have edits that haven&rsquo;t finished saving. Leaving now may
+              discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => blocker.reset?.()}>
+              Stay
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => blocker.proceed?.()}
+            >
+              Leave anyway
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={pendingSwitch !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingSwitch(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Switch mode?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have unsaved edits to{" "}
+              <span className="text-foreground font-medium">
+                &ldquo;{selectedMode}&rdquo;
+              </span>
+              . Switching will discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setPendingSwitch(null)}>
+              Stay
+            </AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={confirmSwitch}>
+              Discard and switch
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface EmptyStateProps {
+  hasAny: boolean;
+}
+
+function EmptyState({ hasAny }: EmptyStateProps) {
+  return (
+    <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
+      <p className="text-sm">
+        {hasAny
+          ? "Pick a mode above to start editing."
+          : "No modes yet. Create one to get started."}
+      </p>
+    </div>
+  );
+}

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -2,11 +2,13 @@ import { faComments as faCommentsLight } from "@fortawesome/pro-light-svg-icons"
 import { faLanguage as faLanguageLight } from "@fortawesome/pro-light-svg-icons";
 import { faMessageBot as faMessageBotLight } from "@fortawesome/pro-light-svg-icons";
 import { faPenToSquare as faPenToSquareLight } from "@fortawesome/pro-light-svg-icons";
+import { faSliders as faSlidersLight } from "@fortawesome/pro-light-svg-icons";
 import { faUsers as faUsersLight } from "@fortawesome/pro-light-svg-icons";
 import { faComments as faCommentsSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faLanguage as faLanguageSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faMessageBot as faMessageBotSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faPenToSquare as faPenToSquareSolid } from "@fortawesome/pro-solid-svg-icons";
+import { faSliders as faSlidersSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faUsers as faUsersSolid } from "@fortawesome/pro-solid-svg-icons";
 import { useNavigate } from "react-router";
 
@@ -43,11 +45,11 @@ export function ActivityBar() {
         <ActivityBarItem
           icon={faPenToSquareLight}
           activeIcon={faPenToSquareSolid}
-          label="Manually configure your BT Servant agent"
-          isActive={activeSection === "prompt-configuration"}
+          label="Edit prompt modes"
+          isActive={activeSection === "modes"}
           onClick={() => {
-            setActiveSection("prompt-configuration");
-            void navigate("/prompt-configuration");
+            setActiveSection("modes");
+            void navigate("/modes");
           }}
         />
         <ActivityBarItem
@@ -61,6 +63,16 @@ export function ActivityBar() {
           }}
           disabled={!canAccessLanguages}
           disabledLabel="No language access — contact your admin"
+        />
+        <ActivityBarItem
+          icon={faSlidersLight}
+          activeIcon={faSlidersSolid}
+          label="Org-wide prompt overrides"
+          isActive={activeSection === "prompt-configuration"}
+          onClick={() => {
+            setActiveSection("prompt-configuration");
+            void navigate("/prompt-configuration");
+          }}
         />
         {isAdmin && (
           <ActivityBarItem

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -23,7 +23,6 @@ import {
   Select,
   SelectContent,
   SelectItem,
-  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -128,7 +127,7 @@ export function ModeSelector({
 
   const handleSelectChange = useCallback(
     (value: string) => {
-      onSelectMode(value === "__org__" ? null : value);
+      onSelectMode(value === "" ? null : value);
     },
     [onSelectMode]
   );
@@ -140,31 +139,32 @@ export function ModeSelector({
           <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
             <FontAwesomeIcon icon={faLayerGroup} className="text-sm" />
           </div>
-          <Select
-            value={selectedMode ?? "__org__"}
-            onValueChange={handleSelectChange}
-          >
+          <Select value={selectedMode ?? ""} onValueChange={handleSelectChange}>
             <SelectTrigger className="w-full sm:w-52">
-              <SelectValue />
+              <SelectValue placeholder="Select a mode" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="__org__">Org Defaults</SelectItem>
-              {visibleModes.length > 0 && <SelectSeparator />}
-              {visibleModes.map((m) => (
-                <SelectItem key={m.name} value={m.name}>
-                  <span className="flex items-center gap-2">
-                    <span className="truncate">{m.label || m.name}</span>
-                    {!isPublished(m) && (
-                      <Badge
-                        variant="outline"
-                        className="px-1.5 py-0 text-[10px]"
-                      >
-                        Draft
-                      </Badge>
-                    )}
-                  </span>
-                </SelectItem>
-              ))}
+              {visibleModes.length === 0 ? (
+                <div className="text-muted-foreground px-2 py-1.5 text-xs">
+                  No modes yet
+                </div>
+              ) : (
+                visibleModes.map((m) => (
+                  <SelectItem key={m.name} value={m.name}>
+                    <span className="flex items-center gap-2">
+                      <span className="truncate">{m.label || m.name}</span>
+                      {!isPublished(m) && (
+                        <Badge
+                          variant="outline"
+                          className="px-1.5 py-0 text-[10px]"
+                        >
+                          Draft
+                        </Badge>
+                      )}
+                    </span>
+                  </SelectItem>
+                ))
+              )}
             </SelectContent>
           </Select>
         </div>

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -65,7 +65,7 @@ export function useSaveMode() {
       body: {
         label?: string;
         description?: string;
-        overrides: PromptOverrides;
+        document: string;
         published?: boolean;
       };
     }) => configApi.putMode(name, body),
@@ -76,21 +76,12 @@ export function useSaveMode() {
   });
 }
 
-export function useSetModePublished() {
-  const qc = useQueryClient();
-  return useMutation({
-    // Partial update: only `published` is sent. The engine merges `overrides`
-    // per-slot and preserves label/description/overrides when they are absent
-    // from the PUT (incoming.x ?? existing.x). This avoids the GET→PUT race
-    // where a concurrent slot save could be overwritten by stale overrides.
-    mutationFn: ({ name, published }: { name: string; published: boolean }) =>
-      configApi.putMode(name, { overrides: {}, published }),
-    onSuccess: (_data, { name }) => {
-      void qc.invalidateQueries({ queryKey: keys.modes });
-      void qc.invalidateQueries({ queryKey: keys.mode(name) });
-    },
-  });
-}
+// Note: publish/unpublish flows through useSaveMode with the full body
+// (always send { label, description, document, published }). The worker
+// PUT contract requires exactly one of `document` or `overrides` per
+// request (worker #200 / PR #213), so the legacy partial-update path
+// is no longer expressible. Mirrors the languages-side pattern — see
+// `useSaveLanguage`.
 
 export function useDeleteMode() {
   const qc = useQueryClient();

--- a/src/hooks/use-sync-section.ts
+++ b/src/hooks/use-sync-section.ts
@@ -6,6 +6,7 @@ import type { Section } from "@/types/ui";
 
 const pathToSection: Record<string, Section> = {
   "/": "baruch",
+  "/modes": "modes",
   "/prompt-configuration": "prompt-configuration",
   "/languages": "languages",
   "/admin/users": "admin-users",

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -87,6 +87,17 @@ export async function listModes(signal?: AbortSignal): Promise<OrgModes> {
   return (await res.json()) as OrgModes;
 }
 
+function unwrapModeResponse(data: Record<string, unknown>): PromptMode {
+  // Worker wraps in `{ org, mode: { name, label?, description?, published?,
+  // document, format, originalSlots? }, message? }`. We ignore `format` and
+  // `originalSlots` — both are diagnostic only and not part of the portal's
+  // contract.
+  if ("mode" in data && typeof data.mode === "object" && data.mode !== null) {
+    return data.mode as PromptMode;
+  }
+  return data as unknown as PromptMode;
+}
+
 export async function getMode(
   name: string,
   signal?: AbortSignal
@@ -101,13 +112,7 @@ export async function getMode(
     throw new Error(`Failed to load mode (${res.status}): ${body}`);
   }
 
-  const data = (await res.json()) as Record<string, unknown>;
-
-  // Engine API wraps in { org, mode: { label, description, overrides } }
-  if ("mode" in data && typeof data.mode === "object") {
-    return data.mode as PromptMode;
-  }
-  return data as unknown as PromptMode;
+  return unwrapModeResponse((await res.json()) as Record<string, unknown>);
 }
 
 export async function putMode(
@@ -115,7 +120,7 @@ export async function putMode(
   body: {
     label?: string;
     description?: string;
-    overrides: PromptOverrides;
+    document: string;
     published?: boolean;
   },
   signal?: AbortSignal
@@ -132,7 +137,10 @@ export async function putMode(
     throw new Error(`Failed to save mode (${res.status}): ${text}`);
   }
 
-  return (await res.json()) as PromptMode;
+  // Unwrap `{ org, mode, message }` envelope — same shape as `putLanguage`.
+  // The pre-#213 cast-as-`PromptMode` had a latent bug where `result.name`
+  // was undefined on the wrapped response.
+  return unwrapModeResponse((await res.json()) as Record<string, unknown>);
 }
 
 export async function deleteMode(

--- a/src/lib/mode-scaffold.ts
+++ b/src/lib/mode-scaffold.ts
@@ -1,0 +1,10 @@
+import { PROMPT_SLOTS, SLOT_LABELS } from "@/types/prompt-override";
+
+// Canonical H2 scaffold a new mode opens with. The seven sections mirror
+// the worker's `toMarkdownView` synthesis (worker PR #213) so a freshly
+// created markdown mode and a not-yet-migrated slotted mode produce the
+// same structural shape on first GET — round-trip identity holds after
+// the first PUT migrates the record.
+export const MODE_DOCUMENT_SCAFFOLD = PROMPT_SLOTS.map(
+  (slot) => `## ${SLOT_LABELS[slot]}\n\n`
+).join("");

--- a/src/types/prompt-override.ts
+++ b/src/types/prompt-override.ts
@@ -42,11 +42,18 @@ export const SLOT_DESCRIPTIONS: Record<PromptSlot, string> = {
 
 export const MAX_SLOT_LENGTH = 8000;
 
+// Modes are stored as a single markdown document on the worker (worker
+// PR #213 / issue #200). The portal sends and receives markdown only;
+// the worker still accepts legacy slotted PUTs for back-compat but the
+// portal does not (per portal issue #82 AC). Legacy slot types
+// (`PromptOverrides`, `PROMPT_SLOTS`, etc.) remain in this file because
+// org-level prompt overrides (`/api/config/prompt-overrides`) are a
+// separate endpoint that has not been migrated.
 export interface PromptMode {
   name: string;
   label?: string;
   description?: string;
-  overrides: PromptOverrides;
+  document: string;
   published?: boolean;
 }
 

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,5 +1,6 @@
 export type Section =
   | "baruch"
+  | "modes"
   | "prompt-configuration"
   | "languages"
   | "admin-users";

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getMode, putMode } from "../src/lib/config-api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchOnce(status: number, body: unknown): void {
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+}
+
+describe("getMode", () => {
+  it("unwraps the wrapped worker response `{ org, mode }`", async () => {
+    mockFetchOnce(200, {
+      org: "uw",
+      mode: {
+        name: "spoken",
+        label: "Spoken",
+        document: "## Identity\n\nYou are…\n",
+        published: true,
+        format: "markdown",
+      },
+    });
+
+    const result = await getMode("spoken");
+
+    expect(result).toEqual({
+      name: "spoken",
+      label: "Spoken",
+      document: "## Identity\n\nYou are…\n",
+      published: true,
+      format: "markdown",
+    });
+  });
+
+  it("passes through the diagnostic `originalSlots` field on legacy modes", async () => {
+    // Worker #213 attaches `originalSlots` on GET for not-yet-migrated modes.
+    // The portal ignores it, but it must not be stripped or break the unwrap.
+    mockFetchOnce(200, {
+      org: "uw",
+      mode: {
+        name: "legacy",
+        document: "## Identity\n\nhi\n",
+        format: "markdown",
+        originalSlots: { identity: "hi" },
+      },
+    });
+
+    const result = await getMode("legacy");
+
+    expect(result.name).toBe("legacy");
+    expect(result.document).toBe("## Identity\n\nhi\n");
+  });
+
+  it("returns an already-unwrapped response unchanged (back-compat)", async () => {
+    mockFetchOnce(200, {
+      name: "spoken",
+      label: "Spoken",
+      document: "",
+      published: false,
+    });
+
+    const result = await getMode("spoken");
+
+    expect(result.name).toBe("spoken");
+  });
+
+  it("encodes the mode name in the URL path", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ mode: { name: "kids-mode", document: "" } })
+        )
+      );
+    await getMode("kids-mode");
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/kids-mode");
+  });
+
+  it("throws with the response body on 4xx", async () => {
+    mockFetchOnce(404, "Mode not found");
+    await expect(getMode("missing")).rejects.toThrow(
+      /Failed to load mode \(404\): Mode not found/
+    );
+  });
+});
+
+describe("putMode", () => {
+  it("unwraps the wrapped worker response `{ org, mode, message }`", async () => {
+    // Worker #213 wraps PUT response in the same envelope as GET. Before this
+    // PR the function cast the wrapped envelope directly as `PromptMode`, so
+    // `result.name` was undefined — same class of bug fixed for putLanguage
+    // in #106.
+    mockFetchOnce(200, {
+      org: "uw",
+      mode: {
+        name: "spoken",
+        label: "Spoken",
+        document: "## Identity\n\nYou are…\n",
+        published: false,
+      },
+      message: "Mode saved",
+    });
+
+    const result = await putMode("spoken", {
+      label: "Spoken",
+      document: "## Identity\n\nYou are…\n",
+      published: false,
+    });
+
+    expect(result).toEqual({
+      name: "spoken",
+      label: "Spoken",
+      document: "## Identity\n\nYou are…\n",
+      published: false,
+    });
+  });
+
+  it("sends the body as JSON with PUT method and `document` field", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "spoken", document: "" } }))
+      );
+    const body = {
+      label: "Spoken",
+      description: "Conversational",
+      document: "## Identity\n",
+      published: true,
+    };
+    await putMode("spoken", body);
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual(body);
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json"
+    );
+  });
+
+  it("does NOT send a legacy `overrides` field", async () => {
+    // Portal #82 AC: the mode editor handles only markdown — no legacy
+    // slot-map awareness in src/lib. The worker would reject a PUT that
+    // includes both `document` and `overrides`, so this is also a
+    // contract-safety check.
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "spoken", document: "" } }))
+      );
+    await putMode("spoken", { document: "## Identity\n" });
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    const parsed = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty("overrides");
+  });
+
+  it("encodes the mode name in the URL path", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ mode: { name: "kids-mode", document: "" } })
+        )
+      );
+    await putMode("kids-mode", { document: "" });
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/kids-mode");
+  });
+
+  it("throws with the response body on 4xx", async () => {
+    mockFetchOnce(400, "Mode document exceeds maximum length");
+    await expect(
+      putMode("spoken", { document: "x".repeat(64_001) })
+    ).rejects.toThrow(
+      /Failed to save mode \(400\): Mode document exceeds maximum length/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The worker shipped phase-1 mode data migration in PR #213 today (synthesizes markdown on GET, accepts `document` on PUT). This PR replaces the portal's six-box slotted mode editor with a single markdown editor + TOC, mirroring the languages page from #73, and removes legacy slot-map awareness from the portal-side per-mode editing path.

## Changes

- **`/modes` is a new route + sidebar entry** with the `faPenToSquare` icon. Markdown editor + TOC, autosave, pending-switch guards — all the patterns from `languages.tsx`.
- **`/prompt-configuration` is now org-overrides-only** and renamed "Prompt Overrides" in the sidebar with the `faSliders` icon. The worker didn't migrate `/api/config/prompt-overrides`, so it keeps the slotted six-box UI for now.
- **`PromptMode.overrides` → `PromptMode.document`** per #82's "no legacy slot-map awareness in `src/components` or `src/lib`" criterion. `PromptOverrides`/`PromptSlot`/`SLOT_LABELS` stay in the file because the org-overrides path still uses them.
- **`useSetModePublished` is dropped.** The new worker contract requires `document` on every PUT (exactly-one-of `document`/`overrides`, no partial path). Publish/unpublish flows through `useSaveMode` with the full body — same pattern as `useSaveLanguage` since #93.
- **Canonical 7-section scaffold for new modes** (`src/lib/mode-scaffold.ts`). Derived from `PROMPT_SLOTS` + `SLOT_LABELS` so the order matches the worker's synthesizer for an empty slotted mode — round-trip GET → PUT → GET is identity-equal at the section level.
- **Drive-by: `putMode` unwraps `{ org, mode, message }` envelope.** Same latent bug as the `putLanguage` envelope fix from #106 — `result.name` was undefined on the wrapped response.
- **10 new tests** in `tests/config-api.test.ts` covering `getMode`/`putMode` shape, envelope unwrap, document-only PUT body, URL encoding, 4xx error propagation, and an explicit "no legacy `overrides` field on the wire" assertion.

Closes #76, #82.

## Test plan

- [ ] Lint passes (zero warnings) — verified locally
- [ ] Typecheck passes — verified locally
- [ ] Build passes — verified locally
- [ ] All 52 vitest tests pass (10 new) — verified locally
- [ ] PR Worker deploys cleanly
- [ ] Manually: navigate to `/modes`, pick an existing slotted mode → see synthesized markdown with the 7 canonical H2s; edit + autosave; verify worker GET round-trips the new document
- [ ] Manually: create a new mode → opens with the 7-section scaffold; save → publish → unpublish without losing edits
- [ ] Manually: navigate to `/prompt-configuration` → org-level six-box still renders + saves; no mode selector
- [ ] Manually: confirm `selectedMode` persists across navigation between `/modes` and other routes