### PR TITLE
chore(#139): add create-org-admin CLI stopgap for new-org bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,31 @@ The Cloudflare Worker acts as a BFF proxy, authenticating requests and forwardin
 | `/api/chat/*`   | Session                    | SSE streaming, history                    |
 | `/api/baruch/*` | Session                    | Baruch SSE streaming, initiation, history |
 | `/api/config/*` | Session (admin for writes) | Modes, languages, prompt overrides        |
+
+## Bootstrapping a new org
+
+An "org" in the portal is a free-text string on each user record — it "exists" the moment the first user with that org string is created. Provisioning a new tenant (or any cross-org user creation) goes through the portal worker's `X-Admin-Secret` path, since org-scoped admins can only create users in their own org.
+
+A stopgap CLI wraps the call so operators don't hand-craft curls. (A proper super-admin UI is tracked in [#138](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/138); this script remains the recovery / CI path.)
+
+```bash
+# Source ADMIN_SECRET from your password manager (1Password example below)
+op run -- npm run create-org-admin -- \
+  --env staging \
+  --org haneen \
+  --email haneen@example.com \
+  --name "Haneen <last>"
+
+# Other useful flags:
+#   --password '...'     supply your own (default: auto-generate 16-char)
+#   --rights '*'         "*" (default), "none", or comma-separated language slugs
+#   --not-admin          create a non-admin member (default: admin)
+#   --confirm-prod       required when --env prod
+#   --url <full-url>     override the portal URL (e.g. custom domain)
+#   --dry-run            print the request without sending
+#   --help               full usage
+
+ADMIN_SECRET=… npm run create-org-admin -- --help
+```
+
+On success the script prints the created user and the initial password — share both out-of-band; the user can change the password after first sign-in. `ADMIN_SECRET` is the portal worker's wrangler secret (see `worker/admin.ts` for the auth model); it is never echoed back.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:watch": "vitest",
     "prepare": "husky",
     "deploy": "wrangler deploy",
-    "deploy:staging": "wrangler deploy --env staging"
+    "deploy:staging": "wrangler deploy --env staging",
+    "create-org-admin": "node scripts/create-org-admin.mjs"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs}": [

--- a/scripts/create-org-admin.mjs
+++ b/scripts/create-org-admin.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+// Stopgap CLI for bootstrapping a new tenant org (or adding any user) via the
+// portal worker's X-Admin-Secret path. Tracks issue #139.
+//
+// Replaces hand-crafted curls. The proper super-admin UI is tracked in #138;
+// keep this script as the recovery / CI path even once that ships, symmetric
+// to the worker's X-Admin-Secret CLI escape.
+
+import { randomBytes } from "node:crypto";
+import { parseArgs } from "node:util";
+
+const PORTAL_URLS = {
+  dev: "https://bt-servant-admin-portal-dev.unfoldingword.workers.dev",
+  staging: "https://bt-servant-admin-portal-staging.unfoldingword.workers.dev",
+  // Best-guess workers.dev URL — override with --url if a custom domain is in use.
+  prod: "https://bt-servant-admin-portal.unfoldingword.workers.dev",
+};
+
+const USAGE = `Usage: npm run create-org-admin -- [options]
+
+Bootstrap a new tenant org (or add any user) via the portal worker's
+X-Admin-Secret path. An org "exists" the moment the first user with that
+org string is created — there is no separate "create org" step.
+
+Required:
+  --email <email>           User email
+  --name <name>             Full name (wrap in quotes if it contains spaces)
+  --org <slug>              Org slug (free-text; becomes the org if new)
+
+Optional:
+  --env <dev|staging|prod>  Target environment (default: staging)
+  --url <url>               Override the portal URL (wins over --env)
+  --password <pw>           Initial password (default: auto-generate 16-char)
+  --rights <rights>         Language rights: "*" (default), "none", or a
+                            comma-separated list of language slugs
+  --not-admin               Set isAdmin: false (default: true — first user of
+                            a new org typically needs admin to self-administer)
+  --confirm-prod            Required when --env prod (guards against typos)
+  --dry-run                 Print the request that would be made and exit
+  --help, -h                Show this help
+
+Environment:
+  ADMIN_SECRET              The portal worker's X-Admin-Secret value.
+                            Required. Never echoed.
+
+Examples:
+  ADMIN_SECRET=... npm run create-org-admin -- \\
+    --env staging --org haneen --email haneen@example.com --name "Haneen X"
+
+  op run -- npm run create-org-admin -- \\
+    --env prod --confirm-prod --org haneen --email haneen@example.com --name "Haneen X"
+
+  # Dry run to inspect the constructed request
+  ADMIN_SECRET=stub npm run create-org-admin -- --dry-run \\
+    --env staging --org haneen --email haneen@example.com --name "Haneen X"
+`;
+
+function fail(message, exitCode = 1) {
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(exitCode);
+}
+
+/**
+ * Generate a 16-character URL-safe password (96 bits of entropy).
+ * @returns {string}
+ */
+export function generatePassword() {
+  return randomBytes(12).toString("base64url");
+}
+
+/**
+ * Parse the --rights flag into the worker's expected language_rights shape.
+ * Returns "*" for full access, [] for no access, or string[] for a list.
+ * @param {string | undefined} value
+ * @returns {"*" | string[]}
+ */
+export function parseRights(value) {
+  if (value === undefined) return "*";
+  const trimmed = value.trim();
+  if (trimmed === "*") return "*";
+  if (trimmed === "" || trimmed.toLowerCase() === "none") return [];
+  return trimmed
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Resolve the portal URL from --url (wins) or --env. Strips trailing slash.
+ * @param {{ url?: string, env?: string }} args
+ * @returns {string}
+ */
+export function resolvePortalUrl({ url, env }) {
+  if (url) return url.replace(/\/+$/, "");
+  const target = env ?? "staging";
+  const resolved = PORTAL_URLS[target];
+  if (!resolved) {
+    throw new Error(
+      `Unknown --env "${target}". Expected one of: ${Object.keys(PORTAL_URLS).join(", ")}.`
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Build the request body sent to POST /api/admin/users.
+ * @param {{
+ *   email: string,
+ *   name: string,
+ *   org: string,
+ *   password: string,
+ *   isAdmin: boolean,
+ *   rights: "*" | string[],
+ * }} args
+ */
+export function buildPayload({ email, name, org, password, isAdmin, rights }) {
+  return {
+    email: email.trim().toLowerCase(),
+    name: name.trim(),
+    org: org.trim(),
+    password,
+    isAdmin,
+    language_rights: rights,
+  };
+}
+
+async function main() {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      options: {
+        email: { type: "string" },
+        name: { type: "string" },
+        org: { type: "string" },
+        env: { type: "string" },
+        url: { type: "string" },
+        password: { type: "string" },
+        rights: { type: "string" },
+        "not-admin": { type: "boolean", default: false },
+        "confirm-prod": { type: "boolean", default: false },
+        "dry-run": { type: "boolean", default: false },
+        help: { type: "boolean", short: "h", default: false },
+      },
+      strict: true,
+      allowPositionals: false,
+    });
+  } catch (err) {
+    process.stderr.write(USAGE);
+    fail(err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  const { values } = parsed;
+
+  if (values.help) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  const missing = ["email", "name", "org"].filter((k) => !values[k]);
+  if (missing.length > 0) {
+    process.stderr.write(USAGE);
+    fail(`Missing required: ${missing.map((k) => `--${k}`).join(", ")}`);
+    return;
+  }
+
+  const env = values.env ?? "staging";
+  if (env === "prod" && !values["confirm-prod"] && !values["dry-run"]) {
+    fail(
+      "Refusing to target prod without --confirm-prod. Re-run with --confirm-prod once you have verified the org slug, email, and that this is the right environment."
+    );
+    return;
+  }
+
+  const adminSecret = process.env.ADMIN_SECRET;
+  if (!adminSecret && !values["dry-run"]) {
+    fail(
+      "ADMIN_SECRET env var is required. Source it from your password manager (e.g. `op run -- npm run create-org-admin -- ...`)."
+    );
+    return;
+  }
+
+  let portalUrl;
+  try {
+    portalUrl = resolvePortalUrl({ url: values.url, env });
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  const password = values.password ?? generatePassword();
+  const payload = buildPayload({
+    email: values.email,
+    name: values.name,
+    org: values.org,
+    password,
+    isAdmin: !values["not-admin"],
+    rights: parseRights(values.rights),
+  });
+
+  const endpoint = `${portalUrl}/api/admin/users`;
+
+  if (values["dry-run"]) {
+    process.stdout.write(
+      [
+        "DRY RUN — no request sent.",
+        "",
+        `  endpoint: POST ${endpoint}`,
+        `  headers:  X-Admin-Secret: <redacted${adminSecret ? "" : "; not set"}>`,
+        `            Content-Type: application/json`,
+        `  body:     ${JSON.stringify({ ...payload, password: "<redacted>" }, null, 2).replace(/\n/g, "\n            ")}`,
+        "",
+        `  password (would be sent): ${password}`,
+        "",
+      ].join("\n")
+    );
+    return;
+  }
+
+  let res;
+  try {
+    res = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Admin-Secret": adminSecret,
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    fail(
+      `Network error reaching ${endpoint}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return;
+  }
+
+  const rawBody = await res.text();
+  let body;
+  try {
+    body = rawBody ? JSON.parse(rawBody) : null;
+  } catch {
+    body = rawBody;
+  }
+
+  if (!res.ok) {
+    const hint =
+      res.status === 401
+        ? " (bad ADMIN_SECRET — verify it matches the portal worker's wrangler secret for this env)"
+        : res.status === 409
+          ? " (user with that email already exists)"
+          : "";
+    process.stderr.write(
+      `HTTP ${res.status}${hint}\n${
+        typeof body === "string" ? body : JSON.stringify(body, null, 2)
+      }\n`
+    );
+    process.exit(1);
+  }
+
+  const created = (body && typeof body === "object" && body.user) || null;
+  process.stdout.write(
+    [
+      "Created user.",
+      "",
+      `  env:       ${env}`,
+      `  endpoint:  ${endpoint}`,
+      `  email:     ${created?.email ?? payload.email}`,
+      `  name:      ${created?.name ?? payload.name}`,
+      `  org:       ${created?.org ?? payload.org}`,
+      `  isAdmin:   ${created?.isAdmin ?? payload.isAdmin}`,
+      `  rights:    ${JSON.stringify(created?.language_rights ?? payload.language_rights)}`,
+      "",
+      `  password:  ${password}`,
+      "",
+      "Share the email + password with the user out-of-band. They can",
+      "change the password after first sign-in.",
+      "",
+    ].join("\n")
+  );
+}
+
+// Only run main() when invoked as a script, not when imported by tests.
+const invokedDirectly =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("create-org-admin.mjs");
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    fail(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  });
+}

--- a/scripts/create-org-admin.mjs
+++ b/scripts/create-org-admin.mjs
@@ -35,7 +35,9 @@ Optional:
                             comma-separated list of language slugs
   --not-admin               Set isAdmin: false (default: true — first user of
                             a new org typically needs admin to self-administer)
-  --confirm-prod            Required when --env prod (guards against typos)
+  --confirm-prod            Required when targeting prod (--env prod, or
+                            --url matching the known prod URL, or any
+                            unrecognized --url that could be prod/custom)
   --dry-run                 Print the request that would be made and exit
   --help, -h                Show this help
 
@@ -103,6 +105,21 @@ export function resolvePortalUrl({ url, env }) {
 }
 
 /**
+ * Classify a resolved portal URL against the known set. "prod" and
+ * "unknown" both require --confirm-prod; "dev" and "staging" do not.
+ * Used to close the trapdoor where --url could target prod (or an
+ * unknown host) while --env was left at the staging default.
+ * @param {string} resolvedUrl
+ * @returns {"dev" | "staging" | "prod" | "unknown"}
+ */
+export function classifyResolvedUrl(resolvedUrl) {
+  if (resolvedUrl === PORTAL_URLS.prod) return "prod";
+  if (resolvedUrl === PORTAL_URLS.staging) return "staging";
+  if (resolvedUrl === PORTAL_URLS.dev) return "dev";
+  return "unknown";
+}
+
+/**
  * Build the request body sent to POST /api/admin/users.
  * @param {{
  *   email: string,
@@ -165,12 +182,6 @@ async function main() {
   }
 
   const env = values.env ?? "staging";
-  if (env === "prod" && !values["confirm-prod"] && !values["dry-run"]) {
-    fail(
-      "Refusing to target prod without --confirm-prod. Re-run with --confirm-prod once you have verified the org slug, email, and that this is the right environment."
-    );
-    return;
-  }
 
   const adminSecret = process.env.ADMIN_SECRET;
   if (!adminSecret && !values["dry-run"]) {
@@ -185,6 +196,24 @@ async function main() {
     portalUrl = resolvePortalUrl({ url: values.url, env });
   } catch (err) {
     fail(err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  // Confirmation guard: check the *resolved* target, not just --env, since
+  // --url overrides --env. Require --confirm-prod when the resolved URL
+  // matches the known prod URL OR is unknown (could be a custom prod
+  // domain we don't recognize). Dev/staging proceed without confirmation.
+  const targetClass = classifyResolvedUrl(portalUrl);
+  if (
+    (targetClass === "prod" || targetClass === "unknown") &&
+    !values["confirm-prod"] &&
+    !values["dry-run"]
+  ) {
+    fail(
+      targetClass === "prod"
+        ? `Refusing to target prod (${portalUrl}) without --confirm-prod. Re-run with --confirm-prod once you have verified the org slug, email, and that this is the right environment.`
+        : `Refusing to target a non-standard URL (${portalUrl}) without --confirm-prod. The known dev/staging URLs are recognized automatically; any --url override could be prod or a custom domain and must be explicitly confirmed.`
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary

Stopgap CLI to bootstrap a new tenant org (or add any cross-org user) without hand-crafting `curl`s against `/api/admin/users` with `X-Admin-Secret`. An \"org\" in the portal exists the moment the first user with that org string is created — there is no separate create-org step — so this same script covers both new-tenant onboarding and ad-hoc cross-org user creation.

- `scripts/create-org-admin.mjs` — plain Node 22 `.mjs` (no transpile, no new dependency)
- `npm run create-org-admin -- ...` — sources `ADMIN_SECRET` from env (works naturally with `op run --`)
- Defaults to `--env staging`; refuses `--env prod` without `--confirm-prod`
- `--dry-run` prints the constructed request (password redacted) so the operator can sanity-check before sending
- Auto-generates a 16-char base64url password by default; `--password` to override
- `--rights '*' | 'none' | 'en,es,ar'` covers the three `language_rights` shapes the worker accepts
- README gains a \"Bootstrapping a new org\" section with the one-liner

Triggered by Elsy's onboarding ask for Haneen (demo) — running this on staging tonight unblocks her without waiting for the proper super-admin UI feature.

## Why now / why not the full UI

The proper super-admin UI is tracked at #138 (new `isSuperAdmin` role on `StoredUser` + cross-org admin surface). That's a multi-PR feature touching auth model, worker handlers, and a new UI route. This is the 1-PR stopgap that immediately unblocks Elsy and removes curl-toil for the next few tenant onboardings. Per #139's spec, the script remains useful as the recovery / CI path even after #138 ships, symmetric to the worker's `X-Admin-Secret` CLI escape.

## Prod URL caveat

The prod URL is best-guessed as `https://bt-servant-admin-portal.unfoldingword.workers.dev` (the workers.dev URL implied by `wrangler.jsonc`'s top-level `name: \"bt-servant-admin-portal\"`). If a custom domain is in use, operators can pass `--url https://admin.btservant.ai` (or similar) to override. A follow-up to confirm + bake-in the actual prod URL can land later.

## Test plan

- [ ] `npm run create-org-admin -- --help` prints the usage block
- [ ] `ADMIN_SECRET=stub npm run create-org-admin -- --dry-run --env staging --org haneen --email h@example.com --name \"Haneen X\"` prints the constructed POST without sending
- [ ] Missing-arg path prints usage + a clear `Missing required: --email, --name, --org` error
- [ ] `--env prod` without `--confirm-prod` exits 1 with the prod guard message
- [ ] `--rights '*'`, `--rights none`, `--rights 'en,es,ar'` produce `\"*\"`, `[]`, and `[\"en\",\"es\",\"ar\"]` respectively in the payload
- [ ] On staging: an actual run (with real `ADMIN_SECRET`) creates a test user, then deletes it via the admin UI — confirming the wire format matches `worker/admin.ts:createUser`

## Reviewer notes

- Commit author is `Claude <claude@anthropic.com>` per `CLAUDE.md`'s cross-agent author convention (Claude authors its own commits; AGENTS.md mirrors this for Codex).
- `.mjs` was chosen over `.ts` to keep the script outside the `tsconfig.app.json` / `tsconfig.worker.json` project refs (no new types to maintain, no transpile step needed in CI). Node 22.22+ is already required by the deploy workflows.
- No unit tests added — script is a stopgap, used 2-3x/year. `--dry-run` is the meaningful smoke path. If the script grows, factoring `parseRights` / `resolvePortalUrl` / `buildPayload` (already exported) into a test file is straightforward.

Closes #139