### PR TITLE
chore(#133): dark mode polish — foreground chroma, chrome states, destructive button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -102,17 +102,20 @@
 
 .dark {
   --background: oklch(0.211 0.01 248);
-  --foreground: oklch(0.827 0 0);
+  /* Foreground tokens carry a cool-cast tint (hue 248, chroma 0.008) so text
+     reads as belonging to the rest of the dark palette rather than sitting
+     on top as warm-neutral grey. Issue #14. */
+  --foreground: oklch(0.827 0.008 248);
   --card: oklch(0.176 0.012 248);
-  --card-foreground: oklch(0.827 0 0);
+  --card-foreground: oklch(0.827 0.008 248);
   --popover: oklch(0.176 0.012 248);
-  --popover-foreground: oklch(0.827 0 0);
+  --popover-foreground: oklch(0.827 0.008 248);
   --primary: oklch(0.541 0.168 248);
   --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.278 0.01 248);
-  --secondary-foreground: oklch(0.827 0 0);
+  --secondary-foreground: oklch(0.827 0.008 248);
   --muted: oklch(0.249 0.01 248);
-  --muted-foreground: oklch(0.682 0 0);
+  --muted-foreground: oklch(0.682 0.01 248);
   --accent: oklch(0.249 0.01 248);
   --accent-foreground: oklch(1 0 0);
   --destructive: oklch(0.637 0.237 25);
@@ -126,7 +129,7 @@
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.176 0.012 248);
-  --sidebar-foreground: oklch(0.827 0 0);
+  --sidebar-foreground: oklch(0.827 0.008 248);
   --sidebar-primary: oklch(0.541 0.168 248);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent: oklch(0.249 0.01 248);

--- a/src/components/activity-bar-item.tsx
+++ b/src/components/activity-bar-item.tsx
@@ -42,12 +42,18 @@ export function ActivityBarItem({
           className={cn(
             "text-muted-foreground relative size-10 rounded-md transition-all",
             "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2",
+            // Dark-mode hover uses a white overlay because the accent token is
+            // only 0.073 L away from the card surface — below the perceptibility
+            // threshold for a hover state. Issue #12.
             !disabled &&
-              "hover:bg-accent hover:text-foreground hover:shadow-sm active:scale-95",
+              "hover:bg-accent hover:text-foreground hover:shadow-sm active:scale-95 dark:hover:bg-white/[0.08]",
             disabled && "cursor-not-allowed opacity-40",
+            // Active state pairs the left-edge primary strip with a subtle
+            // background fill so the signal isn't carried on a 2px stripe + a
+            // small text lightness delta alone. Issue #13.
             isActive &&
               !disabled &&
-              "text-foreground before:bg-primary before:absolute before:inset-y-1.5 before:-left-1 before:w-0.5 before:rounded-full before:transition-all"
+              "bg-primary/8 text-foreground dark:bg-primary/12 before:bg-primary before:absolute before:inset-y-1.5 before:-left-1 before:w-0.5 before:rounded-full before:transition-all"
           )}
         >
           <FontAwesomeIcon

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -28,7 +28,7 @@ export function ActivityBar() {
   const canAccessLanguages = hasAnyLanguageRights(languageRights);
 
   return (
-    <div className="bg-card relative z-10 flex h-full w-12 flex-col items-center py-3 shadow-[2px_0_12px_rgba(0,0,0,0.2)]">
+    <div className="bg-card relative z-10 flex h-full w-12 flex-col items-center py-3 shadow-[2px_0_12px_rgba(0,0,0,0.2)] dark:shadow-[2px_0_12px_rgba(0,0,0,0.35)]">
       <div className="flex flex-col items-center gap-1.5">
         <ActivityBarItem
           icon={faMessageBotLight}

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -130,7 +130,7 @@ export function LanguageSelector({
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex min-w-0 flex-1 items-center gap-2.5 sm:flex-initial">
-          <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
+          <div className="bg-primary/10 dark:bg-primary/20 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
             <FontAwesomeIcon icon={faLanguage} className="text-base" />
           </div>
           <Select

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -136,7 +136,7 @@ export function ModeSelector({
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex min-w-0 flex-1 items-center gap-2.5 sm:flex-initial">
-          <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
+          <div className="bg-primary/10 dark:bg-primary/20 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
             <FontAwesomeIcon icon={faLayerGroup} className="text-sm" />
           </div>
           <Select value={selectedMode ?? ""} onValueChange={handleSelectChange}>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
## Summary

Closes umbrella **#133** in a single design pass — six surviving dark-mode token issues addressed coherently rather than as six independent micro-PRs. All token / CSS only, all on live components.

## Closes (one keyword per issue — GitHub's parser is per-token, not list-aware per repo memory)

- Closes #11 — mode + language selector icon backgrounds invisible at 10% alpha
- Closes #12 — activity bar hover state imperceptible in dark mode
- Closes #13 — active nav item lacks background differentiation
- Closes #14 — foreground tokens have zero chroma (text disconnected from cool-blue palette)
- Closes #16 — activity bar shadow hardcoded RGBA, not tuned for dark theme
- Closes #19 — destructive button uses \`/60\` alpha — looks doubly muted in dark mode
- Closes #133 — dark mode polish umbrella

## Approach

Followed the sequence proposed in #133:

### 1. Foreground chroma baseline (#14)
Tinted the muted-grey foreground tokens with hue 248 + chroma 0.008. Below the visible-tint threshold (~0.015), so this is warmth without coloring. Tokens changed in \`.dark { ... }\`:

| Token | Before | After |
|---|---|---|
| \`--foreground\` | \`oklch(0.827 0 0)\` | \`oklch(0.827 0.008 248)\` |
| \`--card-foreground\` | \`oklch(0.827 0 0)\` | \`oklch(0.827 0.008 248)\` |
| \`--popover-foreground\` | \`oklch(0.827 0 0)\` | \`oklch(0.827 0.008 248)\` |
| \`--secondary-foreground\` | \`oklch(0.827 0 0)\` | \`oklch(0.827 0.008 248)\` |
| \`--muted-foreground\` | \`oklch(0.682 0 0)\` | \`oklch(0.682 0.01 248)\` |
| \`--sidebar-foreground\` | \`oklch(0.827 0 0)\` | \`oklch(0.827 0.008 248)\` |

(\`--accent-foreground\` and \`--sidebar-accent-foreground\` stay at \`oklch(1 0 0)\` — pure white is intentional for highest-contrast contexts.)

### 2. Activity bar (#12, #13, #16)
- **Hover** (\`activity-bar-item.tsx:46\`) — added \`dark:hover:bg-white/[0.08]\` so the hover delta exceeds the perceptibility threshold. Light mode still uses \`hover:bg-accent\`.
- **Active state** (\`activity-bar-item.tsx:50\`) — added \`bg-primary/8 dark:bg-primary/12\` to the active branch. The signal no longer rides entirely on a 2px strip + a small text-color delta.
- **Shadow** (\`activity-bar.tsx:31\`) — added \`dark:shadow-[2px_0_12px_rgba(0,0,0,0.35)]\` so the side shadow still punches through against the darker ambient surface.

### 3. Selector icon backgrounds (#11)
\`bg-primary/10\` produced an invisible icon container in dark mode (composite landed within ~0.005 L of \`--card\`). Bumped to \`dark:bg-primary/20\` in both \`mode-selector.tsx\` and \`language-selector.tsx\` (the issue noted both surfaces).

### 4. Destructive button (#19)
The dark-mode \`--destructive\` token is already a hand-picked darker red (\`oklch(0.637 0.237 25)\`) vs light-mode \`oklch(0.577 0.245 27.325)\`. Adding \`dark:bg-destructive/60\` on top was a double-mute. Dropped the alpha modifier; kept the \`dark:focus-visible:ring-destructive/40\` ring adjustment (unrelated to body fill).

## Out of scope — same triage closed as superseded

These three were originally in #133's scope; investigation during this PR confirmed they were on the dying Prompt Overrides surface and got closed during triage. Umbrella scope narrowed from 9 → 6 sub-issues.

- **#9** (\`SLOT_COLORS_DARK\` secondary chroma) — \`src/components/prompt-panel.tsx\` is **scheduled for deletion in #125 Phase 2** (gated on bt-servant-worker#215; file still exists in this commit but is unreachable from the UI after #125 Phase 1 hid the sidebar entry).
- **#10** (slot background chroma differentiation) — same file, same Phase 2 dependency.
- **#18** (\`.config-grid-bg\` off-system value) — class is only consumed by \`src/app/pages/manual-config.tsx\`, which is **scheduled for deletion in #125 Phase 2** (same gate). Class still defined in \`globals.css\` in this commit.

The intent of "Phase 2 deletes" wording in earlier copies of this body was to say "Phase 2 will delete." Files still exist on disk right now; the surface is just user-unreachable.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint --max-warnings 0\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm run build\` — clean
- [x] All 4 GitHub CI checks pass: Build, Code Quality, Deploy to Cloudflare Workers, Secret Scan
- [ ] **Visual review in dark mode** (this is the real gate — token diffs only):
  - Activity bar: hover any nav item; should be clearly visible. Click into a section; the active item should have both the left-edge strip AND a subtle blue fill.
  - Mode/Language page header: icon containers next to the selector should look like containers, not invisible square slots.
  - Destructive button: open any confirm dialog (e.g., delete a mode/language); destructive button should read at full strength, not muted.
  - Any text-heavy surface (Baruch chat, modes editor, languages editor): text should feel "warm-cool" rather than warm-neutral on the surrounding dark palette.

## Risk

Low. Pure CSS/token changes. No component logic touched, no API surface, no test changes needed. All affected files type-check, lint, format, and build cleanly. Visual review is the gate.

## Reviewer notes

- **Commit author**: per this repo's \`CLAUDE.md\` ("Use \`--author=\"Claude <claude@anthropic.com>\"\` on every commit"), Claude is the sole author. \`AGENTS.md\` has the symmetric rule for Codex, but that governs Codex's commits, not Claude's. No author change needed.