### PR TITLE
feat(#166): PR A — super-admin cross-org config via ?org= (worker)

### DIFF
--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -444,6 +444,56 @@ describe("config authz — cross-org via ?org= (#166)", () => {
     );
   });
 
+  it("super-admin with ?org=<own org> + restricted language_rights → 403 (no self-referential bypass)", async () => {
+    // Frank's PR #185 review caught this: an earlier draft set
+    // `crossOrg: true` for any present ?org=, so a restricted super
+    // admin could bypass their own org's language_rights by adding a
+    // self-referential ?org=acme. `crossOrg` must reflect the resolved
+    // target vs. session.org, not merely the param's presence.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("PUT", "/api/config/languages/english", "org=acme", {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# English\n" }),
+      }),
+      env,
+      makeSession({
+        org: "acme",
+        isSuperAdmin: true,
+        language_rights: ["spanish"],
+      }),
+      "/api/config/languages/english"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("super-admin with ?org=<own org> + matching language_rights → 200 (treated as same-org)", async () => {
+    // Parity check for the self-referential ?org= case: when rights
+    // *do* permit the language, the same-org gate passes and the
+    // request proxies normally (no spurious 403, no spurious /orgs/
+    // path).
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("PUT", "/api/config/languages/spanish", "org=acme", {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# Spanish\n" }),
+      }),
+      env,
+      makeSession({
+        org: "acme",
+        isSuperAdmin: true,
+        language_rights: ["spanish"],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/languages/spanish"
+    );
+  });
+
   it("no ?org= + non-super with restricted language_rights → still 403 (same-org gate intact)", async () => {
     const fetchSpy = spyFetch();
     const res = await handleConfig(

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -250,3 +250,309 @@ describe("config authz — super admin trumps isAdmin", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-org override via ?org= (#166)
+// ---------------------------------------------------------------------------
+//
+// Super admins need to edit modes/languages/prompt-overrides in orgs they
+// don't sit in (Tim's 2026-05-21 Zoom — Elsy as super-admin couldn't see
+// Word Collective from her uW session). Closing the gap with an explicit
+// `?org=<slug>` query param: super-admin only, loud 403 for non-super,
+// 400 on empty/path-traversal shapes. No behavior change when the param
+// is absent — that's the everyday org-admin path.
+
+function makeRequestWithQuery(
+  method: string,
+  pathname: string,
+  query: string,
+  init?: RequestInit
+): Request {
+  return new Request(`https://portal.example.test${pathname}?${query}`, {
+    method,
+    ...init,
+  });
+}
+
+describe("config authz — cross-org via ?org= (#166)", () => {
+  it("non-super-admin with ?org=other → 403 (loud reject, not silent fallback)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("PUT", "/api/config/modes/spoken", "org=other", {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## Identity\n" }),
+      }),
+      env,
+      makeSession({ isAdmin: true, isSuperAdmin: false }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("plain user (non-admin) with ?org=other → 403", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/modes/spoken", "org=other"),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: false }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("?org=  (whitespace-only) → 400", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/modes", "org=%20%20"),
+      env,
+      makeSession({ isSuperAdmin: true }),
+      "/api/config/modes"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("?org= (empty) → 400", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/modes", "org="),
+      env,
+      makeSession({ isSuperAdmin: true }),
+      "/api/config/modes"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("?org=foo/bar (path-traversal shape) → 400 even for super-admin", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/modes", "org=foo%2Fbar"),
+      env,
+      makeSession({ isSuperAdmin: true }),
+      "/api/config/modes"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("no ?org= + super-admin → uses session.org (regression: same-org path unchanged)", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequest("GET", "/api/config/modes"),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/modes"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/modes"
+    );
+  });
+
+  it("super-admin PUT modes/{name} with ?org=other → proxies to /orgs/other/modes/...", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery(
+        "PUT",
+        "/api/config/modes/spoken",
+        "org=word-collective",
+        {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ document: "## Identity\n" }),
+        }
+      ),
+      env,
+      makeSession({ org: "acme", isAdmin: true, isSuperAdmin: true }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/modes/spoken"
+    );
+  });
+
+  it("super-admin GET modes list with ?org=other → proxies to /orgs/other/modes", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/modes", "org=word-collective"),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/modes"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/modes"
+    );
+  });
+
+  it("super-admin PUT prompt-overrides with ?org=other → proxies to /orgs/other/prompt-overrides", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequestWithQuery(
+        "PUT",
+        "/api/config/prompt-overrides",
+        "org=word-collective",
+        {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ identity: "hi" }),
+        }
+      ),
+      env,
+      makeSession({ org: "acme", isAdmin: true, isSuperAdmin: true }),
+      "/api/config/prompt-overrides"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/prompt-overrides"
+    );
+  });
+
+  it("super-admin PUT languages/{name} with ?org=other bypasses language_rights", async () => {
+    // language_rights are scoped to the user's home org; "english" in acme
+    // and "english" in word-collective are distinct documents. Without the
+    // cross-org bypass, a super-admin with restricted same-org shepherd
+    // rights would inherit those restrictions when crossing orgs, which
+    // makes no semantic sense and would block the workflow this PR exists
+    // to enable.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery(
+        "PUT",
+        "/api/config/languages/english",
+        "org=word-collective",
+        {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ document: "# English\n" }),
+        }
+      ),
+      env,
+      makeSession({
+        org: "acme",
+        isSuperAdmin: true,
+        language_rights: ["spanish"],
+      }),
+      "/api/config/languages/english"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/languages/english"
+    );
+  });
+
+  it("no ?org= + non-super with restricted language_rights → still 403 (same-org gate intact)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("PUT", "/api/config/languages/english"),
+      env,
+      makeSession({
+        org: "acme",
+        isAdmin: true,
+        language_rights: ["spanish"],
+      }),
+      "/api/config/languages/english"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("super-admin GET languages list with ?org=other → proxies to /orgs/other/languages", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequestWithQuery(
+        "GET",
+        "/api/config/languages",
+        "org=word-collective"
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/languages"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/languages"
+    );
+  });
+
+  it("super-admin GET language-scaffold with ?org=other → proxies to /orgs/other/language-scaffold", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequestWithQuery(
+        "GET",
+        "/api/config/language-scaffold",
+        "org=word-collective"
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/language-scaffold"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/language-scaffold"
+    );
+  });
+
+  it("super-admin PUT user-mode/{uuid} with ?org=other → proxies to /orgs/other/users/.../mode", async () => {
+    const fetchSpy = spyFetch();
+    const uuid = "00000000-0000-4000-8000-000000000001";
+    await handleConfig(
+      makeRequestWithQuery(
+        "PUT",
+        `/api/config/user-mode/${uuid}`,
+        "org=word-collective",
+        {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mode: "spoken" }),
+        }
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      `/api/config/user-mode/${uuid}`
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      `/api/v1/admin/orgs/word-collective/users/${uuid}/mode`
+    );
+  });
+
+  it("super-admin GET user-memory/{uuid} with ?org=other → proxies to /orgs/other/users/.../memory", async () => {
+    const fetchSpy = spyFetch();
+    const uuid = "00000000-0000-4000-8000-000000000002";
+    await handleConfig(
+      makeRequestWithQuery(
+        "GET",
+        `/api/config/user-memory/${uuid}`,
+        "org=word-collective"
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      `/api/config/user-memory/${uuid}`
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      `/api/v1/admin/orgs/word-collective/users/${uuid}/memory`
+    );
+  });
+
+  it("?org= trims whitespace and proxies the trimmed slug", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequestWithQuery(
+        "GET",
+        "/api/config/modes",
+        "org=%20word-collective%20"
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/modes"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/modes"
+    );
+  });
+});

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -85,13 +85,51 @@ function isAdminMutation(method: string, session: SessionData): boolean {
   return (method === "PUT" || method === "DELETE") && !hasAdminPowers(session);
 }
 
+// Cross-org override via ?org=<slug>. Super-admin only; reject loud rather
+// than silently falling back to session.org so a UI bug or hostile probe
+// surfaces visibly instead of masquerading as a same-org request. Returns
+// `{ crossOrg: false, org }` when the param is absent (the everyday path
+// for org admins — unchanged behavior). `crossOrg: true` signals that
+// language_rights checks should be skipped: language_rights are scoped to
+// the user's home org and don't translate to a different org's namespace,
+// and super-admin already trumps shepherd permissions by design.
+function resolveOrg(
+  request: Request,
+  session: SessionData
+): { crossOrg: boolean; org: string } | { error: Response } {
+  const orgParam = new URL(request.url).searchParams.get("org");
+  if (orgParam === null) {
+    return { crossOrg: false, org: session.org };
+  }
+
+  const trimmed = orgParam.trim();
+  if (!trimmed || trimmed.includes("/")) {
+    return { error: errorResponse("Invalid org parameter", 400) };
+  }
+
+  if (session.isSuperAdmin !== true) {
+    return {
+      error: errorResponse(
+        "Cross-org config access requires isSuperAdmin",
+        403
+      ),
+    };
+  }
+
+  return { crossOrg: true, org: trimmed };
+}
+
 export async function handleConfig(
   request: Request,
   env: Env,
   session: SessionData,
   pathname: string
 ): Promise<Response> {
-  const org = encodeURIComponent(session.org);
+  const resolved = resolveOrg(request, session);
+  if ("error" in resolved) {
+    return resolved.error;
+  }
+  const org = encodeURIComponent(resolved.org);
 
   // /api/config/prompt-overrides → GET (any session) / PUT/DELETE (admin)
   if (pathname === "/api/config/prompt-overrides") {
@@ -125,7 +163,10 @@ export async function handleConfig(
   const languageMatch = pathname.match(/^\/api\/config\/languages\/(.+)$/);
   if (languageMatch?.[1]) {
     const languageName = decodeURIComponent(languageMatch[1]);
-    if (!hasLanguageRights(session.language_rights, languageName)) {
+    if (
+      !resolved.crossOrg &&
+      !hasLanguageRights(session.language_rights, languageName)
+    ) {
       return errorResponse("Forbidden", 403);
     }
     return proxyToEngine(

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -87,12 +87,15 @@ function isAdminMutation(method: string, session: SessionData): boolean {
 
 // Cross-org override via ?org=<slug>. Super-admin only; reject loud rather
 // than silently falling back to session.org so a UI bug or hostile probe
-// surfaces visibly instead of masquerading as a same-org request. Returns
-// `{ crossOrg: false, org }` when the param is absent (the everyday path
-// for org admins — unchanged behavior). `crossOrg: true` signals that
-// language_rights checks should be skipped: language_rights are scoped to
-// the user's home org and don't translate to a different org's namespace,
-// and super-admin already trumps shepherd permissions by design.
+// surfaces visibly instead of masquerading as a same-org request.
+//
+// `crossOrg` reflects whether the resolved target differs from the
+// caller's home org — not merely whether the param was present. A super
+// admin sending `?org=<their own org>` is semantically a same-org
+// request, so language_rights remain enforced. Without this discriminator
+// a restricted-shepherd super admin could bypass their own org's
+// language_rights by adding a self-referential `?org=` (Frank, PR #185
+// review).
 function resolveOrg(
   request: Request,
   session: SessionData
@@ -116,7 +119,7 @@ function resolveOrg(
     };
   }
 
-  return { crossOrg: true, org: trimmed };
+  return { crossOrg: trimmed !== session.org, org: trimmed };
 }
 
 export async function handleConfig(


### PR DESCRIPTION
## Summary

Closes the access gap surfaced in Tim's 2026-05-21 Zoom — Elsy as a super admin couldn't see Word Collective's modes/languages from her uW session because `worker/config.ts:94` bound the upstream org slug from `session.org` with no override path.

Adds an explicit `?org=<slug>` query param to every endpoint in `handleConfig`:

- **Super admin only** — non-super callers get a loud `403 Cross-org config access requires isSuperAdmin` rather than a silent fallback to `session.org`. Loud-403-over-silent-drop, same principle as #138/#141: a UI bug or hostile probe surfaces visibly instead of masquerading as a same-org request.
- **Shape validation** rejects empty / whitespace-only / path-traversal (`/`) values with `400` even for super admins. Defense in depth — the worker is the only enforcement point under the trusted-portal model.
- **Absent param → unchanged.** Org admins are unaffected. Same-org regression test pins this.

**Language-rights carve-out.** `hasLanguageRights` only applies when the override is *not* in play. Rights are scoped to the caller's home org — `english` in `acme` and `english` in `word-collective` are distinct documents, so transferring same-org shepherd restrictions to a cross-org request is semantically meaningless. Super admin already trumps shepherd permissions by design (same shape as the `isCrossOrgScope` branch in `worker/admin.ts`).

PR A is the worker side of #166. PR B follows with the UI org selector on Modes / Languages / Prompt-Overrides pages.

## Touchpoints

- `worker/config.ts` — new `resolveOrg(request, session)` helper; `handleConfig` consumes it; `languages/{name}` branch skips `hasLanguageRights` when cross-org.
- `tests/config-authz.test.ts` — 15 new tests under "Cross-org via ?org= (#166)".

## Test plan

- [x] `npx vitest run tests/config-authz.test.ts` — 31 / 31 pass
- [x] `npx vitest run` — 208 / 208 pass (was 193)
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Pre-commit hook (lint-staged + typecheck + build) — pass
- [ ] Manual smoke on the ephemeral PR deploy: super admin GET `/api/config/modes?org=word-collective` returns Word Collective's modes; non-super gets 403; missing `?org=` still returns own-org modes.

## Test matrix covered

| Case | Caller | `?org=` | Expected | Test |
|---|---|---|---|---|
| Baseline | org admin | absent | session.org passthrough | regression set |
| Cross-org reject | org admin | `other` | 403 | ✓ |
| Cross-org reject | plain user | `other` | 403 | ✓ |
| Cross-org allow | super | `other` | proxy to `/orgs/other/...` | ✓ × 7 endpoints |
| Shape: empty | super | `` | 400 | ✓ |
| Shape: whitespace | super | `   ` | 400 | ✓ |
| Shape: path-traversal | super | `foo/bar` | 400 | ✓ |
| Trim | super | `  foo  ` | proxy to `/orgs/foo/...` | ✓ |
| Lang rights carve-out | super w/ restricted rights | `other` | bypass + proxy | ✓ |
| Lang rights intact same-org | admin w/ restricted rights | absent | 403 | ✓ |

## Related

- Tracks #138 epic (super-admin role)
- Prerequisite for #149 (Mode Library) and #153 (Governance) per the issue body
- Independent of fork-vs-cascade (#170) — closes access gap only