### PR TITLE
feat: hide Prompt Overrides sidebar entry (#125 Phase 1)

### DIFF
--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -2,13 +2,11 @@ import { faComments as faCommentsLight } from "@fortawesome/pro-light-svg-icons"
 import { faLanguage as faLanguageLight } from "@fortawesome/pro-light-svg-icons";
 import { faMessageBot as faMessageBotLight } from "@fortawesome/pro-light-svg-icons";
 import { faPenToSquare as faPenToSquareLight } from "@fortawesome/pro-light-svg-icons";
-import { faSliders as faSlidersLight } from "@fortawesome/pro-light-svg-icons";
 import { faUsers as faUsersLight } from "@fortawesome/pro-light-svg-icons";
 import { faComments as faCommentsSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faLanguage as faLanguageSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faMessageBot as faMessageBotSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faPenToSquare as faPenToSquareSolid } from "@fortawesome/pro-solid-svg-icons";
-import { faSliders as faSlidersSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faUsers as faUsersSolid } from "@fortawesome/pro-solid-svg-icons";
 import { useNavigate } from "react-router";
 
@@ -66,18 +64,6 @@ export function ActivityBar() {
           disabled={!canAccessLanguages}
           disabledLabel="No language access — contact your admin"
         />
-        {isAdmin && (
-          <ActivityBarItem
-            icon={faSlidersLight}
-            activeIcon={faSlidersSolid}
-            label="Org-wide prompt overrides"
-            isActive={activeSection === "prompt-configuration"}
-            onClick={() => {
-              setActiveSection("prompt-configuration");
-              void navigate("/prompt-configuration");
-            }}
-          />
-        )}
         {isAdmin && (
           <ActivityBarItem
             icon={faUsersLight}


### PR DESCRIPTION
## Summary

- Removes the **Prompt Overrides** entry from the activity bar per Elsy's explicit ask ("hide Prompt Overrides from the Menu") and Christou's framing that Modes is the replacement.
- Single-file change in `src/components/activity-bar.tsx`: the `<ActivityBarItem>` block and the now-unused `faSliders` icon imports.
- Leaves the `/prompt-configuration` route, `worker/config.ts` proxy, and upstream worker endpoint **intact** as an emergency escape during the transition. The `"prompt-configuration"` entry in `src/types/ui.ts`, the route in `src/app/App.tsx`, and the path mapping in `use-sync-section.ts` are preserved deliberately for the same reason.
- This is **Phase 1** of the two-phase plan in #125. Phase 2 (full deletion of page + worker BFF route + upstream worker endpoint) remains gated on @IanLindsley confirming the worker no longer consumes `/api/v1/admin/orgs/{org}/prompt-overrides` at chat time.

Closes #125 only partially — the issue stays open for Phase 2.

## Test plan

- [ ] Sign in as a non-admin user → activity bar shows Baruch, Languages (if rights), and the test-chat toggle. No Prompt Overrides entry (also no Modes, Users — pre-existing admin-only gates). ✅ Trivially passes since the entry is removed unconditionally.
- [ ] Sign in as an admin user → activity bar shows Baruch, Modes, Languages, Users (no Prompt Overrides). The Modes entry uses `faPenToSquare`, Users uses `faUsers`.
- [ ] Navigate directly to `/prompt-configuration` in the URL bar → page still renders (emergency escape).
- [ ] No new ESLint/TS errors; pre-commit hook ran lint + typecheck + build successfully locally.

## Out of scope

- Phase 2 deletions (page, BFF route, types, hooks) — see #125 for the full Phase 2 checklist.
- README route table — pre-existing drift from PR #110; not part of #125's stated AC.