### PR TITLE
chore(#91): bump JS actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,13 @@ jobs:
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest
+    # gitleaks-action@v2 ships `runs.using: node20` and has no v3 release.
+    # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 transitions it onto Node 24 ahead of
+    # GitHub's Sep 16 2026 Node 20 removal. Drop this when v3 ships.
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
@@ -30,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -70,10 +75,10 @@ jobs:
     needs: quality
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -104,7 +109,7 @@ jobs:
           echo "**Build completed successfully**" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build
           path: dist

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       WORKER_NAME: bt-servant-admin-portal-pr-${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Comment on the closed PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           WORKER_NAME: ${{ env.WORKER_NAME }}
           DELETE_OUTCOME: ${{ steps.delete.outcome }}

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -32,9 +32,9 @@ jobs:
       WORKER_NAME: ${{ github.event.pull_request.number && format('bt-servant-admin-portal-pr-{0}', github.event.pull_request.number) || 'bt-servant-admin-portal-dev' }}
       WORKER_URL: ${{ github.event.pull_request.number && format('https://bt-servant-admin-portal-pr-{0}.unfoldingword.workers.dev', github.event.pull_request.number) || 'https://bt-servant-admin-portal-dev.unfoldingword.workers.dev' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -72,7 +72,7 @@ jobs:
 
       - name: Comment PR with deploy URL
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           WORKER_NAME: ${{ env.WORKER_NAME }}
           WORKER_URL: ${{ env.WORKER_URL }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -46,9 +46,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -40,14 +40,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # On a PR-merge run, check out the merge commit (now on main).
           # On workflow_dispatch, fall back to the default ref the dispatch was
           # made against.
           ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -93,7 +93,7 @@ jobs:
       - name: Comment on the merged PR with staging URL
         # Only fires on PR-merge runs; workflow_dispatch has no PR context.
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const url = "https://bt-servant-admin-portal-staging.unfoldingword.workers.dev";


### PR DESCRIPTION
## Summary

Closes #91. Clears the runner-side **"Node.js 20 actions are deprecated"** annotation that has surfaced on every CI / deploy run since the staging-on-merge rewire (PR #90, 2026-05-08). Forced opt-out lands 2026-06-02; hard removal of Node 20 from the runner lands 2026-09-16.

## Pin changes

Across `ci.yml`, `deploy-pr.yml`, `deploy-staging.yml`, `deploy-prod.yml`, `cleanup-pr.yml`:

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | v6 ships Node 24 by default |
| `actions/setup-node` | `@v4` | `@v6` | v6 ships Node 24 by default |
| `actions/github-script` | `@v7` | `@v8` | v8 is Node 24; staying below v9 (v9 breaks `require('@actions/github')` via ESM — our scripts don't use that pattern, but tighter surface for future edits) |
| `actions/upload-artifact` | `@v4` | `@v6` | v6 is Node 24 by default; **not** `@v7` — v7 adds an `archive: false` direct-upload mode that we don't use (our one call site uploads `dist/` as a directory with the default `archive: true`). v6 is the pure runtime bump. |

## gitleaks/gitleaks-action stays at v2

`gitleaks/gitleaks-action`'s `action.yml` is explicitly `runs.using: "node20"` and there is no `v3` release (last v2 was Apr 2025). The issue's escape-hatch note covers this case — added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` on the `secret-scan` job env in `ci.yml`. Inline comment in the file flags the workaround as transitional and to drop when v3 ships.

## Verification on this PR

The deprecation annotation runs on the runner itself, so it'll surface (or stop surfacing) when this PR's jobs execute. Validation path:

- CI: Secret Scan, Code Quality, Build — all should pass on the new pins
- Deploy PR: per-PR ephemeral worker spins up cleanly and the github-script@v8 comment-back step succeeds
- Annotation: `Node.js 20 actions are deprecated` should be **absent** from this run's summary (with `secret-scan` using the escape-hatch env var, the gitleaks step won't trigger it)

## Out of scope

No companion bump for non-action third-party tooling. `wrangler@^4` and `npm ci` are unaffected (they run on the `setup-node` runtime, not the action SDK runtime — separate layer per #87).

## Test plan

- [ ] CI jobs all pass on bumped pins
- [ ] Per-PR Cloudflare Worker deploy succeeds (`deploy-pr.yml`)
- [ ] `github-script@v8` comment-back step posts the dev deployment comment correctly
- [ ] Run-summary on this PR shows **no** Node.js 20 deprecation annotation