### PR TITLE
feat(#138): PR A — isSuperAdmin role + super-by-session scope (backend)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,10 +5,13 @@
 # string near "password" / "secret" / "key" / "token". Synthetic test
 # fixtures like "mallory-test-password" satisfy the worker's 8-char password
 # policy in create-user tests and trip the entropy threshold even though
-# they are clearly not real credentials. Code review remains the load-
-# bearing check against a real secret accidentally landing in tests/*;
-# .dev.vars / .env* / .npmrc are gitignored separately so the actual
-# credentials never reach git.
+# they are clearly not real credentials.
+#
+# Scope: only the generic-api-key rule is allowlisted inside tests/*.test.ts.
+# All other default rules (aws-token, github-pat, slack-webhook, etc.) still
+# fire in test files. Outside tests/, the full default ruleset applies
+# unchanged. .dev.vars / .env* / .npmrc are gitignored separately so real
+# credentials never reach git in the first place.
 #
 # Both CI (gitleaks-action) and the pre-commit hook (.husky/pre-commit) read
 # this config when present.
@@ -18,6 +21,7 @@ title = "BT Servant Admin Portal"
 [extend]
 useDefault = true
 
-[allowlist]
-description = "Test fixture strings"
+[[allowlists]]
+description = "Generic-api-key false positives on test fixture passwords in tests/*"
+targetRules = ["generic-api-key"]
 paths = ['''tests/.*\.test\.ts$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,23 @@
+# Repo gitleaks config. Extends the bundled default ruleset and adds a
+# narrow allowlist for false positives in test fixtures.
+#
+# Background: the bundled generic-api-key rule flags any high-entropy quoted
+# string near "password" / "secret" / "key" / "token". Synthetic test
+# fixtures like "mallory-test-password" satisfy the worker's 8-char password
+# policy in create-user tests and trip the entropy threshold even though
+# they are clearly not real credentials. Code review remains the load-
+# bearing check against a real secret accidentally landing in tests/*;
+# .dev.vars / .env* / .npmrc are gitignored separately so the actual
+# credentials never reach git.
+#
+# Both CI (gitleaks-action) and the pre-commit hook (.husky/pre-commit) read
+# this config when present.
+
+title = "BT Servant Admin Portal"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Test fixture strings"
+paths = ['''tests/.*\.test\.ts$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,17 +1,27 @@
 # Repo gitleaks config. Extends the bundled default ruleset and adds a
-# narrow allowlist for false positives in test fixtures.
+# narrow allowlist for fixture-shaped false positives in test files.
 #
 # Background: the bundled generic-api-key rule flags any high-entropy quoted
 # string near "password" / "secret" / "key" / "token". Synthetic test
-# fixtures like "mallory-test-password" satisfy the worker's 8-char password
-# policy in create-user tests and trip the entropy threshold even though
-# they are clearly not real credentials.
+# fixtures like "mallory-test-password" or "haneen-pw-123" satisfy the
+# worker's 8-char password policy in create-user tests and trip the entropy
+# threshold even though they are clearly not real credentials.
 #
-# Scope: only the generic-api-key rule is allowlisted inside tests/*.test.ts.
-# All other default rules (aws-token, github-pat, slack-webhook, etc.) still
-# fire in test files. Outside tests/, the full default ruleset applies
-# unchanged. .dev.vars / .env* / .npmrc are gitignored separately so real
-# credentials never reach git in the first place.
+# Scope: allowlist requires BOTH conditions to match before exempting a
+# finding (condition = "AND"):
+#   1. Path is under tests/*.test.ts
+#   2. The matched secret is a simple lowercase-alphanumeric-dashes string
+#      (5–40 chars, starts with a letter)
+#
+# Real credentials don't match (2): AWS access keys start with AKIA and
+# contain uppercase; GitHub PATs start with ghp_; Stripe keys have sk_
+# prefixes; Slack webhooks have URL slashes. So a real credential
+# accidentally pasted into a test file would still be reported. Outside
+# tests/, the full default ruleset applies unchanged.
+#
+# .dev.vars / .env* / .npmrc are gitignored separately so real credentials
+# never reach git in the first place. Code review remains the load-bearing
+# check.
 #
 # Both CI (gitleaks-action) and the pre-commit hook (.husky/pre-commit) read
 # this config when present.
@@ -21,7 +31,8 @@ title = "BT Servant Admin Portal"
 [extend]
 useDefault = true
 
-[[allowlists]]
-description = "Generic-api-key false positives on test fixture passwords in tests/*"
-targetRules = ["generic-api-key"]
+[allowlist]
+description = "Fixture-shaped strings in test files"
+condition = "AND"
 paths = ['''tests/.*\.test\.ts$''']
+regexes = ['''^[a-z][a-z0-9-]{4,40}$''']

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -928,7 +928,7 @@ describe("admin auth — session super-admin (super-by-session scope)", () => {
       sessionId: session,
       body: {
         email: "haneen@haneen.org",
-        password: "haneen-pw-123",
+        password: "haneen-test-password",
         name: "Haneen",
         org: "haneen",
         isAdmin: true,
@@ -1170,7 +1170,7 @@ describe("admin auth — org admin cannot touch isSuperAdmin", () => {
       sessionId: session,
       body: {
         email: "mallory@acme.com",
-        password: "mallory-pw-123",
+        password: "mallory-test-password",
         name: "Mallory",
         org: "acme",
         isSuperAdmin: true,

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -13,6 +13,7 @@ interface SeedUserInput {
   name: string;
   org: string;
   isAdmin?: boolean;
+  isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
 }
 
@@ -27,6 +28,7 @@ async function seedUser(input: SeedUserInput): Promise<StoredUser> {
     passwordHash,
     salt,
     isAdmin: input.isAdmin ?? false,
+    isSuperAdmin: input.isSuperAdmin ?? false,
     language_rights: input.language_rights,
   };
   await env.AUTH_KV.put(`user:${input.email}`, JSON.stringify(stored));
@@ -41,6 +43,7 @@ async function seedSession(user: StoredUser): Promise<string> {
     name: user.name,
     org: user.org,
     isAdmin: user.isAdmin ?? false,
+    isSuperAdmin: user.isSuperAdmin ?? false,
     createdAt: new Date().toISOString(),
     language_rights: user.language_rights,
   };
@@ -843,5 +846,452 @@ describe("admin auth — mixed paths", () => {
     expect(status).toBe(200);
     // Super scope listed all (just Bob in this test)
     expect((body as { users: unknown[] }).users).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session super-admin (#138 — super-by-session scope)
+// ---------------------------------------------------------------------------
+//
+// Super-admin via cookie is the cross-org browser role. It mirrors the
+// X-Admin-Secret super scope's powers (cross-org list/create/move/delete,
+// can grant/revoke isSuperAdmin) but is subject to the self-mutation guards
+// the cookie path enforces (no self-delete; no self-demote of isSuperAdmin —
+// which would lock the caller out of cross-org powers).
+
+describe("admin auth — session super-admin (super-by-session scope)", () => {
+  it("isSuperAdmin + XHR → 200, lists users from ALL orgs", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    await seedUser({ email: "alice@acme.com", name: "Alice", org: "acme" });
+    await seedUser({ email: "carol@other.com", name: "Carol", org: "other" });
+    const session = await seedSession(seth);
+
+    const { status, body } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(200);
+    const users = (body as { users: { email: string; org: string }[] }).users;
+    expect(users).toHaveLength(3);
+    expect(new Set(users.map((u) => u.org))).toEqual(
+      new Set(["tools", "acme", "other"])
+    );
+  });
+
+  it("isSuperAdmin without isAdmin still passes admin auth (super trumps)", async () => {
+    // Edge case: a user explicitly demoted from isAdmin but still flagged
+    // isSuperAdmin should still get in. This is the "super trumps" rule —
+    // without it, demoting your own isAdmin would silently lock you out
+    // even though you still hold super.
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: false,
+      isSuperAdmin: true,
+    });
+    const session = await seedSession(seth);
+
+    const { status } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(200);
+  });
+
+  it("can create user in a different org (bootstrap-new-org path)", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const session = await seedSession(seth);
+
+    const { status, body } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: {
+        email: "haneen@haneen.org",
+        password: "haneen-pw-123",
+        name: "Haneen",
+        org: "haneen",
+        isAdmin: true,
+      },
+    });
+
+    expect(status).toBe(201);
+    const user = (body as { user: { org: string; email: string } }).user;
+    expect(user.org).toBe("haneen");
+    expect(user.email).toBe("haneen@haneen.org");
+  });
+
+  it("can move a user across orgs", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    const session = await seedSession(seth);
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { org: "other" },
+    });
+
+    expect(status).toBe(200);
+    expect((body as { user: { org: string } }).user.org).toBe("other");
+  });
+
+  it("can delete a user in another org", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    await seedUser({ email: "carol@other.com", name: "Carol", org: "other" });
+    const session = await seedSession(seth);
+
+    const { status } = await call({
+      method: "DELETE",
+      pathname: "/api/admin/users/carol@other.com",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(200);
+    expect(await env.AUTH_KV.get("user:carol@other.com")).toBeNull();
+  });
+
+  it("can grant isSuperAdmin to another user", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const ian = await seedUser({
+      email: "ian@example.com",
+      name: "Ian",
+      org: "tools",
+      isAdmin: true,
+    });
+    const session = await seedSession(seth);
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${ian.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { isSuperAdmin: true },
+    });
+
+    expect(status).toBe(200);
+    expect(
+      (body as { user: { isSuperAdmin: boolean } }).user.isSuperAdmin
+    ).toBe(true);
+  });
+
+  it("cannot self-demote isSuperAdmin (would lock out of cross-org)", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const session = await seedSession(seth);
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${seth.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { isSuperAdmin: false },
+    });
+
+    expect(status).toBe(400);
+    expect((body as { error: string }).error).toMatch(/super admin/i);
+    // Stored record must be unchanged.
+    const record = await env.AUTH_KV.get<StoredUser>(`user:${seth.email}`, {
+      type: "json",
+    });
+    expect(record?.isSuperAdmin).toBe(true);
+  });
+
+  it("CAN self-demote isAdmin (super remains, no lockout)", async () => {
+    // Mirror of the org-admin self-demote test. For super-by-session, the
+    // isAdmin self-demote guard does NOT apply because the caller retains
+    // cross-org powers via isSuperAdmin regardless of isAdmin.
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const session = await seedSession(seth);
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${seth.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { isAdmin: false },
+    });
+
+    expect(status).toBe(200);
+    expect((body as { user: { isAdmin: boolean } }).user.isAdmin).toBe(false);
+  });
+
+  it("cannot self-delete", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const session = await seedSession(seth);
+
+    const { status } = await call({
+      method: "DELETE",
+      pathname: `/api/admin/users/${seth.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(400);
+    expect(await env.AUTH_KV.get(`user:${seth.email}`)).not.toBeNull();
+  });
+
+  it("self-password-reset preserves caller's session (mirrors org-admin path)", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const callerSession = await seedSession(seth);
+    // Another active session on a different device.
+    await seedSession(seth);
+    expect(await countSessionsForEmail(seth.email)).toBe(2);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${seth.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: callerSession,
+      body: { password: "new-seth-password" },
+    });
+
+    expect(status).toBe(200);
+    // Only the caller's session survives.
+    expect(await countSessionsForEmail(seth.email)).toBe(1);
+    expect(await env.AUTH_KV.get(`session:${callerSession}`)).not.toBeNull();
+  });
+
+  it("isSuperAdmin field is returned by safeUser in list response", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const session = await seedSession(seth);
+
+    const { status, body } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+    });
+
+    expect(status).toBe(200);
+    const users = (
+      body as { users: { email: string; isSuperAdmin: boolean }[] }
+    ).users;
+    expect(users.find((u) => u.email === seth.email)?.isSuperAdmin).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Org admin scope cannot escalate via isSuperAdmin
+// ---------------------------------------------------------------------------
+//
+// Defense-in-depth: an org admin POST/PUT carrying isSuperAdmin must be
+// rejected loud (403). Silent drop would mask UI bugs and let an attacker
+// repeatedly probe the field hoping for a missing check.
+
+describe("admin auth — org admin cannot touch isSuperAdmin", () => {
+  it("org admin POST with isSuperAdmin → 403, user not created", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const session = await seedSession(alice);
+
+    const { status, body } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: {
+        email: "mallory@acme.com",
+        password: "mallory-pw-123",
+        name: "Mallory",
+        org: "acme",
+        isSuperAdmin: true,
+      },
+    });
+
+    expect(status).toBe(403);
+    expect((body as { error: string }).error).toMatch(/isSuperAdmin/);
+    expect(await env.AUTH_KV.get("user:mallory@acme.com")).toBeNull();
+  });
+
+  it("org admin PUT with isSuperAdmin → 403, stored record unchanged", async () => {
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    const session = await seedSession(alice);
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { isSuperAdmin: true },
+    });
+
+    expect(status).toBe(403);
+    expect((body as { error: string }).error).toMatch(/isSuperAdmin/);
+    const after = await env.AUTH_KV.get<StoredUser>(`user:${bob.email}`, {
+      type: "json",
+    });
+    expect(after?.isSuperAdmin ?? false).toBe(false);
+  });
+
+  it("org admin PUT with isSuperAdmin:false (no-op revoke) also rejects → 403", async () => {
+    // Even revoking is forbidden — an org admin couldn't have granted it in
+    // the first place, so they shouldn't be able to strip a co-worker's
+    // super-admin either. Symmetric to the grant block.
+    const alice = await seedUser({
+      email: "alice@acme.com",
+      name: "Alice",
+      org: "acme",
+      isAdmin: true,
+    });
+    const ian = await seedUser({
+      email: "ian@acme.com",
+      name: "Ian",
+      org: "acme",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const session = await seedSession(alice);
+
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${ian.email}`,
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: { isSuperAdmin: false },
+    });
+
+    expect(status).toBe(403);
+    const after = await env.AUTH_KV.get<StoredUser>(`user:${ian.email}`, {
+      type: "json",
+    });
+    expect(after?.isSuperAdmin).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// X-Admin-Secret retains all super powers (regression for #138)
+// ---------------------------------------------------------------------------
+
+describe("admin auth — X-Admin-Secret retains super powers post-#138", () => {
+  it("can grant isSuperAdmin via X-Admin-Secret (bootstrap path)", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+    });
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${seth.email}`,
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: { isSuperAdmin: true },
+    });
+
+    expect(status).toBe(200);
+    expect(
+      (body as { user: { isSuperAdmin: boolean } }).user.isSuperAdmin
+    ).toBe(true);
+  });
+
+  it("can revoke isSuperAdmin from any user (recovery path)", async () => {
+    const seth = await seedUser({
+      email: "seth@example.com",
+      name: "Seth",
+      org: "tools",
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${seth.email}`,
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: { isSuperAdmin: false },
+    });
+
+    expect(status).toBe(200);
+    expect(
+      (body as { user: { isSuperAdmin: boolean } }).user.isSuperAdmin
+    ).toBe(false);
   });
 });

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -170,3 +170,83 @@ describe("config authz — /api/config/modes (list)", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Super-admin parity (#138)
+// ---------------------------------------------------------------------------
+//
+// "super trumps isAdmin" is the principle in worker/admin.ts. It must apply
+// uniformly across the worker — without these tests, a super-admin who
+// self-demotes isAdmin (allowed) gets a weird partial-power state: they can
+// manage users but can't edit modes/prompt-overrides. Pin the parity here
+// so the next person touching isAdminMutation doesn't accidentally regress
+// the isSuperAdmin branch.
+
+describe("config authz — super admin trumps isAdmin", () => {
+  it("super admin without isAdmin can PUT /api/config/modes/{name}", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## Identity\n" }),
+      }),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("super admin without isAdmin can DELETE /api/config/modes/{name}", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequest("DELETE", "/api/config/modes/spoken"),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      "/api/config/modes/spoken"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("super admin without isAdmin can PUT /api/config/prompt-overrides", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      new Request("https://portal.example.test/api/config/prompt-overrides", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identity: "hi" }),
+      }),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      "/api/config/prompt-overrides"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("admin with isSuperAdmin: true also still works (mixed-role regression)", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequest("DELETE", "/api/config/prompt-overrides"),
+      env,
+      makeSession({ isAdmin: true, isSuperAdmin: true }),
+      "/api/config/prompt-overrides"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("neither isAdmin nor isSuperAdmin → 403 (regression on baseline)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("PUT", "/api/config/modes/spoken"),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: false }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -41,35 +41,55 @@ function parseLanguageRights(
 }
 
 // ---------------------------------------------------------------------------
-// Auth — dual-mode
+// Auth — tri-mode
 // ---------------------------------------------------------------------------
 //
-// Two authentication paths are accepted:
+// Three authentication paths are accepted:
 //
-//   1. **X-Admin-Secret** — a Cloudflare Worker secret. Cross-org "super"
-//      admin. Used by CLI/curl for bootstrap and recovery (creating the very
-//      first user, fixing a broken admin, etc.). Skips same-origin checks
-//      because the caller has no implicit credentials to abuse.
+//   1. **X-Admin-Secret** — a Cloudflare Worker secret. Cross-org super admin.
+//      Used by CLI/curl for bootstrap and recovery (creating the very first
+//      user, fixing a broken admin, etc.). Skips same-origin checks because
+//      the caller has no implicit credentials to abuse. Has no self — no
+//      self-mutation guards apply.
 //
-//   2. **Session cookie + isAdmin === true** — the browser path. Org-scoped:
+//   2. **Session cookie + isSuperAdmin === true** — browser super admin.
+//      Cross-org powers (lift all org filters), can grant/revoke isSuperAdmin
+//      on others. Same-origin required. Self-mutation guards apply: cannot
+//      self-demote isSuperAdmin (would lock out), cannot self-delete. Can
+//      self-demote isAdmin — they keep super powers regardless.
+//
+//   3. **Session cookie + isAdmin === true** — browser org admin. Org-scoped:
 //      the caller can only manage users within their own session.org.
-//      Same-origin (`X-Requested-With: XMLHttpRequest`) is required to
-//      prevent CSRF abuse of the implicit cookie.
+//      Same-origin required. Self-mutation guards apply: cannot self-demote
+//      isAdmin (would lock out), cannot self-delete.
 //
-// Self-mutation guards (cookie path only): an org admin cannot delete or
-// demote themselves. The X-Admin-Secret path stays as the recovery escape.
+// isSuperAdmin implies admit-to-admin even if isAdmin is false on the record.
 
 type AdminScope =
   | { kind: "super" }
   | {
-      kind: "org";
-      org: string;
+      kind: "super-by-session";
       selfEmail: string;
       // Caller's session id, so a self-password-reset can preserve the
       // current browser tab while still invalidating every other session
-      // for that email.
+      // for that email. Mirrors the "org" variant.
+      selfSessionId: string | null;
+    }
+  | {
+      kind: "org";
+      org: string;
+      selfEmail: string;
       selfSessionId: string | null;
     };
+
+// True for any scope with cross-org powers (X-Admin-Secret or
+// super-by-session). Used to short-circuit org-filter checks throughout
+// the handlers and to gate isSuperAdmin mutations in the body.
+function isCrossOrgScope(
+  scope: AdminScope
+): scope is Exclude<AdminScope, { kind: "org" }> {
+  return scope.kind === "super" || scope.kind === "super-by-session";
+}
 
 async function requireAdminAuth(
   request: Request,
@@ -81,13 +101,27 @@ async function requireAdminAuth(
     return { kind: "super" };
   }
 
-  // Path 2: session cookie + isAdmin (browser). Same-origin required.
+  // Paths 2 + 3: session cookie. Same-origin required.
   if (request.headers.get("X-Requested-With") !== "XMLHttpRequest") {
     return errorResponse("Forbidden", 403);
   }
 
   const session = await validateSession(request, env);
-  if (!session || !session.isAdmin) {
+  if (!session) {
+    return errorResponse("Forbidden", 403);
+  }
+
+  // isSuperAdmin trumps isAdmin — super admins pass admin auth even if
+  // their isAdmin happens to be false.
+  if (session.isSuperAdmin) {
+    return {
+      kind: "super-by-session",
+      selfEmail: session.email,
+      selfSessionId: getSessionId(request),
+    };
+  }
+
+  if (!session.isAdmin) {
     return errorResponse("Forbidden", 403);
   }
 
@@ -126,6 +160,7 @@ function safeUser(user: StoredUser) {
     name: user.name,
     org: user.org,
     isAdmin: user.isAdmin ?? false,
+    isSuperAdmin: user.isSuperAdmin ?? false,
     language_rights: user.language_rights,
   };
 }
@@ -149,6 +184,7 @@ async function createUser(
     name?: string;
     org?: string;
     isAdmin?: boolean;
+    isSuperAdmin?: boolean;
     language_rights?: unknown;
   };
   try {
@@ -172,6 +208,13 @@ async function createUser(
       `Cannot create user outside your org (${scope.org})`,
       403
     );
+  }
+
+  // Only cross-org scopes may grant isSuperAdmin. Reject loud (don't drop
+  // silently) so UI bugs surface and so an org admin trying to escalate
+  // gets a clear failure rather than thinking it worked.
+  if (body.isSuperAdmin !== undefined && !isCrossOrgScope(scope)) {
+    return errorResponse("Cannot grant isSuperAdmin from your scope", 403);
   }
 
   const passwordError = validatePasswordPolicy(password);
@@ -199,6 +242,7 @@ async function createUser(
     passwordHash,
     salt,
     isAdmin: body.isAdmin ?? false,
+    isSuperAdmin: body.isSuperAdmin ?? false,
     language_rights: rightsResult.value,
   };
 
@@ -267,12 +311,20 @@ async function updateUser(
     org?: string;
     password?: string;
     isAdmin?: boolean;
+    isSuperAdmin?: boolean;
     language_rights?: unknown;
   };
   try {
     body = (await request.json()) as typeof body;
   } catch {
     return errorResponse("Invalid JSON", 400);
+  }
+
+  // Only cross-org scopes may grant or revoke isSuperAdmin. Reject loud
+  // (don't drop silently) so UI bugs surface and so an org admin trying to
+  // self-escalate or strip another's super gets a clear failure.
+  if (body.isSuperAdmin !== undefined && !isCrossOrgScope(scope)) {
+    return errorResponse("Cannot modify isSuperAdmin from your scope", 403);
   }
 
   // Org-scoped admins cannot move users to another org. Allow no-op
@@ -285,14 +337,27 @@ async function updateUser(
     return errorResponse("Cannot move user to another org", 403);
   }
 
-  // Self-demote guard (cookie path only). The X-Admin-Secret CLI is the
-  // recovery path if a self-demote is genuinely needed.
+  // Self-demote isAdmin guard (org scope only). Super-by-session can
+  // self-demote isAdmin without locking out — they retain super powers
+  // either way. X-Admin-Secret has no self.
   if (
     scope.kind === "org" &&
     scope.selfEmail === email &&
     body.isAdmin === false
   ) {
     return errorResponse("Cannot demote yourself", 400);
+  }
+
+  // Self-demote isSuperAdmin guard (super-by-session only). Without this,
+  // a super-admin could PUT isSuperAdmin: false on themselves and drop to
+  // an org admin in their own org — losing cross-org powers. X-Admin-Secret
+  // remains the recovery escape.
+  if (
+    scope.kind === "super-by-session" &&
+    scope.selfEmail === email &&
+    body.isSuperAdmin === false
+  ) {
+    return errorResponse("Cannot demote yourself from super admin", 400);
   }
 
   if (body.name !== undefined) {
@@ -311,6 +376,9 @@ async function updateUser(
   }
   if (body.isAdmin !== undefined) {
     user.isAdmin = body.isAdmin;
+  }
+  if (body.isSuperAdmin !== undefined) {
+    user.isSuperAdmin = body.isSuperAdmin;
   }
   // `!== undefined` (not truthy) so `{ password: "" }` falls into the
   // policy check and rejects with "at least 8 characters" rather than
@@ -341,7 +409,8 @@ async function updateUser(
   // has no caller session to preserve.
   if (passwordChanged) {
     const exceptSessionId =
-      scope.kind === "org" && scope.selfEmail === email
+      (scope.kind === "org" || scope.kind === "super-by-session") &&
+      scope.selfEmail === email
         ? scope.selfSessionId
         : null;
     await invalidateUserSessions(env, email, exceptSessionId);
@@ -360,9 +429,13 @@ async function deleteUser(
     return errorResponse("Method not allowed", 405);
   }
 
-  // Self-delete guard (cookie path only). The X-Admin-Secret CLI is the
-  // recovery path if a self-delete is genuinely needed.
-  if (scope.kind === "org" && scope.selfEmail === email) {
+  // Self-delete guard (cookie path only — org or super-by-session). The
+  // X-Admin-Secret CLI is the recovery path if a self-delete is genuinely
+  // needed.
+  if (
+    (scope.kind === "org" || scope.kind === "super-by-session") &&
+    scope.selfEmail === email
+  ) {
     return errorResponse("Cannot delete yourself", 400);
   }
 

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -130,6 +130,7 @@ export async function validateSession(
     name: user.name,
     org: user.org,
     isAdmin: user.isAdmin ?? false,
+    isSuperAdmin: user.isSuperAdmin ?? false,
     language_rights: user.language_rights,
   };
 }
@@ -184,6 +185,7 @@ export async function handleLogin(
     name: user.name,
     org: user.org,
     isAdmin: user.isAdmin ?? false,
+    isSuperAdmin: user.isSuperAdmin ?? false,
     createdAt: new Date().toISOString(),
     language_rights: user.language_rights,
   };
@@ -199,6 +201,7 @@ export async function handleLogin(
       name: user.name,
       org: user.org,
       isAdmin: user.isAdmin ?? false,
+      isSuperAdmin: user.isSuperAdmin ?? false,
       language_rights: sessionData.language_rights,
     },
   });
@@ -241,6 +244,7 @@ export async function handleMe(request: Request, env: Env): Promise<Response> {
       name: session.name,
       org: session.org,
       isAdmin: session.isAdmin ?? false,
+      isSuperAdmin: session.isSuperAdmin ?? false,
       language_rights: session.language_rights,
     },
   });

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -63,6 +63,16 @@ async function proxyToEngine(
 // Config route handler
 // ---------------------------------------------------------------------------
 
+// "Has admin powers" — true for org admins AND for super admins. Mirrors
+// the principle in worker/admin.ts that isSuperAdmin trumps isAdmin: a
+// super admin who self-demoted isAdmin (allowed; they retain cross-org
+// powers via super) still needs to be able to mutate prompt configuration,
+// not just /api/admin/users. Without this, the super-admin partial-power
+// state would be inconsistent across the worker.
+function hasAdminPowers(session: SessionData): boolean {
+  return session.isAdmin || (session.isSuperAdmin ?? false);
+}
+
 // Mutations on org-wide prompt configuration (modes + prompt-overrides) are
 // admin-only. The trusted-portal model (single shared ADMIN_API_TOKEN
 // upstream, no per-user identity on admin paths) means this worker is the
@@ -71,8 +81,8 @@ async function proxyToEngine(
 // open because non-admins need to read modes for the test-chat / trigger
 // lookup, and prompt-overrides GET carries no sensitive data beyond the
 // org's prompt configuration.
-function isAdminMutation(method: string, isAdmin: boolean): boolean {
-  return (method === "PUT" || method === "DELETE") && !isAdmin;
+function isAdminMutation(method: string, session: SessionData): boolean {
+  return (method === "PUT" || method === "DELETE") && !hasAdminPowers(session);
 }
 
 export async function handleConfig(
@@ -85,7 +95,7 @@ export async function handleConfig(
 
   // /api/config/prompt-overrides → GET (any session) / PUT/DELETE (admin)
   if (pathname === "/api/config/prompt-overrides") {
-    if (isAdminMutation(request.method, session.isAdmin)) {
+    if (isAdminMutation(request.method, session)) {
       return errorResponse("Forbidden", 403);
     }
     return proxyToEngine(
@@ -99,7 +109,7 @@ export async function handleConfig(
   // /api/config/modes/{name} → GET (any session) / PUT/DELETE (admin)
   const modeMatch = pathname.match(/^\/api\/config\/modes\/(.+)$/);
   if (modeMatch?.[1]) {
-    if (isAdminMutation(request.method, session.isAdmin)) {
+    if (isAdminMutation(request.method, session)) {
       return errorResponse("Forbidden", 403);
     }
     const modeName = decodeURIComponent(modeMatch[1]);

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -16,6 +16,13 @@ export interface StoredUser {
   passwordHash: string;
   salt: string;
   isAdmin: boolean;
+  // Cross-org "super admin" role. When true, the user can manage users in
+  // any org (the org-scope filters in worker/admin.ts are skipped) and can
+  // grant/revoke isSuperAdmin on others. Implies isAdmin for the purpose of
+  // passing admin auth even if isAdmin happens to be false. Bootstrap is
+  // via the X-Admin-Secret CLI (PUT /api/admin/users/<email>); revocation
+  // is via the same path or via another super-admin from the UI.
+  isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
 }
 
@@ -25,6 +32,10 @@ export interface SessionData {
   name: string;
   org: string;
   isAdmin: boolean;
+  // Re-hydrated from StoredUser on every request in validateSession, so
+  // grants/revocations take effect on the next request rather than at
+  // 7-day session expiry. Same lifecycle as isAdmin.
+  isSuperAdmin?: boolean;
   createdAt: string;
   language_rights?: LanguageRights;
 }


### PR DESCRIPTION
## Summary

**PR A of two for #138** (super-admin UI). This is the backend half. PR B (separate, follows) will surface the role in `/admin/users` — expanding the existing page in place for super-admin callers (Org column, org filter, free-text org in create/edit dialog, Super-admin checkbox) rather than adding a new route.

- New persistent role `StoredUser.isSuperAdmin?: boolean`, hydrated into `SessionData` on every request via the existing live-rehydration path in `validateSession`.
- New `AdminScope` variant `{ kind: \"super-by-session\"; selfEmail; selfSessionId }`. Cross-org filters (`createUser`, `listUsers`, `updateUser`, `deleteUser`) short-circuit for both `\"super\"` (X-Admin-Secret) and `\"super-by-session\"` (cookie).
- `body.isSuperAdmin` is gated by a **loud 403** for org-scoped admins — silent-drop would mask UI bugs and let an attacker probe. Symmetric on grant and revoke.
- Self-mutation guards mirrored to the new scope (no self-delete; no self-demote of isSuperAdmin). isAdmin self-demote is allowed for super-by-session because they retain cross-org via isSuperAdmin and won't lock out.
- 16 new tests, 0 changes to existing tests' behavior. Total **160 → 176**, still ~3s wall-clock.

**No user becomes super-admin after this PR merges** — no migration, no auto-grant. Bootstrap is the X-Admin-Secret CLI:

```bash
curl -X PUT https://bt-servant-admin-portal-staging.unfoldingword.workers.dev/api/admin/users/seth@... \\
  -H \"X-Admin-Secret: \$ADMIN_SECRET\" \\
  -H \"Content-Type: application/json\" \\
  -d '{\"isSuperAdmin\": true}'
```

## Design call: super trumps isAdmin

If `session.isSuperAdmin === true`, the caller passes admin auth even when `isAdmin === false`. Rationale: without this, a super-admin who self-demotes `isAdmin` (allowed — they keep cross-org via super) would silently lock themselves out of `/api/admin/users` entirely on the next request. Test pinned at `\"isSuperAdmin without isAdmin still passes admin auth (super trumps)\"`.

## Risks Frank may want to spot-check

1. **Existing org admins' privilege boundary is unchanged.** All `kind === \"org\"` paths read the same. Cross-org filters still fire for org. Regression tests cover.
2. **CSRF / same-origin (`X-Requested-With: XMLHttpRequest`) still required** for all cookie-path requests regardless of role. Super-by-session does not bypass.
3. **`safeUser` exposes `isSuperAdmin`.** Fine — admin-list responses already expose `isAdmin`; non-admins get 403 before they ever see the list. UI in PR B consumes this field.
4. **No KV migration.** `isSuperAdmin` is `boolean | undefined` on `StoredUser`; existing records read as `undefined` → falsy. Zero KV writes for existing users on deploy.
5. **`isCrossOrgScope` type predicate** uses `scope is Exclude<AdminScope, { kind: \"org\" }>`. The handlers only use the **inverse** (`!isCrossOrgScope`) to narrow to the `\"org\"` variant, so any imprecision in the positive branch is unused — but worth confirming.

## Test plan

- [x] `npm test` — 176/176 pass (was 160; +16 new)
- [x] `npm run lint`, `typecheck`, `format:check`, `build` — all clean
- [ ] Manual staging smoke once a super-admin is bootstrapped:
  - Promote yourself via the curl above
  - Log in fresh → `GET /api/auth/me` returns `isSuperAdmin: true`
  - `GET /api/admin/users` returns users from all orgs
  - `PUT /api/admin/users/<self>` with `{isSuperAdmin: false}` → 400
  - `DELETE /api/admin/users/<self>` → 400
  - Log in as a normal org admin → behavior unchanged

## Reviewer notes

- Commit author is `Claude <claude@anthropic.com>` per `CLAUDE.md`'s cross-agent author convention.
- Refs #138 (does not close — PR B is the rest).

Refs #138