### PR TITLE
test: backfill permissions + markdown-headings parser (#118, #119)

### DIFF
--- a/tests/markdown-headings.test.ts
+++ b/tests/markdown-headings.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import { parseHeadings } from "../src/lib/markdown-headings";
+
+// `parseHeadings` is a state-machine parser shared by the modes + languages
+// markdown editors (from #75 / PR #85). Behavior pinned here:
+//   - ATX H1/H2/H3 only; H4-H6 and setext styles ignored.
+//   - Fenced code blocks (``` and ~~~) suppress headings inside.
+//   - Ulysses-style `%%` paragraph comments and `++…++` inline spans
+//     suppress / strip heading content per the syntax in #77 (Tim Jore /
+//     help.ulysses.app).
+//   - Duplicate slugs get `-N` suffixes; symbol-only headings fall back
+//     to `section`.
+
+describe("parseHeadings — basic ATX headings", () => {
+  it("parses H1/H2/H3 at the correct levels with line numbers", () => {
+    const doc = ["# Top", "", "## Section", "", "### Subsection"].join("\n");
+    expect(parseHeadings(doc)).toEqual([
+      { level: 1, text: "Top", slug: "top", line: 0 },
+      { level: 2, text: "Section", slug: "section", line: 2 },
+      { level: 3, text: "Subsection", slug: "subsection", line: 4 },
+    ]);
+  });
+
+  it("ignores H4–H6 (regex caps at three hashes)", () => {
+    const doc = ["#### Four", "##### Five", "###### Six"].join("\n");
+    expect(parseHeadings(doc)).toEqual([]);
+  });
+
+  it("ignores setext (===, ---) underline-style headings", () => {
+    const doc = ["Top", "====", "", "Sub", "----"].join("\n");
+    expect(parseHeadings(doc)).toEqual([]);
+  });
+
+  it("strips trailing closing hashes (`## Title ##` → `Title`)", () => {
+    expect(parseHeadings("## Title ##")).toEqual([
+      { level: 2, text: "Title", slug: "title", line: 0 },
+    ]);
+  });
+
+  it("skips a heading with only whitespace as body", () => {
+    expect(parseHeadings("##   ")).toEqual([]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const doc = "# A\r\n\r\n## B";
+    expect(parseHeadings(doc).map((h) => h.text)).toEqual(["A", "B"]);
+  });
+});
+
+describe("parseHeadings — fenced code blocks", () => {
+  it("ignores ATX headings inside ``` fences", () => {
+    const doc = [
+      "## Before",
+      "```",
+      "## not a heading",
+      "### nope",
+      "```",
+      "## After",
+    ].join("\n");
+    expect(parseHeadings(doc).map((h) => h.text)).toEqual(["Before", "After"]);
+  });
+
+  it("ignores ATX headings inside ~~~ fences", () => {
+    const doc = [
+      "## Before",
+      "~~~",
+      "## not a heading",
+      "~~~",
+      "## After",
+    ].join("\n");
+    expect(parseHeadings(doc).map((h) => h.text)).toEqual(["Before", "After"]);
+  });
+
+  it("requires a matching closing fence — unclosed fence swallows the rest", () => {
+    const doc = ["## Before", "```", "## inside", "## still inside"].join("\n");
+    expect(parseHeadings(doc).map((h) => h.text)).toEqual(["Before"]);
+  });
+});
+
+describe("parseHeadings — `%%` paragraph comments", () => {
+  it("suppresses an ATX heading on a `%%`-prefixed line", () => {
+    expect(parseHeadings("%% ## not a real heading")).toEqual([]);
+  });
+
+  it("suppresses headings within a `%%` paragraph until blank line", () => {
+    const doc = [
+      "%% start of comment",
+      "## still in comment",
+      "more comment",
+      "",
+      "## After blank line",
+    ].join("\n");
+    expect(parseHeadings(doc).map((h) => h.text)).toEqual(["After blank line"]);
+  });
+
+  it("a `%%` mid-paragraph (not at start) does not start a comment block", () => {
+    const doc = ["lead-in text %% mid-line", "## After"].join("\n");
+    expect(parseHeadings(doc).map((h) => h.text)).toEqual(["After"]);
+  });
+});
+
+describe("parseHeadings — `++…++` inline spans", () => {
+  it("strips inline `++…++` content from heading text", () => {
+    expect(parseHeadings("## Title ++hidden++ visible")).toEqual([
+      { level: 2, text: "Title visible", slug: "title-visible", line: 0 },
+    ]);
+  });
+
+  it("suppresses headings inside a multi-line `++…++` span", () => {
+    const doc = [
+      "start ++span open",
+      "## suppressed",
+      "span close++",
+      "## After",
+    ].join("\n");
+    expect(parseHeadings(doc).map((h) => h.text)).toEqual(["After"]);
+  });
+
+  it("two `++` tokens on the same line toggle paired and back (heading emits)", () => {
+    expect(parseHeadings("## A ++stripped++ B")).toEqual([
+      { level: 2, text: "A B", slug: "a-b", line: 0 },
+    ]);
+  });
+});
+
+describe("parseHeadings — slug uniqueness + fallback", () => {
+  it("appends -2, -3 to duplicate slugs in document order", () => {
+    const doc = ["## Section", "", "## Section", "", "## Section"].join("\n");
+    expect(parseHeadings(doc).map((h) => h.slug)).toEqual([
+      "section",
+      "section-2",
+      "section-3",
+    ]);
+  });
+
+  it("symbol-only heading text falls back to slug 'section'", () => {
+    // After punctuation→hyphen and stripping leading/trailing hyphens, the
+    // result is empty — `slugify` falls back to "section". The unique-counter
+    // still increments off "section" so a real `## Section` later collides
+    // intentionally.
+    expect(parseHeadings("## ???")).toEqual([
+      { level: 2, text: "???", slug: "section", line: 0 },
+    ]);
+  });
+
+  it("lowercases and hyphenates the slug", () => {
+    expect(parseHeadings("## My Cool Heading!")).toEqual([
+      { level: 2, text: "My Cool Heading!", slug: "my-cool-heading", line: 0 },
+    ]);
+  });
+});
+
+describe("parseHeadings — combined / regression", () => {
+  it("ignores comment + fence + span in one document", () => {
+    const doc = [
+      "# Title", // 0 → emit
+      "",
+      "%% commented", // 2 → comment block
+      "## inside-comment", // 3 → suppressed
+      "",
+      "## After-comment", // 5 → emit
+      "```", // 6 → fence open
+      "## inside-fence", // 7 → suppressed
+      "```", // 8 → fence close
+      "++span", // 9 → span open
+      "## inside-span", // 10 → suppressed
+      "span++", // 11 → span close
+      "## End", // 12 → emit
+    ].join("\n");
+    expect(
+      parseHeadings(doc).map((h) => ({ text: h.text, line: h.line }))
+    ).toEqual([
+      { text: "Title", line: 0 },
+      { text: "After-comment", line: 5 },
+      { text: "End", line: 12 },
+    ]);
+  });
+});

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterAuthorizedLanguages,
+  hasAnyLanguageRights,
+  hasLanguageRights,
+} from "../src/lib/permissions";
+
+// Trinary back-compat is load-bearing for this file:
+//   undefined → full access (predates language_rights)
+//   "*"       → full access (explicit)
+//   string[]  → explicit allowlist
+// All three branches are exercised so a refactor that collapses them
+// (e.g. tightening `undefined` to "no access") fails loudly here.
+
+describe("hasLanguageRights", () => {
+  it("undefined → true (back-compat for users predating language_rights)", () => {
+    expect(hasLanguageRights(undefined, "en")).toBe(true);
+    expect(hasLanguageRights(undefined, "anything")).toBe(true);
+  });
+
+  it("'*' → true for any name", () => {
+    expect(hasLanguageRights("*", "en")).toBe(true);
+    expect(hasLanguageRights("*", "fr")).toBe(true);
+    expect(hasLanguageRights("*", "")).toBe(true);
+  });
+
+  it("array containing the name → true", () => {
+    expect(hasLanguageRights(["en", "fr"], "en")).toBe(true);
+    expect(hasLanguageRights(["en", "fr"], "fr")).toBe(true);
+  });
+
+  it("array missing the name → false", () => {
+    expect(hasLanguageRights(["en", "fr"], "es")).toBe(false);
+  });
+
+  it("empty array → false (explicit deny-all)", () => {
+    expect(hasLanguageRights([], "en")).toBe(false);
+    expect(hasLanguageRights([], "anything")).toBe(false);
+  });
+
+  it("is case-sensitive on the name comparison", () => {
+    // The engine names are slugs (lowercase), so this is a contract check —
+    // we don't want a silent case-insensitive comparison sneaking in.
+    expect(hasLanguageRights(["en"], "EN")).toBe(false);
+  });
+});
+
+describe("hasAnyLanguageRights", () => {
+  it("undefined → true (back-compat)", () => {
+    expect(hasAnyLanguageRights(undefined)).toBe(true);
+  });
+
+  it("'*' → true", () => {
+    expect(hasAnyLanguageRights("*")).toBe(true);
+  });
+
+  it("non-empty array → true", () => {
+    expect(hasAnyLanguageRights(["en"])).toBe(true);
+    expect(hasAnyLanguageRights(["en", "fr"])).toBe(true);
+  });
+
+  it("empty array → false (explicit deny-all)", () => {
+    expect(hasAnyLanguageRights([])).toBe(false);
+  });
+});
+
+describe("filterAuthorizedLanguages", () => {
+  const all = [
+    { name: "en", label: "English" },
+    { name: "fr", label: "French" },
+    { name: "es", label: "Spanish" },
+  ];
+
+  it("undefined → returns input unchanged", () => {
+    expect(filterAuthorizedLanguages(all, undefined)).toEqual(all);
+  });
+
+  it("'*' → returns input unchanged", () => {
+    expect(filterAuthorizedLanguages(all, "*")).toEqual(all);
+  });
+
+  it("array → filters to the allowed names", () => {
+    expect(filterAuthorizedLanguages(all, ["en", "es"])).toEqual([
+      { name: "en", label: "English" },
+      { name: "es", label: "Spanish" },
+    ]);
+  });
+
+  it("preserves input order under array form", () => {
+    // Output order follows the input array's order, not the rights' order —
+    // important so the dropdown stays alphabetized regardless of how the
+    // rights array was constructed.
+    const out = filterAuthorizedLanguages(all, ["es", "en"]);
+    expect(out.map((l) => l.name)).toEqual(["en", "es"]);
+  });
+
+  it("empty rights → empty output", () => {
+    expect(filterAuthorizedLanguages(all, [])).toEqual([]);
+  });
+
+  it("rights with unknown names → just drops the unknowns", () => {
+    expect(filterAuthorizedLanguages(all, ["en", "klingon"])).toEqual([
+      { name: "en", label: "English" },
+    ]);
+  });
+
+  it("preserves the full input object shape (generic over T)", () => {
+    const richer = [
+      { name: "en", label: "English", published: true, document: "..." },
+      { name: "fr", label: "French", published: false, document: "..." },
+    ];
+    const out = filterAuthorizedLanguages(richer, ["en"]);
+    expect(out).toEqual([
+      { name: "en", label: "English", published: true, document: "..." },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes **#118**, **#119**. High-value test backfill from the retrospective audit. Two pure helpers with non-trivial logic — both load-bearing and untested until now.

## Why these two first

### \`src/lib/permissions.ts\` (#118) — sole portal-side language gate

The trusted-portal model means the engine carries no user identity on admin paths; the portal worker (and these helpers) are the only gates. The trinary back-compat (\`undefined\` → full, \`"*"\` → full, \`string[]\` → explicit) is exactly the shape a refactor could silently collapse.

18 tests across the three functions:
- \`hasLanguageRights\` — undefined, \`"*"\`, allow-list hit, allow-list miss, empty array (deny-all), case-sensitivity
- \`hasAnyLanguageRights\` — undefined, \`"*"\`, non-empty, empty
- \`filterAuthorizedLanguages\` — pass-through under undefined / \`"*"\`, filter on array, **preserves input order** (so the dropdown stays alphabetized regardless of how the rights array was constructed), empty rights → empty output, unknown names dropped, generic-over-T shape preservation

### \`src/lib/markdown-headings.ts\` (#119) — modes + languages editor TOC parser

State-machine parser shipped in #75 / PR #85. Interleaved suppression states (fence, paragraph comment, inline span) make this prone to subtle breakage on refactor — and #77 will add more comment syntax soon.

18 tests across:
- Basic ATX H1/H2/H3 at correct levels + line numbers; H4-H6 and setext ignored; closing-hash trim; CRLF
- Fenced code blocks (\` \`\`\` \` and \`~~~\`); unclosed fence swallows rest
- \`%%\` paragraph comments — only trigger at paragraph start; terminate at blank line
- \`++…++\` inline spans — strip from heading text; multi-line spans suppress; paired-on-same-line toggles back
- Slug uniqueness (-2/-3 suffixes); symbol-only fallback to \"section\"; lowercase + hyphenate
- **Combined regression**: one document with all suppression states interleaved so future refactors that break one state's interaction with another fail loudly

## Verification

\`npx vitest run\` — **105 tests across 9 files** (36 new), lint + typecheck + build all green locally.

## Out of scope

- #120 (admin-users-api + remaining config-api / languages-api gaps) — next PR in the batch.
- #117 (chat-stream \`user_id\` ownership) — deferred to a separate design discussion.