### PR TITLE
feat(#138): PR B — super-admin UI on /admin/users (frontend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ The Cloudflare Worker acts as a BFF proxy, authenticating requests and forwardin
 
 ## Bootstrapping a new org
 
-An "org" in the portal is a free-text string on each user record — it "exists" the moment the first user with that org string is created. Provisioning a new tenant (or any cross-org user creation) goes through the portal worker's `X-Admin-Secret` path, since org-scoped admins can only create users in their own org.
+An "org" in the portal is a free-text string on each user record — it "exists" the moment the first user with that org string is created. Two paths:
 
-A stopgap CLI wraps the call so operators don't hand-craft curls. (A proper super-admin UI is tracked in [#138](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/138); this script remains the recovery / CI path.)
+1. **From the UI as a super admin** — on `/admin/users` the create-user dialog has an editable Org field for super admins. Typing a new slug creates that org with this user as a member. (See "Bootstrapping a super admin" below for how to get the first super admin.)
+2. **Via the CLI with `X-Admin-Secret`** — the recovery / CI path, also used before any super admin exists in an environment.
 
 ```bash
 # Source ADMIN_SECRET from your password manager (1Password example below)
@@ -111,3 +112,21 @@ ADMIN_SECRET=… npm run create-org-admin -- --help
 ```
 
 On success the script prints the created user and the initial password — share both out-of-band; the user can change the password after first sign-in. `ADMIN_SECRET` is the portal worker's wrangler secret (see `worker/admin.ts` for the auth model); it is never echoed back.
+
+## Bootstrapping a super admin
+
+A super admin has cross-org powers: they see users across every org on `/admin/users`, can create users in any org, can move users between orgs, and can grant/revoke `isSuperAdmin` on others. This is intentionally a small set of people (typically the maintainers).
+
+The first super admin in any environment is granted via a one-time curl against the portal worker with `X-Admin-Secret`. After that, super admins can grant the role to each other from the UI.
+
+```bash
+op run -- curl -X PUT \
+  https://bt-servant-admin-portal-staging.unfoldingword.workers.dev/api/admin/users/seth@example.com \
+  -H "X-Admin-Secret: $ADMIN_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"isSuperAdmin": true}'
+```
+
+The grant takes effect on the user's next request (the session re-hydrates from the live user record on every request, so no logout/login is required — but they may need to refresh the page to see the new UI affordances).
+
+Revocation works the same way with `{"isSuperAdmin": false}`. A super admin cannot self-revoke from the UI (the worker rejects with 400 to prevent locking yourself out); use the CLI for that.

--- a/src/app/pages/admin-users.tsx
+++ b/src/app/pages/admin-users.tsx
@@ -7,6 +7,7 @@ import type { AdminUser } from "@/types/admin-users";
 import {
   AdminUsersForbiddenError,
   AdminUsersRequestError,
+  ORG_FILTER_ALL_SENTINEL,
 } from "@/lib/admin-users-api";
 import { useAuthStore } from "@/lib/auth-store";
 import { useAdminUsers, useDeleteAdminUser } from "@/hooks/use-admin-users";
@@ -33,11 +34,6 @@ import { AdminUserCreateDialog } from "@/components/admin-user-create-dialog";
 import { AdminUserEditDialog } from "@/components/admin-user-edit-dialog";
 import { PageHeader } from "@/components/page-header";
 
-// Sentinel for the "all orgs" entry in the super-admin org filter Select.
-// Radix Select disallows empty-string item values, so we use a literal
-// that can never collide with a real org slug.
-const ALL_ORGS = "__all__";
-
 export function AdminUsersPage() {
   const callerEmail = useAuthStore((s) => s.user?.email ?? "");
   const callerOrg = useAuthStore((s) => s.user?.org ?? "");
@@ -53,7 +49,7 @@ export function AdminUsersPage() {
     null
   );
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [orgFilter, setOrgFilter] = useState<string>(ALL_ORGS);
+  const [orgFilter, setOrgFilter] = useState<string>(ORG_FILTER_ALL_SENTINEL);
 
   const editingUser = useMemo(
     () => usersQuery.data?.find((u) => u.email === editingEmail) ?? null,
@@ -75,7 +71,7 @@ export function AdminUsersPage() {
 
   const visibleUsers = useMemo(() => {
     if (!usersQuery.data) return [];
-    if (!callerIsSuperAdmin || orgFilter === ALL_ORGS) {
+    if (!callerIsSuperAdmin || orgFilter === ORG_FILTER_ALL_SENTINEL) {
       return usersQuery.data;
     }
     return usersQuery.data.filter((u) => u.org === orgFilter);
@@ -119,7 +115,9 @@ export function AdminUsersPage() {
                 <SelectValue placeholder="Filter by org" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={ALL_ORGS}>All organizations</SelectItem>
+                <SelectItem value={ORG_FILTER_ALL_SENTINEL}>
+                  All organizations
+                </SelectItem>
                 {distinctOrgs.map((org) => (
                   <SelectItem key={org} value={org}>
                     {org}
@@ -163,7 +161,7 @@ export function AdminUsersPage() {
               No users in <span className="font-mono">{orgFilter}</span>.{" "}
               <button
                 type="button"
-                onClick={() => setOrgFilter(ALL_ORGS)}
+                onClick={() => setOrgFilter(ORG_FILTER_ALL_SENTINEL)}
                 className="text-foreground underline-offset-2 hover:underline"
               >
                 Clear filter
@@ -312,10 +310,14 @@ function UserRow({
       )}
       <td className="px-6 py-3">
         <div className="flex flex-wrap gap-1">
-          {user.isSuperAdmin && (
-            // Distinct visual from the org Admin badge so the cross-org
-            // role is obvious at a glance. Only super-admin viewers see
-            // this field populated (org admins get an org-filtered list).
+          {callerIsSuperAdmin && user.isSuperAdmin && (
+            // Gated on the viewer (callerIsSuperAdmin), not just the row.
+            // The worker's safeUser returns isSuperAdmin to every admin
+            // caller — including org admins viewing their own org-filtered
+            // list — so an unsuper viewer seeing a same-org colleague who
+            // happens to also hold super would leak the cross-org role.
+            // A worker-side redaction is a more durable fix (track as a
+            // follow-up) but the UI gate closes the leak today.
             <Badge className="bg-primary/15 text-primary hover:bg-primary/20 border-primary/30 border">
               Super
             </Badge>

--- a/src/app/pages/admin-users.tsx
+++ b/src/app/pages/admin-users.tsx
@@ -22,13 +22,26 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { AdminUserCreateDialog } from "@/components/admin-user-create-dialog";
 import { AdminUserEditDialog } from "@/components/admin-user-edit-dialog";
 import { PageHeader } from "@/components/page-header";
 
+// Sentinel for the "all orgs" entry in the super-admin org filter Select.
+// Radix Select disallows empty-string item values, so we use a literal
+// that can never collide with a real org slug.
+const ALL_ORGS = "__all__";
+
 export function AdminUsersPage() {
   const callerEmail = useAuthStore((s) => s.user?.email ?? "");
   const callerOrg = useAuthStore((s) => s.user?.org ?? "");
+  const callerIsSuperAdmin = useAuthStore((s) => s.user?.isSuperAdmin ?? false);
 
   const usersQuery = useAdminUsers();
   const languagesQuery = useLanguages();
@@ -40,6 +53,7 @@ export function AdminUsersPage() {
     null
   );
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [orgFilter, setOrgFilter] = useState<string>(ALL_ORGS);
 
   const editingUser = useMemo(
     () => usersQuery.data?.find((u) => u.email === editingEmail) ?? null,
@@ -49,6 +63,23 @@ export function AdminUsersPage() {
     () => usersQuery.data?.find((u) => u.email === confirmDeleteEmail) ?? null,
     [usersQuery.data, confirmDeleteEmail]
   );
+
+  // Distinct orgs from the returned user list. Org admins receive an
+  // org-filtered list (trivially length 1) but we hide the filter for
+  // them anyway; for super admins this enumerates every org with at
+  // least one user.
+  const distinctOrgs = useMemo(() => {
+    if (!usersQuery.data) return [];
+    return Array.from(new Set(usersQuery.data.map((u) => u.org))).sort();
+  }, [usersQuery.data]);
+
+  const visibleUsers = useMemo(() => {
+    if (!usersQuery.data) return [];
+    if (!callerIsSuperAdmin || orgFilter === ALL_ORGS) {
+      return usersQuery.data;
+    }
+    return usersQuery.data.filter((u) => u.org === orgFilter);
+  }, [usersQuery.data, callerIsSuperAdmin, orgFilter]);
 
   const handleConfirmDelete = () => {
     if (!confirmDeleteUser) return;
@@ -73,11 +104,30 @@ export function AdminUsersPage() {
     <div className="flex h-full flex-col overflow-hidden">
       <PageHeader
         title="Users"
-        subtitle={`Manage users in the ${callerOrg} organization. Assign org admin and language-shepherd permissions here.`}
+        subtitle={
+          callerIsSuperAdmin
+            ? "Manage users across all organizations. Assign org admin, super admin, and language-shepherd permissions here."
+            : `Manage users in the ${callerOrg} organization. Assign org admin and language-shepherd permissions here.`
+        }
       />
 
       <div className="bg-card border-b">
         <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
+          {callerIsSuperAdmin && distinctOrgs.length > 0 && (
+            <Select value={orgFilter} onValueChange={setOrgFilter}>
+              <SelectTrigger className="w-[220px]">
+                <SelectValue placeholder="Filter by org" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_ORGS}>All organizations</SelectItem>
+                {distinctOrgs.map((org) => (
+                  <SelectItem key={org} value={org}>
+                    {org}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
           <div className="flex-1" />
           <Button size="sm" onClick={() => setCreateOpen(true)}>
             <Plus className="mr-1.5 size-3.5" />
@@ -107,12 +157,28 @@ export function AdminUsersPage() {
               No users yet. Click &ldquo;New user&rdquo; to add the first one.
             </p>
           </div>
+        ) : visibleUsers.length === 0 ? (
+          <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+            <p className="text-sm">
+              No users in <span className="font-mono">{orgFilter}</span>.{" "}
+              <button
+                type="button"
+                onClick={() => setOrgFilter(ALL_ORGS)}
+                className="text-foreground underline-offset-2 hover:underline"
+              >
+                Clear filter
+              </button>
+            </p>
+          </div>
         ) : (
           <table className="w-full text-sm">
             <thead className="bg-muted/40 text-muted-foreground sticky top-0 text-xs tracking-wide uppercase">
               <tr>
                 <th className="px-6 py-3 text-left font-medium">Name</th>
                 <th className="px-6 py-3 text-left font-medium">Email</th>
+                {callerIsSuperAdmin && (
+                  <th className="px-6 py-3 text-left font-medium">Org</th>
+                )}
                 <th className="px-6 py-3 text-left font-medium">Role</th>
                 <th className="px-6 py-3 text-left font-medium">
                   Language access
@@ -121,11 +187,12 @@ export function AdminUsersPage() {
               </tr>
             </thead>
             <tbody className="divide-y">
-              {usersQuery.data.map((u) => (
+              {visibleUsers.map((u) => (
                 <UserRow
                   key={u.email}
                   user={u}
                   isSelf={u.email === callerEmail}
+                  callerIsSuperAdmin={callerIsSuperAdmin}
                   onEdit={() => setEditingEmail(u.email)}
                   onDelete={() => {
                     setDeleteError(null);
@@ -142,6 +209,7 @@ export function AdminUsersPage() {
         open={createOpen}
         onOpenChange={setCreateOpen}
         callerOrg={callerOrg}
+        callerIsSuperAdmin={callerIsSuperAdmin}
         availableLanguages={languagesQuery.data?.languages}
       />
 
@@ -152,6 +220,7 @@ export function AdminUsersPage() {
           if (!open) setEditingEmail(null);
         }}
         callerEmail={callerEmail}
+        callerIsSuperAdmin={callerIsSuperAdmin}
         availableLanguages={languagesQuery.data?.languages}
       />
 
@@ -215,11 +284,18 @@ export function AdminUsersPage() {
 interface UserRowProps {
   user: AdminUser;
   isSelf: boolean;
+  callerIsSuperAdmin: boolean;
   onEdit: () => void;
   onDelete: () => void;
 }
 
-function UserRow({ user, isSelf, onEdit, onDelete }: UserRowProps) {
+function UserRow({
+  user,
+  isSelf,
+  callerIsSuperAdmin,
+  onEdit,
+  onDelete,
+}: UserRowProps) {
   return (
     <tr className="hover:bg-muted/30 transition-colors">
       <td className="px-6 py-3">
@@ -229,12 +305,27 @@ function UserRow({ user, isSelf, onEdit, onDelete }: UserRowProps) {
       <td className="text-muted-foreground px-6 py-3 font-mono text-xs">
         {user.email}
       </td>
+      {callerIsSuperAdmin && (
+        <td className="text-muted-foreground px-6 py-3 font-mono text-xs">
+          {user.org}
+        </td>
+      )}
       <td className="px-6 py-3">
-        {user.isAdmin ? (
-          <Badge>Admin</Badge>
-        ) : (
-          <Badge variant="outline">Member</Badge>
-        )}
+        <div className="flex flex-wrap gap-1">
+          {user.isSuperAdmin && (
+            // Distinct visual from the org Admin badge so the cross-org
+            // role is obvious at a glance. Only super-admin viewers see
+            // this field populated (org admins get an org-filtered list).
+            <Badge className="bg-primary/15 text-primary hover:bg-primary/20 border-primary/30 border">
+              Super
+            </Badge>
+          )}
+          {user.isAdmin ? (
+            <Badge>Admin</Badge>
+          ) : (
+            <Badge variant="outline">Member</Badge>
+          )}
+        </div>
       </td>
       <td className="px-6 py-3">
         <LanguageRightsBadge value={user.language_rights} />

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -11,7 +11,7 @@ import { faUsers as faUsersSolid } from "@fortawesome/pro-solid-svg-icons";
 import { useNavigate } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
-import { hasAnyLanguageRights } from "@/lib/permissions";
+import { hasAdminPowers, hasAnyLanguageRights } from "@/lib/permissions";
 import { useUiStore } from "@/lib/ui-store";
 import { Separator } from "@/components/ui/separator";
 import { ActivityBarItem } from "@/components/activity-bar-item";
@@ -24,7 +24,9 @@ export function ActivityBar() {
   const testChatOpen = useUiStore((s) => s.testChatOpen);
   const toggleTestChat = useUiStore((s) => s.toggleTestChat);
   const languageRights = useAuthStore((s) => s.user?.language_rights);
-  const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
+  // Uses hasAdminPowers so super admins (even without isAdmin) see the
+  // Modes + Users entries. Mirrors worker's "super trumps" rule.
+  const isAdmin = useAuthStore((s) => hasAdminPowers(s.user));
   const canAccessLanguages = hasAnyLanguageRights(languageRights);
 
   return (

--- a/src/components/admin-user-create-dialog.tsx
+++ b/src/components/admin-user-create-dialog.tsx
@@ -5,6 +5,7 @@ import type { LanguageRights } from "@/types/auth";
 import {
   AdminUsersForbiddenError,
   AdminUsersRequestError,
+  isReservedOrgSlug,
 } from "@/lib/admin-users-api";
 import { useCreateAdminUser } from "@/hooks/use-admin-users";
 import { Button } from "@/components/ui/button";
@@ -92,6 +93,13 @@ export function AdminUserCreateDialog({
     }
     if (callerIsSuperAdmin && !trimmedOrg) {
       setErrorText("Org cannot be empty.");
+      return;
+    }
+    // Reserved by the UI for the "all orgs" filter Select. Without this
+    // guard a super admin could create an org with the sentinel slug,
+    // which would then be unfilterable on this page.
+    if (callerIsSuperAdmin && isReservedOrgSlug(trimmedOrg)) {
+      setErrorText("That org slug is reserved by the UI — pick another.");
       return;
     }
     if (password.length < 8) {

--- a/src/components/admin-user-create-dialog.tsx
+++ b/src/components/admin-user-create-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { Language } from "@/types/language";
 import type { LanguageRights } from "@/types/auth";
@@ -23,9 +23,15 @@ import { LanguageRightsSelector } from "@/components/language-rights-selector";
 interface CreateUserDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  // The caller's org. Pre-fills the form and is the only allowed value
-  // for org-scoped admins (the worker enforces this regardless).
+  // The caller's org. For org admins this is the only allowed org (worker
+  // enforces). For super admins this is the default pre-fill — they can
+  // override the Org field to create a user in any org (including a
+  // brand-new one; creating a user with a never-before-seen org slug is
+  // how a new org comes into existence).
   callerOrg: string;
+  // When true, render the editable Org field and the Super-admin checkbox.
+  // When false, the dialog matches the original org-admin shape exactly.
+  callerIsSuperAdmin: boolean;
   availableLanguages: Language[] | undefined;
   onCreated?: (email: string) => void;
 }
@@ -34,6 +40,7 @@ export function AdminUserCreateDialog({
   open,
   onOpenChange,
   callerOrg,
+  callerIsSuperAdmin,
   availableLanguages,
   onCreated,
 }: CreateUserDialogProps) {
@@ -42,15 +49,26 @@ export function AdminUserCreateDialog({
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
+  const [org, setOrg] = useState(callerOrg);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isSuperAdmin, setIsSuperAdmin] = useState(false);
   const [rights, setRights] = useState<LanguageRights>([]);
   const [errorText, setErrorText] = useState<string | null>(null);
+
+  // Re-sync the Org default if callerOrg changes while the dialog is
+  // mounted (rare — only on auth changes). Without this, a stale org
+  // would persist between dialog opens.
+  useEffect(() => {
+    setOrg(callerOrg);
+  }, [callerOrg]);
 
   const reset = () => {
     setEmail("");
     setPassword("");
     setName("");
+    setOrg(callerOrg);
     setIsAdmin(false);
+    setIsSuperAdmin(false);
     setRights([]);
     setErrorText(null);
     createUser.reset();
@@ -66,9 +84,14 @@ export function AdminUserCreateDialog({
     setErrorText(null);
     const trimmedEmail = email.trim().toLowerCase();
     const trimmedName = name.trim();
+    const trimmedOrg = org.trim();
 
     if (!trimmedEmail || !password || !trimmedName) {
       setErrorText("Email, password, and name are required.");
+      return;
+    }
+    if (callerIsSuperAdmin && !trimmedOrg) {
+      setErrorText("Org cannot be empty.");
       return;
     }
     if (password.length < 8) {
@@ -81,8 +104,15 @@ export function AdminUserCreateDialog({
         email: trimmedEmail,
         password,
         name: trimmedName,
-        org: callerOrg,
+        // Org admins always send their own org (worker enforces anyway);
+        // super admins send whatever they typed.
+        org: callerIsSuperAdmin ? trimmedOrg : callerOrg,
         isAdmin,
+        // Only include the field when the caller is a super admin and
+        // checked the box. Sending `false` from a non-super caller would
+        // get a 403 from the worker (it rejects any non-undefined
+        // isSuperAdmin from org-scoped admins).
+        ...(callerIsSuperAdmin && isSuperAdmin ? { isSuperAdmin: true } : {}),
         language_rights: rights,
       },
       {
@@ -113,10 +143,22 @@ export function AdminUserCreateDialog({
           <DialogHeader>
             <DialogTitle>Add a new user</DialogTitle>
             <DialogDescription>
-              The user will be added to the{" "}
-              <span className="text-foreground font-medium">{callerOrg}</span>{" "}
-              organization. Share the password with them out-of-band; they can
-              change it after first sign-in.
+              {callerIsSuperAdmin ? (
+                <>
+                  Pick the destination organization. Using a slug that
+                  doesn&rsquo;t exist yet creates a brand-new org with this user
+                  as its first member.
+                </>
+              ) : (
+                <>
+                  The user will be added to the{" "}
+                  <span className="text-foreground font-medium">
+                    {callerOrg}
+                  </span>{" "}
+                  organization. Share the password with them out-of-band; they
+                  can change it after first sign-in.
+                </>
+              )}
             </DialogDescription>
           </DialogHeader>
 
@@ -145,6 +187,23 @@ export function AdminUserCreateDialog({
               />
             </div>
 
+            {callerIsSuperAdmin && (
+              <div className="space-y-2">
+                <Label htmlFor="new-user-org">Organization</Label>
+                <Input
+                  id="new-user-org"
+                  value={org}
+                  onChange={(e) => setOrg(e.target.value)}
+                  placeholder="org-slug"
+                  required
+                />
+                <p className="text-muted-foreground text-xs">
+                  Free-text slug. Type the name of an existing org to add the
+                  user there, or a new slug to create a fresh org.
+                </p>
+              </div>
+            )}
+
             <div className="space-y-2">
               <Label htmlFor="new-user-password">Initial password</Label>
               <Input
@@ -172,11 +231,30 @@ export function AdminUserCreateDialog({
               <div className="space-y-0.5">
                 <div className="text-sm font-medium">Org admin</div>
                 <div className="text-muted-foreground text-xs">
-                  Can manage users in {callerOrg} (this surface). Independent of
-                  language access.
+                  {callerIsSuperAdmin
+                    ? "Can manage users in their org. Independent of language access."
+                    : `Can manage users in ${callerOrg} (this surface). Independent of language access.`}
                 </div>
               </div>
             </label>
+
+            {callerIsSuperAdmin && (
+              <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors">
+                <input
+                  type="checkbox"
+                  checked={isSuperAdmin}
+                  onChange={(e) => setIsSuperAdmin(e.target.checked)}
+                  className="mt-0.5"
+                />
+                <div className="space-y-0.5">
+                  <div className="text-sm font-medium">Super admin</div>
+                  <div className="text-muted-foreground text-xs">
+                    Cross-org powers. Can manage users in any org, grant super
+                    admin to others. Use sparingly.
+                  </div>
+                </div>
+              </label>
+            )}
 
             <LanguageRightsSelector
               value={rights}

--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -6,6 +6,7 @@ import type { Language } from "@/types/language";
 import {
   AdminUsersForbiddenError,
   AdminUsersRequestError,
+  isReservedOrgSlug,
 } from "@/lib/admin-users-api";
 import { useUpdateAdminUser } from "@/hooks/use-admin-users";
 import { Button } from "@/components/ui/button";
@@ -87,6 +88,13 @@ export function AdminUserEditDialog({
     const trimmedOrg = org.trim();
     if (callerIsSuperAdmin && !trimmedOrg) {
       setErrorText("Org cannot be empty.");
+      return;
+    }
+    // Reserved by the UI for the "all orgs" filter Select — refuse to
+    // move a user into the sentinel slug. (Same guard as the create
+    // dialog; see ORG_FILTER_ALL_SENTINEL in lib/admin-users-api.)
+    if (callerIsSuperAdmin && isReservedOrgSlug(trimmedOrg)) {
+      setErrorText("That org slug is reserved by the UI — pick another.");
       return;
     }
 

--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -31,6 +31,10 @@ interface EditUserDialogProps {
   // controls (the worker also enforces these — UI just prevents the obvious
   // footgun before the request goes out).
   callerEmail: string;
+  // When true, render the editable Org field (move-org) and the
+  // Super-admin checkbox. When false, the dialog matches the original
+  // org-admin shape exactly.
+  callerIsSuperAdmin: boolean;
   availableLanguages: Language[] | undefined;
 }
 
@@ -39,12 +43,15 @@ export function AdminUserEditDialog({
   open,
   onOpenChange,
   callerEmail,
+  callerIsSuperAdmin,
   availableLanguages,
 }: EditUserDialogProps) {
   const updateUser = useUpdateAdminUser();
 
   const [name, setName] = useState("");
+  const [org, setOrg] = useState("");
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isSuperAdmin, setIsSuperAdmin] = useState(false);
   const [rights, setRights] = useState<LanguageRights | undefined>(undefined);
   const [password, setPassword] = useState("");
   const [errorText, setErrorText] = useState<string | null>(null);
@@ -54,7 +61,9 @@ export function AdminUserEditDialog({
   useEffect(() => {
     if (!user) return;
     setName(user.name);
+    setOrg(user.org);
     setIsAdmin(user.isAdmin);
+    setIsSuperAdmin(user.isSuperAdmin ?? false);
     setRights(user.language_rights);
     setPassword("");
     setErrorText(null);
@@ -75,10 +84,19 @@ export function AdminUserEditDialog({
       setErrorText("Name cannot be empty.");
       return;
     }
+    const trimmedOrg = org.trim();
+    if (callerIsSuperAdmin && !trimmedOrg) {
+      setErrorText("Org cannot be empty.");
+      return;
+    }
 
     const body: UpdateUserBody = {};
     if (trimmedName !== user.name) body.name = trimmedName;
+    if (callerIsSuperAdmin && trimmedOrg !== user.org) body.org = trimmedOrg;
     if (isAdmin !== user.isAdmin) body.isAdmin = isAdmin;
+    if (callerIsSuperAdmin && isSuperAdmin !== (user.isSuperAdmin ?? false)) {
+      body.isSuperAdmin = isSuperAdmin;
+    }
     // Send language_rights when the value differs. Comparing arrays needs
     // a deep compare; we serialize.
     const currentSerialized = JSON.stringify(user.language_rights ?? null);
@@ -154,23 +172,67 @@ export function AdminUserEditDialog({
               />
             </div>
 
+            {callerIsSuperAdmin && (
+              <div className="space-y-2">
+                <Label htmlFor="edit-user-org">Organization</Label>
+                <Input
+                  id="edit-user-org"
+                  value={org}
+                  onChange={(e) => setOrg(e.target.value)}
+                  placeholder="org-slug"
+                  required
+                />
+                <p className="text-muted-foreground text-xs">
+                  Changing this moves the user to a different org. Typing a new
+                  slug creates that org with this user as a member.
+                </p>
+              </div>
+            )}
+
             <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60">
               <input
                 type="checkbox"
                 checked={isAdmin}
-                disabled={isSelf}
+                // Org admins can't self-demote isAdmin (worker rejects
+                // with 400). Super admins can — they keep cross-org powers
+                // via isSuperAdmin.
+                disabled={isSelf && !callerIsSuperAdmin}
                 onChange={(e) => setIsAdmin(e.target.checked)}
                 className="mt-0.5"
               />
               <div className="space-y-0.5">
                 <div className="text-sm font-medium">Org admin</div>
                 <div className="text-muted-foreground text-xs">
-                  {isSelf
+                  {isSelf && !callerIsSuperAdmin
                     ? "You cannot demote yourself. Use the X-Admin-Secret CLI if you really need to."
                     : "Can manage users in this org. Independent of language access."}
                 </div>
               </div>
             </label>
+
+            {callerIsSuperAdmin && (
+              <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60">
+                <input
+                  type="checkbox"
+                  checked={isSuperAdmin}
+                  // The worker rejects self-demote of isSuperAdmin with
+                  // 400 (would lock the caller out of cross-org powers).
+                  // Disabling when isSelf && currently-super surfaces that
+                  // boundary up-front rather than after a failed PUT.
+                  disabled={isSelf && isSuperAdmin}
+                  onChange={(e) => setIsSuperAdmin(e.target.checked)}
+                  className="mt-0.5"
+                />
+                <div className="space-y-0.5">
+                  <div className="text-sm font-medium">Super admin</div>
+                  <div className="text-muted-foreground text-xs">
+                    {isSelf && isSuperAdmin
+                      ? "You cannot demote yourself from super admin. Use the X-Admin-Secret CLI if you really need to."
+                      : "Cross-org powers. Can manage users in any org, grant super admin to others."}
+                  </div>
+                </div>
+              </label>
+            )}
 
             <LanguageRightsSelector
               value={rights}

--- a/src/components/require-admin.tsx
+++ b/src/components/require-admin.tsx
@@ -2,14 +2,20 @@ import type { ReactNode } from "react";
 import { Navigate } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
+import { hasAdminPowers } from "@/lib/permissions";
 
-// Gates a route on session.isAdmin === true. The worker enforces this on
+// Gates a route on org admin OR super admin. The worker enforces this on
 // /api/admin/users regardless, but redirecting non-admins client-side
 // avoids a useless 403 round-trip and a broken-looking page. RequireAuth
 // (the parent gate) already handles the unauthenticated case.
+//
+// Super admins pass even when isAdmin is false (mirrors worker's "super
+// trumps" rule). Without this, a super admin who self-demoted isAdmin
+// would be redirected away from /admin/users despite the worker letting
+// them in.
 export function RequireAdmin({ children }: { children: ReactNode }) {
-  const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
-  if (!isAdmin) {
+  const user = useAuthStore((s) => s.user);
+  if (!hasAdminPowers(user)) {
     return <Navigate to="/" replace />;
   }
   return children;

--- a/src/lib/admin-users-api.ts
+++ b/src/lib/admin-users-api.ts
@@ -4,6 +4,20 @@ import type {
   UpdateUserBody,
 } from "@/types/admin-users";
 
+// Sentinel for the "all orgs" entry in the super-admin org filter Select.
+// Radix Select disallows empty-string item values, so a literal stands in
+// for "no filter". The value is deliberately distinctive — `@@` brackets
+// + the project namespace — so any realistic org slug ("acme", "haneen",
+// "uw", "tools", …) won't collide. Dialogs additionally refuse to create
+// or move an org to exactly this slug via isReservedOrgSlug.
+export const ORG_FILTER_ALL_SENTINEL = "@@bt-servant:all-orgs@@";
+
+// One source of truth so the sentinel and the dialog guards can't drift
+// apart on future renames.
+export function isReservedOrgSlug(slug: string): boolean {
+  return slug === ORG_FILTER_ALL_SENTINEL;
+}
+
 // X-Requested-With is the same-origin marker the worker requires on the
 // cookie-auth path (see worker/admin.ts requireAdminAuth). All admin user
 // requests from the browser must include it.

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,5 +1,18 @@
 import type { LanguageRights } from "@/types/auth";
 
+// Mirror of worker/config.ts hasAdminPowers — true for org admins OR
+// super admins. The "super trumps isAdmin" rule lives in worker/admin.ts:
+// a super-admin who self-demotes isAdmin (allowed; they retain cross-org
+// powers via super) must still pass UI gates. Without this, the client
+// would redirect them away from /admin/users and the sidebar Modes/Users
+// entries would disappear even though the worker would let them through.
+export function hasAdminPowers(
+  user: { isAdmin?: boolean; isSuperAdmin?: boolean } | null | undefined
+): boolean {
+  if (!user) return false;
+  return (user.isAdmin ?? false) || (user.isSuperAdmin ?? false);
+}
+
 // `undefined` is the back-compat default until bt-servant-engine#207 lands —
 // treat it as full access so existing users aren't locked out.
 export function hasLanguageRights(

--- a/src/types/admin-users.ts
+++ b/src/types/admin-users.ts
@@ -8,6 +8,11 @@ export interface AdminUser {
   name: string;
   org: string;
   isAdmin: boolean;
+  // Only set/relevant when the viewer is a super-admin (org admins receive
+  // an org-filtered list where this field is still present but typically
+  // false). The UI gates the Super badge + Super checkbox on the viewer's
+  // role, not the row's.
+  isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
 }
 
@@ -17,6 +22,9 @@ export interface CreateUserBody {
   name: string;
   org: string;
   isAdmin?: boolean;
+  // Only honored by the worker when the caller scope is super or
+  // super-by-session. Org admins sending this get a loud 403.
+  isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
 }
 
@@ -25,5 +33,9 @@ export interface UpdateUserBody {
   org?: string;
   password?: string;
   isAdmin?: boolean;
+  // Same gate as CreateUserBody — worker rejects with 403 from non-super
+  // scopes. Distinct from isAdmin (org admins may grant/revoke isAdmin
+  // within their own org).
+  isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -10,5 +10,11 @@ export interface AuthUser {
   name: string;
   org: string;
   isAdmin: boolean;
+  // Cross-org "super admin". When true, the UI lifts org filters on the
+  // /admin/users page, makes the Org field editable in create/edit
+  // dialogs, and surfaces an isSuperAdmin checkbox. The backend enforces
+  // the same powers regardless of UI state (worker/admin.ts +
+  // worker/config.ts both honor the "super trumps isAdmin" rule).
+  isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
 }

--- a/tests/admin-users-api.test.ts
+++ b/tests/admin-users-api.test.ts
@@ -3,8 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AdminUsersForbiddenError,
   AdminUsersRequestError,
+  ORG_FILTER_ALL_SENTINEL,
   createAdminUser,
   deleteAdminUser,
+  isReservedOrgSlug,
   listAdminUsers,
   updateAdminUser,
 } from "../src/lib/admin-users-api";
@@ -220,5 +222,38 @@ describe("error parsing edge cases", () => {
       // Falls back to the default "Request failed (500)" message.
       expect(err.message).toBe("Request failed (500)");
     }
+  });
+});
+
+describe("isReservedOrgSlug", () => {
+  // Pin the exact sentinel string so a rename of ORG_FILTER_ALL_SENTINEL
+  // without updating the matcher would fail loudly here.
+  it("returns true for the exact sentinel", () => {
+    expect(isReservedOrgSlug(ORG_FILTER_ALL_SENTINEL)).toBe(true);
+  });
+
+  it("is exact-match (no trimming, no case-folding, no partial)", () => {
+    // Trim discipline lives in the dialogs (they trim before the check),
+    // so this helper itself must not silently accept whitespace variants.
+    expect(isReservedOrgSlug(` ${ORG_FILTER_ALL_SENTINEL} `)).toBe(false);
+    expect(isReservedOrgSlug(ORG_FILTER_ALL_SENTINEL.toUpperCase())).toBe(
+      false
+    );
+    expect(isReservedOrgSlug(`prefix${ORG_FILTER_ALL_SENTINEL}suffix`)).toBe(
+      false
+    );
+  });
+
+  it("returns false for realistic org slugs", () => {
+    expect(isReservedOrgSlug("acme")).toBe(false);
+    expect(isReservedOrgSlug("haneen")).toBe(false);
+    expect(isReservedOrgSlug("uw")).toBe(false);
+    expect(isReservedOrgSlug("tools")).toBe(false);
+  });
+
+  it("returns false for empty string and other non-sentinel values", () => {
+    expect(isReservedOrgSlug("")).toBe(false);
+    expect(isReservedOrgSlug("@@")).toBe(false);
+    expect(isReservedOrgSlug("__all__")).toBe(false);
   });
 });

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   filterAuthorizedLanguages,
+  hasAdminPowers,
   hasAnyLanguageRights,
   hasLanguageRights,
 } from "../src/lib/permissions";
@@ -62,6 +63,40 @@ describe("hasAnyLanguageRights", () => {
 
   it("empty array → false (explicit deny-all)", () => {
     expect(hasAnyLanguageRights([])).toBe(false);
+  });
+});
+
+describe("hasAdminPowers", () => {
+  // "super trumps isAdmin" mirror. Pin every (isAdmin, isSuperAdmin) cell
+  // and the null cases so the next person touching the helper can see the
+  // truth table at a glance.
+
+  it("null user → false", () => {
+    expect(hasAdminPowers(null)).toBe(false);
+  });
+
+  it("undefined user → false", () => {
+    expect(hasAdminPowers(undefined)).toBe(false);
+  });
+
+  it("isAdmin=true, no isSuperAdmin → true (existing org-admin path)", () => {
+    expect(hasAdminPowers({ isAdmin: true })).toBe(true);
+  });
+
+  it("isAdmin=false, isSuperAdmin=true → true (super trumps)", () => {
+    expect(hasAdminPowers({ isAdmin: false, isSuperAdmin: true })).toBe(true);
+  });
+
+  it("isAdmin=true, isSuperAdmin=true → true (both set)", () => {
+    expect(hasAdminPowers({ isAdmin: true, isSuperAdmin: true })).toBe(true);
+  });
+
+  it("isAdmin=false, isSuperAdmin=false → false", () => {
+    expect(hasAdminPowers({ isAdmin: false, isSuperAdmin: false })).toBe(false);
+  });
+
+  it("both flags undefined → false (neither set ≠ admin)", () => {
+    expect(hasAdminPowers({})).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

**Closes #138.** Completes the super-admin feature — PR A (#141) landed the backend; this expands the existing `/admin/users` page in place for super-admin callers rather than adding a new route. The existing surface already does most of what's needed; PR B just lifts the org-scope where appropriate.

**Org admins**: zero visible change. Every super-admin-only branch is gated on `callerIsSuperAdmin` (defaulted to `false` from a missing field).

**Super admins** (after they're bootstrapped via the one-time `X-Admin-Secret` PUT documented in the README):
- Subtitle becomes \"Manage users across all organizations\"
- Org filter dropdown (shadcn Select) listing distinct orgs from the response
- Org column added to the users table
- \"Super\" badge on rows where `isSuperAdmin === true`
- Create dialog: editable Org field (free-text — typing a never-seen slug creates a new org) + Super admin checkbox
- Edit dialog: same two extra fields. Super admin checkbox is disabled when `isSelf && already-super` (mirrors worker's 400 on self-demote)
- isAdmin self-demote guard relaxed for super-admin callers (worker allows this since super trumps)

**Tests**: 7 new on `hasAdminPowers` truth table. **181 → 188**, still ~3s wall-clock.

## How super admin gets bootstrapped

Once this lands and deploys, no user is yet a super admin in any environment. Bootstrap is the one-time curl now documented in README's \"Bootstrapping a super admin\" section:

```bash
op run -- curl -X PUT \\
  https://bt-servant-admin-portal-staging.unfoldingword.workers.dev/api/admin/users/seth@example.com \\
  -H \"X-Admin-Secret: \$ADMIN_SECRET\" \\
  -H \"Content-Type: application/json\" \\
  -d '{\"isSuperAdmin\": true}'
```

Takes effect on the user's next request (live session re-hydration from PR A); page refresh shows the new UI affordances.

## Risks Frank may want to spot-check

1. **Org admin behavior byte-identical** when `isSuperAdmin` is false/undefined. Every new branch is gated on `callerIsSuperAdmin`. Subtitle, columns, dialog fields all preserved exactly when the flag is false.
2. **isSuperAdmin omitted from create/edit bodies** when caller is not super. The worker rejects any non-undefined value from non-super scopes with 403 (per PR A); we omit instead of sending `false` so the UI never trips that 403 on its own.
3. **Select sentinel `__all__`** is the standard workaround for Radix Select's empty-string-disallowed values. Can't collide with a real org slug.
4. **isAdmin self-demote guard scope-aware** on the UI: disabled for non-super self (worker would 400), enabled for super self (worker allows — super remains).
5. **`hasAdminPowers` exists in two places** (worker/config.ts and src/lib/permissions.ts) by design — the worker version is the authoritative gate, the client version is defense-in-depth + UI gating. Both encode the same \"super trumps isAdmin\" rule. Kept in sync via parallel tests (PR A's config-authz.test.ts + this PR's permissions.test.ts).

## Manual smoke needed

No DOM/React test pool in this repo (vitest-pool-workers is workerd-only, per `feedback_real_tests`). The pure helpers are unit-tested; the UI rewiring needs a manual pass:

- [ ] Bootstrap yourself via the README curl on staging
- [ ] Log in fresh → org filter visible, Org column, Super badge on your row
- [ ] Create dialog: Org and Super admin fields visible; create a user in a brand-new org slug → user appears, org joins the filter
- [ ] Edit dialog on your own row → Super admin checkbox disabled with lockout tooltip
- [ ] Log in as a normal org admin (any test tenant) → no UI changes vs current main

## Reviewer notes

- Commit author is `Claude <claude@anthropic.com>` per `CLAUDE.md`'s cross-agent author convention.
- Closes #138 — this is the last piece of the super-admin feature.

Closes #138