### PR TITLE
docs: refresh README pages + worker route tables (Frank cleanup from #127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,20 @@ worker/
 ├── auth.ts      → Login/logout/session management
 ├── chat.ts      → Chat SSE streaming & history proxy
 ├── baruch.ts    → Baruch SSE streaming, initiation & history proxy
-├── config.ts    → Prompt override & mode config proxy
+├── config.ts    → Modes, languages & prompt-override config proxy
 ├── admin.ts     → Admin user CRUD
 └── helpers.ts   → Response helpers, same-origin guard
 ```
 
 ## Pages
 
-| Route            | Page                 | Description                     |
-| ---------------- | -------------------- | ------------------------------- |
-| `/login`         | Login                | Email/password authentication   |
-| `/`              | Baruch               | Conversational config assistant |
-| `/manual-config` | Prompt Configuration | Manage prompt overrides & modes |
+| Route          | Page        | Description                                               |
+| -------------- | ----------- | --------------------------------------------------------- |
+| `/login`       | Login       | Email/password authentication                             |
+| `/`            | Baruch      | Conversational config assistant                           |
+| `/modes`       | Modes       | Markdown editor for prompt modes (admin only)             |
+| `/languages`   | Languages   | Markdown editor for per-language tuning (language rights) |
+| `/admin/users` | Admin Users | Manage users in your org (admin only)                     |
 
 ## Development
 
@@ -74,10 +76,10 @@ Pre-commit hooks (via Husky + lint-staged) run ESLint, Prettier, typecheck, and 
 
 The Cloudflare Worker acts as a BFF proxy, authenticating requests and forwarding to the BT Servant Engine API.
 
-| Route           | Auth         | Description                               |
-| --------------- | ------------ | ----------------------------------------- |
-| `/api/auth/*`   | None         | Login, logout, session check              |
-| `/api/admin/*`  | Admin secret | User CRUD                                 |
-| `/api/chat/*`   | Session      | SSE streaming, history                    |
-| `/api/baruch/*` | Session      | Baruch SSE streaming, initiation, history |
-| `/api/config/*` | Session      | Prompt overrides, modes, default mode     |
+| Route           | Auth                       | Description                               |
+| --------------- | -------------------------- | ----------------------------------------- |
+| `/api/auth/*`   | None                       | Login, logout, session check              |
+| `/api/admin/*`  | Admin secret or session    | User CRUD                                 |
+| `/api/chat/*`   | Session                    | SSE streaming, history                    |
+| `/api/baruch/*` | Session                    | Baruch SSE streaming, initiation, history |
+| `/api/config/*` | Session (admin for writes) | Modes, languages, prompt overrides        |


### PR DESCRIPTION
## Summary

Frank flagged a stale `/manual-config` row in the Pages table on PR #127 review. Cleaning up that drift plus a few adjacent staleness items that landed in the same README sections during recent merges.

## Drift fixed

- **Pages table.** Dropped the `/manual-config` row (no longer in the sidebar after #125 Phase 1; the route is preserved as an emergency escape until Phase 2 deletes the page entirely, gated on bt-servant-worker#215). Added the three reachable surfaces missing from the table: `/modes` (PR #110), `/languages` (PR #93), `/admin/users` (PR #100). Each row now notes its access gate (admin / language rights).
- **Architecture diagram.** `worker/config.ts` line now mentions languages — the file gained `/api/config/languages` routes in PR #92 (#79).
- **Worker BFF Routes table.**
  - `/api/admin/*` auth: dual-auth ("Admin secret or session") per the 2026-05-08 retrospective audit; previously listed only the secret path.
  - `/api/config/*`: writes are admin-only (per the #112 retro batch and the worker-side 403 added there); "default mode" dropped (removed in worker #211 / PR #212 deterministic cascade); languages added.

## Out of scope (deliberately)

- `BT Servant Engine` references in the architecture overview and Environments table — accurate-but-misleading per the 2026-05-08 evening refile audit (engine dormant since 2026-01-16; ENGINE_BASE_URL points at bt-servant-worker). Worth a separate, focused vocab-cleanup PR rather than mixing it in here.

## Test plan

- [x] `npx prettier --check README.md` — clean
- [x] `npm run typecheck` — pre-commit gate
- [x] `npm run build` — pre-commit gate
- [x] Visual diff verified against actual route definitions in `src/app/App.tsx`, sidebar entries in `src/components/activity-bar.tsx`, and route handlers in `worker/config.ts` + `worker/admin.ts`

Pure docs PR; no code or schema impact.