### PR TITLE
feat: invalidate user sessions on admin password reset (#99)

### DIFF
--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -46,6 +46,7 @@ export function AdminUserEditDialog({
   const [name, setName] = useState("");
   const [isAdmin, setIsAdmin] = useState(false);
   const [rights, setRights] = useState<LanguageRights | undefined>(undefined);
+  const [password, setPassword] = useState("");
   const [errorText, setErrorText] = useState<string | null>(null);
 
   // Re-sync form state from the user prop whenever the target changes
@@ -55,6 +56,7 @@ export function AdminUserEditDialog({
     setName(user.name);
     setIsAdmin(user.isAdmin);
     setRights(user.language_rights);
+    setPassword("");
     setErrorText(null);
     updateUser.reset();
     // updateUser is a stable reference from React Query
@@ -83,6 +85,16 @@ export function AdminUserEditDialog({
     const nextSerialized = JSON.stringify(rights ?? null);
     if (currentSerialized !== nextSerialized && rights !== undefined) {
       body.language_rights = rights;
+    }
+    // Password is opt-in: only include when the admin actually typed
+    // something. Empty = leave the existing hash alone. Mirror the
+    // server's 8-char floor (worker rejects shorter with 400).
+    if (password) {
+      if (password.length < 8) {
+        setErrorText("Password must be at least 8 characters.");
+        return;
+      }
+      body.password = password;
     }
 
     if (Object.keys(body).length === 0) {
@@ -166,6 +178,31 @@ export function AdminUserEditDialog({
               availableLanguages={availableLanguages}
               showLegacyHint
             />
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-user-password">Reset password</Label>
+              <Input
+                id="edit-user-password"
+                type="text"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Leave blank to keep current"
+              />
+              <p className="text-muted-foreground text-xs">
+                {isSelf ? (
+                  <>
+                    Sets a new password for your account. Your other sessions
+                    are signed out; this tab keeps working.
+                  </>
+                ) : (
+                  <>
+                    Sets a new password and signs the user out of every active
+                    session. Share the new password with them out-of-band.
+                  </>
+                )}
+              </p>
+            </div>
 
             {errorText && (
               <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -614,6 +614,212 @@ describe("admin password policy", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Password reset → session invalidation (#99)
+// ---------------------------------------------------------------------------
+
+// Helper: count sessions in AUTH_KV whose stored email matches `email`.
+async function countSessionsForEmail(email: string): Promise<number> {
+  let cursor: string | undefined;
+  let count = 0;
+  do {
+    const page = await env.AUTH_KV.list({ prefix: "session:", cursor });
+    for (const key of page.keys) {
+      const sess = await env.AUTH_KV.get<SessionData>(key.name, {
+        type: "json",
+      });
+      if (sess?.email === email) count += 1;
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  return count;
+}
+
+describe("admin password-reset → session invalidation (#99)", () => {
+  it("cookie path: admin resets another user's password → target's sessions deleted, caller's session intact", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    const aliceSession = await seedSession(alice);
+    // Bob has two active sessions (e.g., laptop + phone).
+    await seedSession(bob);
+    await seedSession(bob);
+
+    expect(await countSessionsForEmail(bob.email)).toBe(2);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: aliceSession,
+      body: { password: "new-password-123" },
+    });
+
+    expect(status).toBe(200);
+    expect(await countSessionsForEmail(bob.email)).toBe(0);
+    // Alice's session must still validate — her cookie shouldn't get
+    // collateral-damaged by Bob's reset.
+    expect(await countSessionsForEmail(alice.email)).toBe(1);
+  });
+
+  it("cookie path: admin resets own password → current session preserved, other own-email sessions deleted", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    // Alice is logged in on two devices; she resets her own password from
+    // the first one. The first session is the caller; the second should
+    // be invalidated.
+    const aliceCurrentSession = await seedSession(alice);
+    await seedSession(alice);
+
+    expect(await countSessionsForEmail(alice.email)).toBe(2);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${alice.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: aliceCurrentSession,
+      body: { password: "new-alice-password" },
+    });
+
+    expect(status).toBe(200);
+    // Only the caller's session survives.
+    expect(await countSessionsForEmail(alice.email)).toBe(1);
+    const surviving = await env.AUTH_KV.get(`session:${aliceCurrentSession}`);
+    expect(surviving).not.toBeNull();
+  });
+
+  it("X-Admin-Secret path: resets another user's password → all target sessions deleted (no caller session)", async () => {
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    await seedSession(bob);
+    await seedSession(bob);
+    await seedSession(bob);
+
+    expect(await countSessionsForEmail(bob.email)).toBe(3);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: { password: "new-bob-password" },
+    });
+
+    expect(status).toBe(200);
+    expect(await countSessionsForEmail(bob.email)).toBe(0);
+  });
+
+  it("PUT without password → target's sessions untouched", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    const aliceSession = await seedSession(alice);
+    await seedSession(bob);
+    await seedSession(bob);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: aliceSession,
+      body: { name: "Bob Updated", language_rights: ["es"] },
+    });
+
+    expect(status).toBe(200);
+    // Bob's two sessions are both preserved — non-password PUTs must not
+    // log users out.
+    expect(await countSessionsForEmail(bob.email)).toBe(2);
+  });
+
+  it("failed password policy → no sessions deleted (atomic: hash is not written, sessions not killed)", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    const aliceSession = await seedSession(alice);
+    await seedSession(bob);
+    await seedSession(bob);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: aliceSession,
+      // Below the 8-char floor — must reject without touching sessions.
+      body: { password: "short" },
+    });
+
+    expect(status).toBe(400);
+    expect(await countSessionsForEmail(bob.email)).toBe(2);
+  });
+
+  it("password reset does not delete sessions belonging to OTHER users", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    const carol = await seedUser({
+      email: "carol@acme.com",
+      name: "Carol",
+      org: "acme",
+    });
+    const aliceSession = await seedSession(alice);
+    await seedSession(bob);
+    await seedSession(carol);
+    await seedSession(carol);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: aliceSession,
+      body: { password: "new-bob-password" },
+    });
+
+    expect(status).toBe(200);
+    expect(await countSessionsForEmail(bob.email)).toBe(0);
+    // Carol's two sessions and Alice's caller session are untouched.
+    expect(await countSessionsForEmail(carol.email)).toBe(2);
+    expect(await countSessionsForEmail(alice.email)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Mixed paths
 // ---------------------------------------------------------------------------
 

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -1,4 +1,4 @@
-import { validateSession } from "./auth";
+import { getSessionId, invalidateUserSessions, validateSession } from "./auth";
 import { generateSalt, hashPassword, timingSafeEqual } from "./crypto";
 import type { Env } from "./helpers";
 import { errorResponse, jsonResponse } from "./helpers";
@@ -61,7 +61,15 @@ function parseLanguageRights(
 
 type AdminScope =
   | { kind: "super" }
-  | { kind: "org"; org: string; selfEmail: string };
+  | {
+      kind: "org";
+      org: string;
+      selfEmail: string;
+      // Caller's session id, so a self-password-reset can preserve the
+      // current browser tab while still invalidating every other session
+      // for that email.
+      selfSessionId: string | null;
+    };
 
 async function requireAdminAuth(
   request: Request,
@@ -83,7 +91,12 @@ async function requireAdminAuth(
     return errorResponse("Forbidden", 403);
   }
 
-  return { kind: "org", org: session.org, selfEmail: session.email };
+  return {
+    kind: "org",
+    org: session.org,
+    selfEmail: session.email,
+    selfSessionId: getSessionId(request),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -302,13 +315,14 @@ async function updateUser(
   // `!== undefined` (not truthy) so `{ password: "" }` falls into the
   // policy check and rejects with "at least 8 characters" rather than
   // silently no-op'ing and returning success.
-  if (body.password !== undefined) {
-    const passwordError = validatePasswordPolicy(body.password);
+  const passwordChanged = body.password !== undefined;
+  if (passwordChanged) {
+    const passwordError = validatePasswordPolicy(body.password as string);
     if (passwordError) {
       return errorResponse(passwordError, 400);
     }
     user.salt = generateSalt();
-    user.passwordHash = await hashPassword(body.password, user.salt);
+    user.passwordHash = await hashPassword(body.password as string, user.salt);
   }
   if (body.language_rights !== undefined) {
     const rightsResult = parseLanguageRights(body.language_rights);
@@ -319,6 +333,19 @@ async function updateUser(
   }
 
   await env.AUTH_KV.put(`user:${email}`, JSON.stringify(user));
+
+  // After a password change, every existing session for the target user
+  // must be invalidated so the new password is actually required to
+  // continue. Preserve the caller's own session when they're resetting
+  // their own password via the cookie path; the X-Admin-Secret CLI path
+  // has no caller session to preserve.
+  if (passwordChanged) {
+    const exceptSessionId =
+      scope.kind === "org" && scope.selfEmail === email
+        ? scope.selfSessionId
+        : null;
+    await invalidateUserSessions(env, email, exceptSessionId);
+  }
 
   return jsonResponse({ user: safeUser(user) });
 }

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -37,10 +37,42 @@ async function isRateLimited(
 // Session helpers
 // ---------------------------------------------------------------------------
 
-function getSessionId(request: Request): string | null {
+export function getSessionId(request: Request): string | null {
   const cookie = request.headers.get("Cookie") || "";
   const match = cookie.match(/(?:^|;\s*)session=([^\s;]+)/);
   return match?.[1] ?? null;
+}
+
+// Scans session:* in AUTH_KV and deletes every session whose stored email
+// matches targetEmail. Optionally skips one session id — used by callers
+// that want to preserve their own cookie (self-change-password, admin
+// resetting their own password). Awaits all deletes before returning so
+// callers can be sure invalidation took effect before responding.
+export async function invalidateUserSessions(
+  env: Env,
+  targetEmail: string,
+  exceptSessionId?: string | null
+): Promise<void> {
+  let cursor: string | undefined;
+  const deletePromises: Promise<void>[] = [];
+  do {
+    const page = await env.AUTH_KV.list({ prefix: "session:", cursor });
+    const reads = page.keys
+      .filter(
+        (key) => !exceptSessionId || key.name !== `session:${exceptSessionId}`
+      )
+      .map(async (key) => {
+        const sess = await env.AUTH_KV.get<SessionData>(key.name, {
+          type: "json",
+        });
+        if (sess?.email === targetEmail) {
+          deletePromises.push(env.AUTH_KV.delete(key.name));
+        }
+      });
+    await Promise.all(reads);
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  await Promise.all(deletePromises);
 }
 
 function sessionCookie(
@@ -280,30 +312,10 @@ export async function handleChangePassword(
 
   await env.AUTH_KV.put(`user:${session.email}`, JSON.stringify(user));
 
-  // Invalidate all other sessions for this user
-  const currentSessionId = getSessionId(request);
-  let cursor: string | undefined;
-  const deletePromises: Promise<void>[] = [];
-  do {
-    const page = await env.AUTH_KV.list({
-      prefix: "session:",
-      cursor,
-    });
-
-    const reads = page.keys
-      .filter((key) => key.name !== `session:${currentSessionId}`)
-      .map(async (key) => {
-        const sess = await env.AUTH_KV.get<SessionData>(key.name, {
-          type: "json",
-        });
-        if (sess?.email === session.email) {
-          deletePromises.push(env.AUTH_KV.delete(key.name));
-        }
-      });
-    await Promise.all(reads);
-
-    cursor = page.list_complete ? undefined : page.cursor;
-  } while (cursor);
+  // Invalidate all other sessions for this user. The caller's session is
+  // preserved so they don't get logged out of the tab where they just
+  // changed their password.
+  await invalidateUserSessions(env, session.email, getSessionId(request));
 
   return jsonResponse({ ok: true });
 }


### PR DESCRIPTION
## Summary

Closes #99. `PUT /api/admin/users/{email}` now deletes every active session for the target user when the request body contains a `password` field, closing the "reset password but the old cookie keeps working" gap. The caller's own cookie is preserved when an admin happens to reset their own password from the browser (so they don't get logged out mid-action); the X-Admin-Secret CLI path has no caller session and wipes the target's sessions wholesale.

Frontend re-introduction of the password field in `AdminUserEditDialog` (issue #99 AC #4) — was pulled in PR #100 pending this fix.

## Why the helper extraction

`worker/auth.ts handleChangePassword` already had a scan-and-delete loop for the same purpose, but it built up `deletePromises` and **never awaited them** before returning. In a Cloudflare Worker that means the deletes were fire-and-forget — they may or may not complete after the response is sent. Extracted as `invalidateUserSessions(env, targetEmail, exceptSessionId?)` in `worker/auth.ts`, used by both `handleChangePassword` and the new admin path. The helper awaits all deletes before returning.

## Plumbing

- `getSessionId` is now exported from `worker/auth.ts`.
- `AdminScope.org` gains `selfSessionId: string | null`. `requireAdminAuth` captures it at auth time so the password-write branch in `updateUser` can pass it through.
- `super` scope (X-Admin-Secret) has no caller session by design — `exceptSessionId` is `null`.
- `updateUser` calls `invalidateUserSessions` **only** when `body.password !== undefined`. PUTs that only touch `name` / `isAdmin` / `language_rights` don't log anyone out.

## Tests

6 new in `tests/admin-auth.test.ts` (plus a small `countSessionsForEmail` helper). 160/160 across the full suite pass locally.

| Case | Expected | Verified |
|---|---|---|
| Cookie path: admin resets another user | target's sessions deleted, admin's session intact | ✅ |
| Cookie path: admin resets own password | caller's tab survives, other own-email sessions die | ✅ |
| X-Admin-Secret path resets another user | all target sessions deleted (no caller to preserve) | ✅ |
| PUT without password field | target's sessions untouched | ✅ |
| Failed policy (`password: "short"`) | 400, no sessions deleted (atomic) | ✅ |
| Cross-user isolation | other users' sessions never touched | ✅ |

## Frontend UX

The `AdminUserEditDialog` gains an optional "Reset password" `<Input type="text">` (visible deliberately, mirroring the create dialog so admins can copy/share). Blank = leave the hash alone. Hint text adapts to whether the admin is resetting themselves or someone else:

- Self: "Sets a new password for your account. Your other sessions are signed out; this tab keeps working."
- Other: "Sets a new password and signs the user out of every active session. Share the new password with them out-of-band."

Client-side validation mirrors the worker's 8-char floor; the worker is the source of truth.

## Test plan

- [ ] CI green (Code Quality / Build / Secret Scan / per-PR Cloudflare Worker deploy)
- [ ] Frank review
- [ ] Manual smoke (recommend on the PR's per-PR worker): admin (Alice) edits another user (Bob), sets a new password → Bob's cookie immediately stops working on next request, Alice stays signed in
- [ ] Manual smoke: admin (Alice) edits herself, sets a new password from Tab A → Tab A keeps working, Tab B (older Alice session) gets logged out on next request

## Out of scope

- The X-Admin-Secret CLI path inherits the new invalidation behavior automatically — same fix, same code path. No CLI-specific changes.
- Rate-limiting the admin-reset path is not in scope here; existing CSRF + same-origin + admin authz gates are unchanged.