### PR TITLE
test: backfill API client coverage (#120)

### DIFF
--- a/tests/admin-users-api.test.ts
+++ b/tests/admin-users-api.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AdminUsersForbiddenError,
+  AdminUsersRequestError,
+  createAdminUser,
+  deleteAdminUser,
+  listAdminUsers,
+  updateAdminUser,
+} from "../src/lib/admin-users-api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchOnce(status: number, body: unknown): void {
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+}
+
+const SAMPLE_USER = {
+  id: "abc-123",
+  email: "alice@acme.com",
+  name: "Alice",
+  org: "acme",
+  isAdmin: true,
+};
+
+describe("listAdminUsers", () => {
+  it("returns `data.users` from the JSON envelope", async () => {
+    mockFetchOnce(200, { users: [SAMPLE_USER] });
+    const users = await listAdminUsers();
+    expect(users).toEqual([SAMPLE_USER]);
+  });
+
+  it("sends X-Requested-With on the same-origin marker", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ users: [] })));
+    await listAdminUsers();
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe(
+      "XMLHttpRequest"
+    );
+  });
+
+  it("throws AdminUsersForbiddenError on 403", async () => {
+    mockFetchOnce(403, { error: "Forbidden" });
+    await expect(listAdminUsers()).rejects.toBeInstanceOf(
+      AdminUsersForbiddenError
+    );
+  });
+
+  it("throws AdminUsersRequestError with status preserved on non-403 4xx", async () => {
+    mockFetchOnce(401, { error: "Unauthorized" });
+    await expect(listAdminUsers()).rejects.toMatchObject({
+      name: "AdminUsersRequestError",
+      status: 401,
+    });
+  });
+});
+
+describe("createAdminUser", () => {
+  it("sends the body as JSON via POST and returns `data.user`", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ user: SAMPLE_USER }), { status: 201 })
+      );
+    const body = {
+      email: "alice@acme.com",
+      password: "exactly8c",
+      name: "Alice",
+      org: "acme",
+    };
+    const result = await createAdminUser(body);
+    expect(result).toEqual(SAMPLE_USER);
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual(body);
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json"
+    );
+  });
+
+  it("AdminUsersForbiddenError surfaces the server's error message", async () => {
+    mockFetchOnce(403, { error: "Cannot create user outside your org (acme)" });
+    try {
+      await createAdminUser({
+        email: "x@other.com",
+        password: "exactly8c",
+        name: "X",
+        org: "other",
+      });
+      throw new Error("expected rejection");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AdminUsersForbiddenError);
+      const err = e as AdminUsersForbiddenError;
+      expect(err.serverMessage).toBe(
+        "Cannot create user outside your org (acme)"
+      );
+      expect(err.message).toBe("Cannot create user outside your org (acme)");
+    }
+  });
+
+  it("AdminUsersRequestError preserves status on 409 duplicate", async () => {
+    mockFetchOnce(409, { error: "User already exists" });
+    try {
+      await createAdminUser({
+        email: "alice@acme.com",
+        password: "exactly8c",
+        name: "Alice",
+        org: "acme",
+      });
+      throw new Error("expected rejection");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AdminUsersRequestError);
+      const err = e as AdminUsersRequestError;
+      expect(err.status).toBe(409);
+      expect(err.serverMessage).toBe("User already exists");
+    }
+  });
+});
+
+describe("updateAdminUser", () => {
+  it("URL-encodes the email in the path and sends PUT", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ user: SAMPLE_USER }))
+      );
+    await updateAdminUser("user+tag@acme.com", { name: "Updated" });
+    expect(spy.mock.calls[0]![0]).toBe(
+      "/api/admin/users/user%2Btag%40acme.com"
+    );
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("returns `data.user` on success", async () => {
+    mockFetchOnce(200, { user: SAMPLE_USER });
+    const result = await updateAdminUser("alice@acme.com", { name: "Alice" });
+    expect(result).toEqual(SAMPLE_USER);
+  });
+
+  it("400 self-demote → AdminUsersRequestError with status", async () => {
+    mockFetchOnce(400, { error: "Cannot demote yourself" });
+    await expect(
+      updateAdminUser("alice@acme.com", { isAdmin: false })
+    ).rejects.toMatchObject({
+      name: "AdminUsersRequestError",
+      status: 400,
+    });
+  });
+
+  it("404 cross-org → AdminUsersRequestError (not Forbidden)", async () => {
+    // Worker returns 404 (not 403) on cross-org targets to avoid existence
+    // enumeration. The client must surface it as a request error, not a
+    // forbidden error, so the dialog renders the right copy.
+    mockFetchOnce(404, { error: "User not found" });
+    await expect(
+      updateAdminUser("carol@other.com", { name: "X" })
+    ).rejects.toMatchObject({
+      name: "AdminUsersRequestError",
+      status: 404,
+    });
+  });
+});
+
+describe("deleteAdminUser", () => {
+  it("sends DELETE and URL-encodes the email", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await deleteAdminUser("user+tag@acme.com");
+    expect(spy.mock.calls[0]![0]).toBe(
+      "/api/admin/users/user%2Btag%40acme.com"
+    );
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("403 → AdminUsersForbiddenError", async () => {
+    mockFetchOnce(403, { error: "Forbidden" });
+    await expect(deleteAdminUser("alice@acme.com")).rejects.toBeInstanceOf(
+      AdminUsersForbiddenError
+    );
+  });
+
+  it("400 self-delete → AdminUsersRequestError", async () => {
+    mockFetchOnce(400, { error: "Cannot delete yourself" });
+    await expect(deleteAdminUser("alice@acme.com")).rejects.toMatchObject({
+      name: "AdminUsersRequestError",
+      status: 400,
+    });
+  });
+});
+
+describe("error parsing edge cases", () => {
+  it("readErrorMessage tolerates a non-JSON error body (undefined message)", async () => {
+    // The worker returns JSON via errorResponse, but defense-in-depth: if a
+    // proxy or CDN ever rewrites the body to HTML/plaintext, the client must
+    // not crash on the JSON parse.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("<html>oops</html>", {
+        status: 500,
+        headers: { "Content-Type": "text/html" },
+      })
+    );
+    try {
+      await listAdminUsers();
+      throw new Error("expected rejection");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AdminUsersRequestError);
+      const err = e as AdminUsersRequestError;
+      expect(err.status).toBe(500);
+      expect(err.serverMessage).toBeUndefined();
+      // Falls back to the default "Request failed (500)" message.
+      expect(err.message).toBe("Request failed (500)");
+    }
+  });
+});

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  clearUserMode,
+  deleteMode,
+  deleteUserMemory,
   getMode,
   getOrgOverrides,
+  getUserMemory,
+  listModes,
   putMode,
   putOrgOverrides,
+  setUserMode,
 } from "../src/lib/config-api";
 
 afterEach(() => {
@@ -267,6 +273,154 @@ describe("putOrgOverrides", () => {
     mockFetchOnce(403, "Forbidden");
     await expect(putOrgOverrides({ identity: "hi" })).rejects.toThrow(
       /Failed to save overrides \(403\): Forbidden/
+    );
+  });
+});
+
+describe("listModes", () => {
+  it("returns the response JSON unchanged", async () => {
+    const payload = { modes: [{ name: "spoken", document: "" }] };
+    mockFetchOnce(200, payload);
+    expect(await listModes()).toEqual(payload);
+  });
+
+  it("sends a GET to the modes endpoint with the same-origin marker", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ modes: [] })));
+    await listModes();
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes");
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe(
+      "XMLHttpRequest"
+    );
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetchOnce(500, "Engine error");
+    await expect(listModes()).rejects.toThrow(/Failed to load modes \(500\)/);
+  });
+});
+
+describe("deleteMode", () => {
+  it("sends DELETE and URL-encodes the name", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await deleteMode("kids-mode");
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/kids-mode");
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("throws on non-ok response with status + body", async () => {
+    mockFetchOnce(404, "Mode not found");
+    await expect(deleteMode("missing")).rejects.toThrow(
+      /Failed to delete mode \(404\): Mode not found/
+    );
+  });
+});
+
+// User-memory + user-mode endpoints take a UUID-v4 user id that the worker
+// validates upstream (`worker/config.ts`); the client's job is to URL-encode
+// it and use the right method + body shape. A refactor that breaks `{ mode }`
+// to `{ name }` on `setUserMode` would silently 400 at the worker, so the
+// body-shape assertion is load-bearing.
+const SAMPLE_UUID = "abc12345-6789-4abc-89ab-cdef01234567";
+
+describe("getUserMemory", () => {
+  it("sends GET with URL-encoded user id", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ memory: {} })));
+    await getUserMemory(SAMPLE_UUID);
+    expect(spy.mock.calls[0]![0]).toBe(
+      `/api/config/user-memory/${SAMPLE_UUID}`
+    );
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBeUndefined();
+  });
+
+  it("returns the response JSON unchanged", async () => {
+    const payload = { memory: { facts: ["foo"] }, message: "ok" };
+    mockFetchOnce(200, payload);
+    expect(await getUserMemory(SAMPLE_UUID)).toEqual(payload);
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetchOnce(404, "Not found");
+    await expect(getUserMemory(SAMPLE_UUID)).rejects.toThrow(
+      /Failed to load user memory \(404\)/
+    );
+  });
+});
+
+describe("deleteUserMemory", () => {
+  it("sends DELETE with URL-encoded user id", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await deleteUserMemory(SAMPLE_UUID);
+    expect(spy.mock.calls[0]![0]).toBe(
+      `/api/config/user-memory/${SAMPLE_UUID}`
+    );
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetchOnce(500, "boom");
+    await expect(deleteUserMemory(SAMPLE_UUID)).rejects.toThrow(
+      /Failed to delete user memory \(500\)/
+    );
+  });
+});
+
+describe("setUserMode", () => {
+  it("sends PUT with the body `{ mode }` (NOT `{ name }`)", async () => {
+    // Easy to mis-refactor to `{ name }` since the function param is the
+    // mode name. The worker validates the field at upstream. Pin the wire
+    // shape here so a refactor fails CI rather than 400ing in production.
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await setUserMode(SAMPLE_UUID, "spoken");
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual({ mode: "spoken" });
+  });
+
+  it("URL-encodes the user id and sends Content-Type application/json", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await setUserMode(SAMPLE_UUID, "spoken");
+    expect(spy.mock.calls[0]![0]).toBe(`/api/config/user-mode/${SAMPLE_UUID}`);
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json"
+    );
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetchOnce(400, "Invalid mode");
+    await expect(setUserMode(SAMPLE_UUID, "bad")).rejects.toThrow(
+      /Failed to set user mode \(400\)/
+    );
+  });
+});
+
+describe("clearUserMode", () => {
+  it("sends DELETE with URL-encoded user id", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await clearUserMode(SAMPLE_UUID);
+    expect(spy.mock.calls[0]![0]).toBe(`/api/config/user-mode/${SAMPLE_UUID}`);
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetchOnce(500, "engine down");
+    await expect(clearUserMode(SAMPLE_UUID)).rejects.toThrow(
+      /Failed to clear user mode \(500\)/
     );
   });
 });

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { LanguageForbiddenError, putLanguage } from "../src/lib/languages-api";
+import {
+  LanguageForbiddenError,
+  deleteLanguage,
+  getLanguage,
+  listLanguages,
+  putLanguage,
+} from "../src/lib/languages-api";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -96,6 +102,128 @@ describe("putLanguage", () => {
     expect(JSON.parse(init.body as string)).toEqual(body);
     expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
       "application/json"
+    );
+  });
+});
+
+describe("listLanguages", () => {
+  it("returns the response JSON unchanged", async () => {
+    const payload = {
+      languages: [{ name: "arabic", label: "Arabic", document: "" }],
+    };
+    mockFetchOnce(200, payload);
+    expect(await listLanguages()).toEqual(payload);
+  });
+
+  it("sends GET with the same-origin marker", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ languages: [] })));
+    await listLanguages();
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/languages");
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe(
+      "XMLHttpRequest"
+    );
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetchOnce(500, "boom");
+    await expect(listLanguages()).rejects.toThrow(
+      /Failed to load languages \(500\)/
+    );
+  });
+});
+
+describe("getLanguage", () => {
+  it("unwraps the wrapped engine response `{ org, language }`", async () => {
+    mockFetchOnce(200, {
+      org: "uw",
+      language: {
+        name: "arabic",
+        label: "Arabic",
+        document: "## Tone\n",
+        published: true,
+      },
+    });
+    const result = await getLanguage("arabic");
+    expect(result).toEqual({
+      name: "arabic",
+      label: "Arabic",
+      document: "## Tone\n",
+      published: true,
+    });
+  });
+
+  it("returns an already-unwrapped response unchanged (back-compat)", async () => {
+    mockFetchOnce(200, { name: "arabic", document: "" });
+    const result = await getLanguage("arabic");
+    expect(result.name).toBe("arabic");
+  });
+
+  it("throws LanguageForbiddenError on 403 with operation `read`", async () => {
+    // Operation discriminant is load-bearing for the UI's permission
+    // messaging — `read` shows "view permission" copy, `write` shows
+    // "edit permission" copy, `delete` shows "delete permission" copy.
+    mockFetchOnce(403, { error: "Forbidden" });
+    try {
+      await getLanguage("arabic");
+      throw new Error("expected rejection");
+    } catch (e) {
+      expect(e).toBeInstanceOf(LanguageForbiddenError);
+      const err = e as LanguageForbiddenError;
+      expect(err.operation).toBe("read");
+      expect(err.languageName).toBe("arabic");
+    }
+  });
+
+  it("throws generic Error on non-403 4xx", async () => {
+    mockFetchOnce(404, "Language not found");
+    await expect(getLanguage("missing")).rejects.toThrow(
+      /Failed to load language \(404\): Language not found/
+    );
+  });
+
+  it("URL-encodes the language name", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ language: { name: "haitian-creole", document: "" } })
+        )
+      );
+    await getLanguage("haitian-creole");
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/languages/haitian-creole");
+  });
+});
+
+describe("deleteLanguage", () => {
+  it("sends DELETE with URL-encoded name", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await deleteLanguage("haitian-creole");
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/languages/haitian-creole");
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("throws LanguageForbiddenError on 403 with operation `delete`", async () => {
+    mockFetchOnce(403, { error: "Forbidden" });
+    try {
+      await deleteLanguage("arabic");
+      throw new Error("expected rejection");
+    } catch (e) {
+      expect(e).toBeInstanceOf(LanguageForbiddenError);
+      const err = e as LanguageForbiddenError;
+      expect(err.operation).toBe("delete");
+      expect(err.languageName).toBe("arabic");
+    }
+  });
+
+  it("throws generic Error on non-403 4xx", async () => {
+    mockFetchOnce(404, "Language not found");
+    await expect(deleteLanguage("missing")).rejects.toThrow(
+      /Failed to delete language \(404\)/
     );
   });
 });


### PR DESCRIPTION
## Summary

Closes **#120**. Last PR in the retrospective-audit batch — fills the API-client test gaps Frank's audit flagged.

## Changes

### \`tests/admin-users-api.test.ts\` — new file, 15 tests

Whole module was previously untested. Pins the error-class branching the UI dialogs depend on:

- 403 → \`AdminUsersForbiddenError\` (with \`serverMessage\` from worker's \`error\` field).
- 400/404/409 → \`AdminUsersRequestError\` (with \`status\` preserved for the duplicate-email / self-demote / not-found dialogs).
- Cross-org 404 → \`AdminUsersRequestError\` (NOT \`Forbidden\`) — workers returns 404 to avoid existence enumeration, and the client must surface that distinction so the dialog renders the right copy.
- Non-JSON error body (CDN-rewritten HTML, etc.) → request error with default \`"Request failed (N)"\` fallback.

Plus URL-encoding on email path params (e.g. \`user+tag@acme.com\` → \`%2B\` / \`%40\`) and method/Content-Type assertions on POST/PUT.

### \`tests/config-api.test.ts\` — 15 new

Previously only \`getMode\`/\`putMode\` covered. Added \`listModes\`, \`deleteMode\`, \`getUserMemory\`, \`deleteUserMemory\`, \`setUserMode\`, \`clearUserMode\`.

Load-bearing assertion: \`setUserMode\` sends \`{ mode }\` on the wire, NOT \`{ name }\`. A refactor that confuses the function param (\`mode\`) with the body field would 400 silently at the worker upstream. Pinned here so it fails CI instead.

### \`tests/languages-api.test.ts\` — 11 new

Previously only \`putLanguage\` covered. Added \`listLanguages\`, \`getLanguage\`, \`deleteLanguage\`.

- \`getLanguage\` has its own \`{ org, language }\` envelope unwrap (same class of bug fixed for \`putLanguage\` / \`putMode\`) — pinned with both wrapped and back-compat unwrapped cases.
- 403 → \`LanguageForbiddenError\` with the correct \`operation\` discriminant (\`read\` on GET, \`delete\` on DELETE, \`write\` already covered by putLanguage). The discriminant is load-bearing for the UI's per-operation permission copy at \`languages.tsx:373-383\`.

## Verification

**110 tests across 8 files** (41 new across the three suites — 15 admin-users + 15 config + 11 languages). Lint + typecheck + build all clean.

## Out of scope

- #117 (chat-stream \`user_id\` ownership) — deferred to a separate design discussion.

## Related (full batch)

- #121 — Worker authz on config mutations + password policy (merged \`69d033b\`).
- #122 — UX cleanup: save errors visible, envelope unwrap, UI state leak.
- #123 — Test backfill: \`permissions.ts\` + \`markdown-headings.ts\`.
- #124 (this) — API client test backfill.

\`#117\` is the only finding from the retrospective audit not yet addressed in code.