### PR TITLE
fix: UX cleanup — save errors, envelope unwrap, UI state leak (#113, #114, #116)

### DIFF
--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -92,6 +92,12 @@ export function LanguagesPage() {
   // Publish/Unpublish click reads stale `published` from the cache and the
   // PUT silently reverts the toggle (Frank P2 review of #93).
   const [lastSyncedPublished, setLastSyncedPublished] = useState(false);
+  // The most recently autosaved doc that failed. Used to pause autosave on
+  // the same draft until the user edits it again or hits Save manually — a
+  // failed save would otherwise retry indefinitely (Frank P2 on PR #122),
+  // hammering the API and flickering the error banner because TanStack
+  // clears `error` while a retry is `pending`.
+  const [lastFailedDoc, setLastFailedDoc] = useState<string | null>(null);
   const [headings, setHeadings] = useState<MarkdownHeading[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const activeLine = useActiveHeadingLine(textareaRef, draft, headings);
@@ -110,6 +116,7 @@ export function LanguagesPage() {
       setDraft("");
       setLastSyncedDoc("");
       setLastSyncedPublished(false);
+      setLastFailedDoc(null);
       return;
     }
     // Wait for the query data to arrive AND match the current selection
@@ -121,6 +128,7 @@ export function LanguagesPage() {
     setDraft(languageQuery.data.document);
     setLastSyncedDoc(languageQuery.data.document);
     setLastSyncedPublished(languageQuery.data.published ?? false);
+    setLastFailedDoc(null);
     syncedNameRef.current = selectedLanguage;
   }, [selectedLanguage, languageQuery.data]);
 
@@ -148,7 +156,13 @@ export function LanguagesPage() {
             published: lastSyncedPublished,
           },
         },
-        { onSuccess: () => setLastSyncedDoc(doc) }
+        {
+          onSuccess: () => {
+            setLastSyncedDoc(doc);
+            setLastFailedDoc(null);
+          },
+          onError: () => setLastFailedDoc(doc),
+        }
       );
     },
     [lastSyncedPublished, saveLanguage, selectedLanguage, serverLabel]
@@ -158,15 +172,25 @@ export function LanguagesPage() {
   // Re-runs when an in-flight save settles so a "save in progress, user
   // typed more" scenario flushes the newer edits as soon as the first
   // save returns.
+  //
+  // The `lastFailedDoc` gate pauses autosave for a draft that already
+  // failed once — without it, the effect would re-fire as soon as
+  // `isPending` flips back to false, putting us in an indefinite retry
+  // loop that hammers the API and flickers the error banner. The user
+  // recovers by either (a) editing the draft (changes `debouncedDraft`)
+  // or (b) clicking Save manually (which routes through `flushSave` and
+  // explicitly retries the failed doc).
   useEffect(() => {
     if (!selectedLanguage) return;
     if (saveLanguage.isPending) return;
     if (debouncedDraft === lastSyncedDoc) return;
+    if (debouncedDraft === lastFailedDoc) return;
     performSave(debouncedDraft);
   }, [
     debouncedDraft,
     saveLanguage.isPending,
     lastSyncedDoc,
+    lastFailedDoc,
     performSave,
     selectedLanguage,
   ]);

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -306,6 +306,18 @@ export function LanguagesPage() {
     return null;
   }, [saveError, deleteError, loadError]);
   const error = forbiddenError ? null : loadError;
+  // Surface non-forbidden save / delete failures so the user can see *why* a
+  // save didn't stick — previously these were silently swallowed, leaving the
+  // "Unsaved changes" chip stuck without any explanation.
+  const genericMutationError = useMemo<Error | null>(() => {
+    if (saveError && !(saveError instanceof LanguageForbiddenError)) {
+      return saveError;
+    }
+    if (deleteError && !(deleteError instanceof LanguageForbiddenError)) {
+      return deleteError;
+    }
+    return null;
+  }, [saveError, deleteError]);
 
   const saveStatus = useMemo(() => {
     if (isSaving) return "Saving…";
@@ -365,8 +377,21 @@ export function LanguagesPage() {
       </div>
 
       {error && (
-        <div className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm">
+        <div
+          className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm"
+          role="alert"
+        >
           {error.message}
+        </div>
+      )}
+
+      {genericMutationError && (
+        <div
+          className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm"
+          role="alert"
+          aria-live="polite"
+        >
+          Save failed: {genericMutationError.message}
         </div>
       )}
 

--- a/src/app/pages/manual-config.tsx
+++ b/src/app/pages/manual-config.tsx
@@ -42,8 +42,21 @@ export function ManualConfigPage() {
       <div className="config-grid-bg min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="space-y-4 sm:space-y-6">
           {orgOverrides.error && (
-            <div className="bg-destructive/10 text-destructive border-destructive rounded-lg border-l-2 px-4 py-3 text-sm">
+            <div
+              className="bg-destructive/10 text-destructive border-destructive rounded-lg border-l-2 px-4 py-3 text-sm"
+              role="alert"
+            >
               {orgOverrides.error.message}
+            </div>
+          )}
+
+          {updateOrg.error && (
+            <div
+              className="bg-destructive/10 text-destructive border-destructive rounded-lg border-l-2 px-4 py-3 text-sm"
+              role="alert"
+              aria-live="polite"
+            >
+              Save failed: {updateOrg.error.message}
             </div>
           )}
 

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -59,6 +59,11 @@ export function ModesPage() {
   const [draft, setDraft] = useState("");
   const [lastSyncedDoc, setLastSyncedDoc] = useState("");
   const [lastSyncedPublished, setLastSyncedPublished] = useState(false);
+  // Pauses autosave on a draft that already failed once, so a failed save
+  // doesn't loop on every isPending → false transition (Frank P2 on
+  // PR #122). User recovers by editing further (changes debouncedDraft) or
+  // by clicking Save manually (which routes through `flushSave`).
+  const [lastFailedDoc, setLastFailedDoc] = useState<string | null>(null);
   const [headings, setHeadings] = useState<MarkdownHeading[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const activeLine = useActiveHeadingLine(textareaRef, draft, headings);
@@ -74,6 +79,7 @@ export function ModesPage() {
       setDraft("");
       setLastSyncedDoc("");
       setLastSyncedPublished(false);
+      setLastFailedDoc(null);
       return;
     }
     if (!modeQuery.data) return;
@@ -82,6 +88,7 @@ export function ModesPage() {
     setDraft(modeQuery.data.document);
     setLastSyncedDoc(modeQuery.data.document);
     setLastSyncedPublished(modeQuery.data.published ?? false);
+    setLastFailedDoc(null);
     syncedNameRef.current = selectedMode;
   }, [selectedMode, modeQuery.data]);
 
@@ -102,7 +109,13 @@ export function ModesPage() {
             published: lastSyncedPublished,
           },
         },
-        { onSuccess: () => setLastSyncedDoc(doc) }
+        {
+          onSuccess: () => {
+            setLastSyncedDoc(doc);
+            setLastFailedDoc(null);
+          },
+          onError: () => setLastFailedDoc(doc),
+        }
       );
     },
     [
@@ -118,11 +131,13 @@ export function ModesPage() {
     if (!selectedMode) return;
     if (saveMode.isPending) return;
     if (debouncedDraft === lastSyncedDoc) return;
+    if (debouncedDraft === lastFailedDoc) return;
     performSave(debouncedDraft);
   }, [
     debouncedDraft,
     saveMode.isPending,
     lastSyncedDoc,
+    lastFailedDoc,
     performSave,
     selectedMode,
   ]);

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -157,6 +157,17 @@ export function ModesPage() {
     setPendingSwitch(null);
   }, [pendingSwitch, setSelectedMode]);
 
+  // Drop a stale `selectedMode` if it's no longer present in the list (admin
+  // deleted it, or the value persisted across a user switch on the same tab).
+  // Mirrors the parallel guard in `languages.tsx` and is defense-in-depth
+  // alongside `use-auth.ts` resetting the UI store on every login (#116).
+  useEffect(() => {
+    if (selectedMode === null) return;
+    if (!modesQuery.data) return;
+    if (modesQuery.data.modes.some((m) => m.name === selectedMode)) return;
+    setSelectedMode(null);
+  }, [selectedMode, modesQuery.data, setSelectedMode]);
+
   const handleCreateMode = useCallback(
     (name: string, label: string, description: string) => {
       saveMode.mutate(
@@ -224,6 +235,7 @@ export function ModesPage() {
 
   const error =
     modesQuery.error || (selectedMode !== null ? modeQuery.error : null);
+  const saveError = saveMode.error ?? deleteMode.error;
 
   const saveStatus = useMemo(() => {
     if (isSaving) return "Saving…";
@@ -281,8 +293,21 @@ export function ModesPage() {
       </div>
 
       {error && (
-        <div className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm">
+        <div
+          className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm"
+          role="alert"
+        >
           {error.message}
+        </div>
+      )}
+
+      {saveError && (
+        <div
+          className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm"
+          role="alert"
+          aria-live="polite"
+        >
+          Save failed: {saveError.message}
         </div>
       )}
 

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -14,12 +14,18 @@ export function useAuth() {
 
   const login = useCallback(
     async (email: string, password: string) => {
+      // Reset persisted UI selections (`selectedMode`, `selectedLanguage`,
+      // etc.) on every login. Without this, a session-expiry → fresh-login on
+      // the same tab carries the previous user's selections into the new
+      // session, which is confusing at best and a privacy smell at worst.
+      // `logout()` already resets but is not reached on cookie-expiry flows.
+      resetUi();
       queryClient.clear();
       const authedUser = await authApi.login(email, password);
       setUser(authedUser);
       void navigate("/", { replace: true });
     },
-    [queryClient, setUser, navigate]
+    [queryClient, resetUi, setUser, navigate]
   );
 
   const logout = useCallback(async () => {

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -13,6 +13,23 @@ const SAME_ORIGIN_HEADERS = {
 // Org-level prompt overrides
 // ---------------------------------------------------------------------------
 
+function unwrapOverridesResponse(
+  data: Record<string, unknown>
+): PromptOverrides {
+  // Engine wraps the overrides in `{ prompt_overrides: {...} }` or
+  // `{ org, overrides: {...}, message? }`. GET has always unwrapped these;
+  // PUT used to cast the envelope directly, which left callers reading
+  // `result.identity` as undefined — same class of bug as the `putLanguage`
+  // / `putMode` envelope fixes from #106 / #110.
+  if ("prompt_overrides" in data && typeof data.prompt_overrides === "object") {
+    return data.prompt_overrides as PromptOverrides;
+  }
+  if ("overrides" in data && typeof data.overrides === "object") {
+    return data.overrides as PromptOverrides;
+  }
+  return data as unknown as PromptOverrides;
+}
+
 export async function getOrgOverrides(
   signal?: AbortSignal
 ): Promise<PromptOverrides> {
@@ -26,15 +43,7 @@ export async function getOrgOverrides(
     throw new Error(`Failed to load overrides (${res.status}): ${body}`);
   }
 
-  const data = (await res.json()) as Record<string, unknown>;
-
-  // Engine API may wrap overrides in { prompt_overrides: {...} } or { org, overrides: {...} }
-  if ("prompt_overrides" in data && typeof data.prompt_overrides === "object") {
-    return data.prompt_overrides as PromptOverrides;
-  } else if ("overrides" in data && typeof data.overrides === "object") {
-    return data.overrides as PromptOverrides;
-  }
-  return data as unknown as PromptOverrides;
+  return unwrapOverridesResponse((await res.json()) as Record<string, unknown>);
 }
 
 export async function putOrgOverrides(
@@ -53,7 +62,7 @@ export async function putOrgOverrides(
     throw new Error(`Failed to save overrides (${res.status}): ${body}`);
   }
 
-  return (await res.json()) as PromptOverrides;
+  return unwrapOverridesResponse((await res.json()) as Record<string, unknown>);
 }
 
 export async function deleteOrgOverrides(signal?: AbortSignal): Promise<void> {

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getMode, putMode } from "../src/lib/config-api";
+import {
+  getMode,
+  getOrgOverrides,
+  putMode,
+  putOrgOverrides,
+} from "../src/lib/config-api";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -177,6 +182,91 @@ describe("putMode", () => {
       putMode("spoken", { document: "x".repeat(64_001) })
     ).rejects.toThrow(
       /Failed to save mode \(400\): Mode document exceeds maximum length/
+    );
+  });
+});
+
+describe("getOrgOverrides", () => {
+  it("unwraps `{ prompt_overrides }` envelope", async () => {
+    mockFetchOnce(200, {
+      prompt_overrides: { identity: "hi", closing: "bye" },
+    });
+
+    const result = await getOrgOverrides();
+
+    expect(result).toEqual({ identity: "hi", closing: "bye" });
+  });
+
+  it("unwraps `{ org, overrides }` envelope", async () => {
+    mockFetchOnce(200, {
+      org: "uw",
+      overrides: { identity: "hi" },
+    });
+
+    const result = await getOrgOverrides();
+
+    expect(result).toEqual({ identity: "hi" });
+  });
+
+  it("returns an already-unwrapped response unchanged (back-compat)", async () => {
+    mockFetchOnce(200, { identity: "hi", closing: "bye" });
+
+    const result = await getOrgOverrides();
+
+    expect(result).toEqual({ identity: "hi", closing: "bye" });
+  });
+});
+
+describe("putOrgOverrides", () => {
+  it("unwraps `{ org, overrides, message }` envelope", async () => {
+    // Pre-fix the cast-as-PromptOverrides returned the wrapper, so a caller
+    // reading `result.identity` got undefined. Same class of bug as the
+    // putLanguage/putMode envelope fixes from #106 / #110.
+    mockFetchOnce(200, {
+      org: "uw",
+      overrides: { identity: "hi", closing: "bye" },
+      message: "Overrides saved",
+    });
+
+    const result = await putOrgOverrides({ identity: "hi", closing: "bye" });
+
+    expect(result).toEqual({ identity: "hi", closing: "bye" });
+  });
+
+  it("unwraps `{ prompt_overrides }` envelope", async () => {
+    mockFetchOnce(200, {
+      prompt_overrides: { identity: "hi" },
+    });
+
+    const result = await putOrgOverrides({ identity: "hi" });
+
+    expect(result).toEqual({ identity: "hi" });
+  });
+
+  it("returns an already-unwrapped response unchanged (back-compat)", async () => {
+    mockFetchOnce(200, { identity: "hi" });
+
+    const result = await putOrgOverrides({ identity: "hi" });
+
+    expect(result).toEqual({ identity: "hi" });
+  });
+
+  it("sends the body as JSON with PUT method", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ overrides: { identity: "hi" } }))
+      );
+    await putOrgOverrides({ identity: "hi" });
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual({ identity: "hi" });
+  });
+
+  it("throws with the response body on 4xx", async () => {
+    mockFetchOnce(403, "Forbidden");
+    await expect(putOrgOverrides({ identity: "hi" })).rejects.toThrow(
+      /Failed to save overrides \(403\): Forbidden/
     );
   });
 });


### PR DESCRIPTION
## Summary

Closes **#113**, **#114**, **#116**. Three UX/quality fixes from the retrospective audit, batched into one PR because they share files and reinforce each other.

## Changes

### `putOrgOverrides` envelope unwrap (#113)

`putOrgOverrides` was casting the engine's wrapped PUT response (`{ org, overrides, message }` or `{ prompt_overrides }`) directly to `PromptOverrides`, so callers reading `result.identity` got undefined. **Third instance** of the same pattern fixed for `putLanguage` in #106 and `putMode` in #110.

Extracted a shared `unwrapOverridesResponse` helper used by both `getOrgOverrides` and `putOrgOverrides`. 8 new tests covering both envelope shapes, back-compat, body shape, and error propagation.

### Save errors are now visible (#114)

A failed `saveMode` / `useUpdateOrgOverrides` / `saveLanguage` previously left the autosave chip stuck on \"Unsaved changes\" with no explanation. Added a \"Save failed: \<message\>\" banner on all three pages:

- \`modes.tsx\` — surfaces \`saveMode.error\` and \`deleteMode.error\` (combined).
- \`manual-config.tsx\` — surfaces \`updateOrg.error\` next to the existing load-error banner.
- \`languages.tsx\` — added a \`genericMutationError\` derivation that filters out \`LanguageForbiddenError\` (those already render in the dedicated banner) so a 401/500/etc. save failure no longer gets silently swallowed by \`error = forbiddenError ? null : loadError\`.

All three banners are \`role=\"alert\"\` + \`aria-live=\"polite\"\`.

### Persisted UI selections reset on login (#116)

\`useAuth.login\` now calls \`resetUi()\` symmetrically with \`logout\`. A session-expiry → fresh-login on the same tab no longer carries the previous user's \`selectedMode\` / \`selectedLanguage\` / \`chatMode\` into the new session.

Added a defensive useEffect on \`modes.tsx\` parallel to \`languages.tsx:207-211\`: if \`selectedMode\` references a mode no longer in the list (admin deleted, or rare race), drop the selection. Defense-in-depth alongside the login reset.

## Tests

8 new in \`tests/config-api.test.ts\` (getOrgOverrides + putOrgOverrides envelopes). **60 tests passing total**, lint/typecheck/build all green.

## Out of scope

- #117 (chat-stream \`user_id\` ownership) — deferred to a separate design discussion (UUID generation moved server-side or KV-tracked).
- Test backfills (#118, #119, #120) — next PR in the batch.

## Related

Builds on the retrospective findings: #112 / #113 / #114 / #115 / #116 / #117 / #118 / #119 / #120.