### PR TITLE
feat(#166): PR B — super-admin cross-org UI selector

### DIFF
--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -36,6 +36,7 @@ import { Button } from "@/components/ui/button";
 import { LanguageSelector } from "@/components/language-selector";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { MarkdownToc } from "@/components/markdown-toc";
+import { OrgContextSelector } from "@/components/org-context-selector";
 import { PageHeader } from "@/components/page-header";
 
 const AUTO_SAVE_DEBOUNCE_MS = 800;
@@ -43,18 +44,28 @@ const AUTO_SAVE_DEBOUNCE_MS = 800;
 export function LanguagesPage() {
   const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
   const languageRights = useAuthStore((s) => s.user?.language_rights);
-  const hasAccess = hasAnyLanguageRights(languageRights);
   const selectedLanguage = useUiStore((s) => s.selectedLanguage);
   const setSelectedLanguage = useUiStore((s) => s.setSelectedLanguage);
   const showDrafts = useUiStore((s) => s.showDrafts);
   const setShowDrafts = useUiStore((s) => s.setShowDrafts);
+  const contextOrg = useUiStore((s) => s.contextOrg);
+
+  // Cross-org reuses the worker's PR A carve-out: super-admins bypass
+  // `hasLanguageRights` when editing a different org's languages, because
+  // shepherd rights are scoped to the user's home org and don't translate
+  // to a foreign namespace. Treat the effective rights as full-access in
+  // that case so the same filter/gate logic continues to work without a
+  // separate cross-org code path.
+  const isCrossOrg = contextOrg !== null;
+  const effectiveRights = isCrossOrg ? "*" : languageRights;
+  const hasAccess = hasAnyLanguageRights(effectiveRights);
 
   // Queries / mutations
-  const languagesQuery = useLanguages();
-  const languageQuery = useLanguage(selectedLanguage);
-  const saveLanguage = useSaveLanguage();
-  const deleteLanguage = useDeleteLanguage();
-  const scaffoldQuery = useLanguageScaffold();
+  const languagesQuery = useLanguages(contextOrg);
+  const languageQuery = useLanguage(selectedLanguage, contextOrg);
+  const saveLanguage = useSaveLanguage(contextOrg);
+  const deleteLanguage = useDeleteLanguage(contextOrg);
+  const scaffoldQuery = useLanguageScaffold(contextOrg);
 
   // Filter the language list to only those the user has rights to. Engine
   // #207 will eventually filter server-side too, but until then this is the
@@ -65,10 +76,10 @@ export function LanguagesPage() {
       ...languagesQuery.data,
       languages: filterAuthorizedLanguages(
         languagesQuery.data.languages,
-        languageRights
+        effectiveRights
       ),
     };
-  }, [languagesQuery.data, languageRights]);
+  }, [languagesQuery.data, effectiveRights]);
 
   // Local document draft (auto-save target).
   //
@@ -228,11 +239,16 @@ export function LanguagesPage() {
   // If the persisted selection is no longer authorized (e.g. an admin
   // revoked rights mid-session, or rights changed since last login), drop
   // it so we don't render an editor for a language the user can't read.
+  // Skip the gate under cross-org context: `setContextOrg` already cleared
+  // `selectedLanguage` to null when the user switched orgs, and any new
+  // selection in cross-org mode is gated server-side via the worker's
+  // super-admin carve-out (PR A) rather than by `language_rights`.
   useEffect(() => {
     if (selectedLanguage === null) return;
+    if (isCrossOrg) return;
     if (hasLanguageRights(languageRights, selectedLanguage)) return;
     setSelectedLanguage(null);
-  }, [languageRights, selectedLanguage, setSelectedLanguage]);
+  }, [isCrossOrg, languageRights, selectedLanguage, setSelectedLanguage]);
 
   const confirmSwitch = useCallback(() => {
     setSelectedLanguage(pendingSwitch);
@@ -360,6 +376,7 @@ export function LanguagesPage() {
 
       <div className="bg-card border-b">
         <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
+          <OrgContextSelector />
           <div className="min-w-0 flex-1">
             <LanguageSelector
               languagesData={authorizedLanguagesData}

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -5,6 +5,7 @@ import { Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
+import { decideContextChange } from "@/lib/context-org-guard";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
   filterAuthorizedLanguages,
@@ -49,6 +50,7 @@ export function LanguagesPage() {
   const showDrafts = useUiStore((s) => s.showDrafts);
   const setShowDrafts = useUiStore((s) => s.setShowDrafts);
   const contextOrg = useUiStore((s) => s.contextOrg);
+  const setContextOrg = useUiStore((s) => s.setContextOrg);
 
   // Cross-org reuses the worker's PR A carve-out: super-admins bypass
   // `hasLanguageRights` when editing a different org's languages, because
@@ -223,6 +225,14 @@ export function LanguagesPage() {
   // Pending language switch within the same page — guards against losing
   // edits when picking a different language from the dropdown.
   const [pendingSwitch, setPendingSwitch] = useState<string | null>(null);
+  // Parallel to `pendingSwitch` but at the org-context layer. Outer null
+  // means "no pending switch"; outer `{ value: X }` means "user picked X
+  // but we're holding it behind a confirmation." `value` itself can be
+  // null (= switch back to home org), which is why we wrap rather than
+  // use a bare `string | null` (Frank P1, PR #186 review).
+  const [pendingContextOrg, setPendingContextOrg] = useState<{
+    value: string | null;
+  } | null>(null);
 
   const handleSelectLanguage = useCallback(
     (next: string | null) => {
@@ -235,6 +245,25 @@ export function LanguagesPage() {
     },
     [isDirty, isSaving, selectedLanguage, setSelectedLanguage]
   );
+
+  const handleRequestContextChange = useCallback(
+    (next: string | null) => {
+      const outcome = decideContextChange(contextOrg, next, isDirty, isSaving);
+      if (outcome === "no-op") return;
+      if (outcome === "confirm") {
+        setPendingContextOrg({ value: next });
+        return;
+      }
+      setContextOrg(next);
+    },
+    [contextOrg, isDirty, isSaving, setContextOrg]
+  );
+
+  const confirmContextSwitch = useCallback(() => {
+    if (!pendingContextOrg) return;
+    setContextOrg(pendingContextOrg.value);
+    setPendingContextOrg(null);
+  }, [pendingContextOrg, setContextOrg]);
 
   // If the persisted selection is no longer authorized (e.g. an admin
   // revoked rights mid-session, or rights changed since last login), drop
@@ -376,7 +405,7 @@ export function LanguagesPage() {
 
       <div className="bg-card border-b">
         <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
-          <OrgContextSelector />
+          <OrgContextSelector onRequestChange={handleRequestContextChange} />
           <div className="min-w-0 flex-1">
             <LanguageSelector
               languagesData={authorizedLanguagesData}
@@ -537,6 +566,37 @@ export function LanguagesPage() {
               Stay
             </AlertDialogCancel>
             <AlertDialogAction variant="destructive" onClick={confirmSwitch}>
+              Discard and switch
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={pendingContextOrg !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingContextOrg(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Switch org context?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have unsaved edits to{" "}
+              <span className="text-foreground font-medium">
+                &ldquo;{selectedLanguage}&rdquo;
+              </span>
+              . Switching org context will discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setPendingContextOrg(null)}>
+              Stay
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={confirmContextSwitch}
+            >
               Discard and switch
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/app/pages/manual-config.tsx
+++ b/src/app/pages/manual-config.tsx
@@ -3,6 +3,8 @@ import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { useAuthStore } from "@/lib/auth-store";
+import { useUiStore } from "@/lib/ui-store";
+import { OrgContextSelector } from "@/components/org-context-selector";
 import { PageHeader } from "@/components/page-header";
 import {
   useOrgOverrides,
@@ -15,10 +17,11 @@ import { UserMemoryDialog } from "@/components/user-memory-dialog";
 
 export function ManualConfigPage() {
   const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
+  const contextOrg = useUiStore((s) => s.contextOrg);
   const [memoryDialogOpen, setMemoryDialogOpen] = useState(false);
 
-  const orgOverrides = useOrgOverrides();
-  const updateOrg = useUpdateOrgOverrides();
+  const orgOverrides = useOrgOverrides(contextOrg);
+  const updateOrg = useUpdateOrgOverrides(contextOrg);
 
   const currentOverrides = useMemo(
     () => orgOverrides.data ?? {},
@@ -38,6 +41,10 @@ export function ManualConfigPage() {
         title="Prompt Overrides"
         subtitle="Org-wide defaults applied to every conversation unless a Mode overrides them."
       />
+
+      <div className="bg-card flex flex-wrap items-center gap-3 border-b p-4 sm:p-6">
+        <OrgContextSelector />
+      </div>
 
       <div className="config-grid-bg min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="space-y-4 sm:space-y-6">

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -5,6 +5,7 @@ import { Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
+import { decideContextChange } from "@/lib/context-org-guard";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
 import { useUiStore } from "@/lib/ui-store";
 import { OrgContextSelector } from "@/components/org-context-selector";
@@ -42,6 +43,7 @@ export function ModesPage() {
   const showDrafts = useUiStore((s) => s.showDrafts);
   const setShowDrafts = useUiStore((s) => s.setShowDrafts);
   const contextOrg = useUiStore((s) => s.contextOrg);
+  const setContextOrg = useUiStore((s) => s.setContextOrg);
 
   const modesQuery = useModes(contextOrg);
   const modeQuery = useMode(selectedMode, contextOrg);
@@ -156,6 +158,14 @@ export function ModesPage() {
   );
 
   const [pendingSwitch, setPendingSwitch] = useState<string | null>(null);
+  // Parallel to `pendingSwitch` but at the org-context layer. Outer null
+  // means "no pending switch"; outer `{ value: X }` means "user picked X
+  // but we're holding it behind a confirmation." `value` itself can be
+  // null (= switch back to home org), which is why we wrap rather than
+  // use a bare `string | null` (Frank P1, PR #186 review).
+  const [pendingContextOrg, setPendingContextOrg] = useState<{
+    value: string | null;
+  } | null>(null);
 
   const handleSelectMode = useCallback(
     (next: string | null) => {
@@ -173,6 +183,25 @@ export function ModesPage() {
     setSelectedMode(pendingSwitch);
     setPendingSwitch(null);
   }, [pendingSwitch, setSelectedMode]);
+
+  const handleRequestContextChange = useCallback(
+    (next: string | null) => {
+      const outcome = decideContextChange(contextOrg, next, isDirty, isSaving);
+      if (outcome === "no-op") return;
+      if (outcome === "confirm") {
+        setPendingContextOrg({ value: next });
+        return;
+      }
+      setContextOrg(next);
+    },
+    [contextOrg, isDirty, isSaving, setContextOrg]
+  );
+
+  const confirmContextSwitch = useCallback(() => {
+    if (!pendingContextOrg) return;
+    setContextOrg(pendingContextOrg.value);
+    setPendingContextOrg(null);
+  }, [pendingContextOrg, setContextOrg]);
 
   // Drop a stale `selectedMode` if it's no longer present in the list (admin
   // deleted it, or the value persisted across a user switch on the same tab).
@@ -271,7 +300,7 @@ export function ModesPage() {
 
       <div className="bg-card border-b">
         <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
-          <OrgContextSelector />
+          <OrgContextSelector onRequestChange={handleRequestContextChange} />
           <div className="min-w-0 flex-1">
             <ModeSelector
               modesData={modesQuery.data}
@@ -412,6 +441,37 @@ export function ModesPage() {
               Stay
             </AlertDialogCancel>
             <AlertDialogAction variant="destructive" onClick={confirmSwitch}>
+              Discard and switch
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={pendingContextOrg !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingContextOrg(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Switch org context?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have unsaved edits to{" "}
+              <span className="text-foreground font-medium">
+                &ldquo;{selectedMode}&rdquo;
+              </span>
+              . Switching org context will discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setPendingContextOrg(null)}>
+              Stay
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={confirmContextSwitch}
+            >
               Discard and switch
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -7,6 +7,7 @@ import { useBlocker } from "react-router";
 import { useAuthStore } from "@/lib/auth-store";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
 import { useUiStore } from "@/lib/ui-store";
+import { OrgContextSelector } from "@/components/org-context-selector";
 import { useDebounced } from "@/hooks/use-debounced";
 import { useActiveHeadingLine } from "@/hooks/use-active-heading-line";
 import {
@@ -40,11 +41,12 @@ export function ModesPage() {
   const setSelectedMode = useUiStore((s) => s.setSelectedMode);
   const showDrafts = useUiStore((s) => s.showDrafts);
   const setShowDrafts = useUiStore((s) => s.setShowDrafts);
+  const contextOrg = useUiStore((s) => s.contextOrg);
 
-  const modesQuery = useModes();
-  const modeQuery = useMode(selectedMode);
-  const saveMode = useSaveMode();
-  const deleteMode = useDeleteMode();
+  const modesQuery = useModes(contextOrg);
+  const modeQuery = useMode(selectedMode, contextOrg);
+  const saveMode = useSaveMode(contextOrg);
+  const deleteMode = useDeleteMode(contextOrg);
 
   // Local document draft (auto-save target).
   //
@@ -269,6 +271,7 @@ export function ModesPage() {
 
       <div className="bg-card border-b">
         <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
+          <OrgContextSelector />
           <div className="min-w-0 flex-1">
             <ModeSelector
               modesData={modesQuery.data}

--- a/src/components/org-context-selector.tsx
+++ b/src/components/org-context-selector.tsx
@@ -18,6 +18,22 @@ import {
 // collision-proof against any real org slug.
 export const HOME_ORG_SENTINEL = "@@bt-servant:home-org@@";
 
+interface OrgContextSelectorProps {
+  // Optional intercept hook. When provided, the selector hands the chosen
+  // value to the parent instead of mutating the store directly. Pages
+  // with an unsaved-draft state (Modes, Languages) wire this to a
+  // dirty-guard handler so a context switch goes through the same
+  // confirmation flow as the per-page selectors. Pages without a draft
+  // (Prompt Overrides — each slot saves immediately) leave the prop
+  // undefined and accept the default direct-set behavior.
+  //
+  // Without this hook the selector would silently call setContextOrg →
+  // store clears selectedMode/selectedLanguage → page's useEffect resets
+  // the draft to "". A super-admin half a sentence into an edit would
+  // lose it with no confirmation (Frank P1, PR #186 review).
+  onRequestChange?: (next: string | null) => void;
+}
+
 // Cross-org context picker for super admins. Renders the home org as the
 // default selection plus every other org that has at least one user. List
 // derived from `useAdminUsers` because (a) it's already cross-org for super
@@ -30,7 +46,9 @@ export const HOME_ORG_SENTINEL = "@@bt-servant:home-org@@";
 // across navigation between Modes / Languages / Prompt-Overrides so a
 // super-admin investigating one org sees consistent context across the
 // three pages.
-export function OrgContextSelector() {
+export function OrgContextSelector({
+  onRequestChange,
+}: OrgContextSelectorProps = {}) {
   const callerOrg = useAuthStore((s) => s.user?.org ?? "");
   const callerIsSuperAdmin = useAuthStore((s) => s.user?.isSuperAdmin ?? false);
   const contextOrg = useUiStore((s) => s.contextOrg);
@@ -52,11 +70,13 @@ export function OrgContextSelector() {
   const selectValue = contextOrg ?? HOME_ORG_SENTINEL;
 
   const handleChange = (value: string) => {
-    if (value === HOME_ORG_SENTINEL || value === callerOrg) {
-      setContextOrg(null);
+    const next =
+      value === HOME_ORG_SENTINEL || value === callerOrg ? null : value;
+    if (onRequestChange) {
+      onRequestChange(next);
       return;
     }
-    setContextOrg(value);
+    setContextOrg(next);
   };
 
   return (

--- a/src/components/org-context-selector.tsx
+++ b/src/components/org-context-selector.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from "react";
+
+import { useAuthStore } from "@/lib/auth-store";
+import { useUiStore } from "@/lib/ui-store";
+import { useAdminUsers } from "@/hooks/use-admin-users";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// Radix Select disallows empty-string values. The store holds `null` to
+// signal "my home org" but the Select needs a non-empty placeholder; this
+// sentinel bridges that gap (mirrors `ORG_FILTER_ALL_SENTINEL` in
+// `src/lib/admin-users-api.ts`). The namespaced bracketing makes the value
+// collision-proof against any real org slug.
+export const HOME_ORG_SENTINEL = "@@bt-servant:home-org@@";
+
+// Cross-org context picker for super admins. Renders the home org as the
+// default selection plus every other org that has at least one user. List
+// derived from `useAdminUsers` because (a) it's already cross-org for super
+// admins and (b) orgs are created implicitly via user creation per
+// `[[per_org_config_scoping]]` — there's no standalone org registry to
+// query. An org with zero users is unreachable here, which matches the
+// system invariant.
+//
+// Renders nothing for non-super-admin sessions. The store value persists
+// across navigation between Modes / Languages / Prompt-Overrides so a
+// super-admin investigating one org sees consistent context across the
+// three pages.
+export function OrgContextSelector() {
+  const callerOrg = useAuthStore((s) => s.user?.org ?? "");
+  const callerIsSuperAdmin = useAuthStore((s) => s.user?.isSuperAdmin ?? false);
+  const contextOrg = useUiStore((s) => s.contextOrg);
+  const setContextOrg = useUiStore((s) => s.setContextOrg);
+
+  // Only fetch when the user can actually use the override. Avoids a
+  // wasted /api/admin/users call for org admins (who'd get a same-org
+  // list back anyway and have no use for it here).
+  const usersQuery = useAdminUsers(callerIsSuperAdmin);
+
+  const otherOrgs = useMemo(() => {
+    if (!usersQuery.data) return [];
+    const distinct = Array.from(new Set(usersQuery.data.map((u) => u.org)));
+    return distinct.filter((o) => o !== callerOrg).sort();
+  }, [usersQuery.data, callerOrg]);
+
+  if (!callerIsSuperAdmin) return null;
+
+  const selectValue = contextOrg ?? HOME_ORG_SENTINEL;
+
+  const handleChange = (value: string) => {
+    if (value === HOME_ORG_SENTINEL || value === callerOrg) {
+      setContextOrg(null);
+      return;
+    }
+    setContextOrg(value);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground text-xs">Org context</span>
+      <Select value={selectValue} onValueChange={handleChange}>
+        <SelectTrigger className="w-[220px]" data-testid="org-context-trigger">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={HOME_ORG_SENTINEL}>
+            Your org ({callerOrg})
+          </SelectItem>
+          {otherOrgs.map((org) => (
+            <SelectItem key={org} value={org}>
+              {org}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/hooks/use-language-scaffold.ts
+++ b/src/hooks/use-language-scaffold.ts
@@ -3,12 +3,17 @@ import { useQuery } from "@tanstack/react-query";
 import { getLanguageScaffold } from "@/lib/language-scaffold-api";
 
 const keys = {
-  scaffold: ["language-scaffold"] as const,
+  scaffold: (org: string | null) => ["language-scaffold", org] as const,
 };
 
-export function useLanguageScaffold() {
+function normalize(org?: string | null): string | null {
+  return org ?? null;
+}
+
+export function useLanguageScaffold(org?: string | null) {
+  const key = normalize(org);
   return useQuery({
-    queryKey: keys.scaffold,
-    queryFn: ({ signal }) => getLanguageScaffold(signal),
+    queryKey: keys.scaffold(key),
+    queryFn: ({ signal }) => getLanguageScaffold(signal, key),
   });
 }

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -2,28 +2,38 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import * as languagesApi from "@/lib/languages-api";
 
+// Org is part of every key so a super-admin's cross-org view doesn't collide
+// with the same-org cache. `null` is the canonical same-org placeholder.
 const keys = {
-  languages: ["languages"] as const,
-  language: (name: string) => ["languages", name] as const,
+  languages: (org: string | null) => ["languages", org] as const,
+  language: (name: string, org: string | null) =>
+    ["languages", name, org] as const,
 };
 
-export function useLanguages() {
+function normalize(org?: string | null): string | null {
+  return org ?? null;
+}
+
+export function useLanguages(org?: string | null) {
+  const key = normalize(org);
   return useQuery({
-    queryKey: keys.languages,
-    queryFn: ({ signal }) => languagesApi.listLanguages(signal),
+    queryKey: keys.languages(key),
+    queryFn: ({ signal }) => languagesApi.listLanguages(signal, key),
   });
 }
 
-export function useLanguage(name: string | null) {
+export function useLanguage(name: string | null, org?: string | null) {
+  const key = normalize(org);
   return useQuery({
-    queryKey: keys.language(name ?? ""),
-    queryFn: ({ signal }) => languagesApi.getLanguage(name!, signal),
+    queryKey: keys.language(name ?? "", key),
+    queryFn: ({ signal }) => languagesApi.getLanguage(name!, signal, key),
     enabled: !!name,
   });
 }
 
-export function useSaveLanguage() {
+export function useSaveLanguage(org?: string | null) {
   const qc = useQueryClient();
+  const key = normalize(org);
   return useMutation({
     mutationFn: ({
       name,
@@ -31,10 +41,10 @@ export function useSaveLanguage() {
     }: {
       name: string;
       body: { label?: string; document: string; published?: boolean };
-    }) => languagesApi.putLanguage(name, body),
+    }) => languagesApi.putLanguage(name, body, undefined, key),
     onSuccess: (_data, { name }) => {
-      void qc.invalidateQueries({ queryKey: keys.languages });
-      void qc.invalidateQueries({ queryKey: keys.language(name) });
+      void qc.invalidateQueries({ queryKey: keys.languages(key) });
+      void qc.invalidateQueries({ queryKey: keys.language(name, key) });
     },
   });
 }
@@ -48,12 +58,14 @@ export function useSaveLanguage() {
 // either (a) loosening the engine PUT contract to make `document` optional
 // or (b) introducing optimistic concurrency via etag/version.
 
-export function useDeleteLanguage() {
+export function useDeleteLanguage(org?: string | null) {
   const qc = useQueryClient();
+  const key = normalize(org);
   return useMutation({
-    mutationFn: (name: string) => languagesApi.deleteLanguage(name),
+    mutationFn: (name: string) =>
+      languagesApi.deleteLanguage(name, undefined, key),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: keys.languages });
+      void qc.invalidateQueries({ queryKey: keys.languages(key) });
     },
   });
 }

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -6,35 +6,47 @@ import type { PromptOverrides } from "@/types/prompt-override";
 // ---------------------------------------------------------------------------
 // Query keys
 // ---------------------------------------------------------------------------
+//
+// Org is part of every key so a super-admin's cross-org view doesn't collide
+// with the same-org cache. `null` is the canonical same-org placeholder (so
+// `null` and an undefined-passing call from a legacy caller hash to the
+// same entry — see #166 PR B).
 
 const keys = {
-  orgOverrides: ["org-overrides"] as const,
-  modes: ["modes"] as const,
-  mode: (name: string) => ["modes", name] as const,
+  orgOverrides: (org: string | null) => ["org-overrides", org] as const,
+  modes: (org: string | null) => ["modes", org] as const,
+  mode: (name: string, org: string | null) => ["modes", name, org] as const,
 };
+
+function normalize(org?: string | null): string | null {
+  return org ?? null;
+}
 
 // ---------------------------------------------------------------------------
 // Queries
 // ---------------------------------------------------------------------------
 
-export function useOrgOverrides() {
+export function useOrgOverrides(org?: string | null) {
+  const key = normalize(org);
   return useQuery({
-    queryKey: keys.orgOverrides,
-    queryFn: ({ signal }) => configApi.getOrgOverrides(signal),
+    queryKey: keys.orgOverrides(key),
+    queryFn: ({ signal }) => configApi.getOrgOverrides(signal, key),
   });
 }
 
-export function useModes() {
+export function useModes(org?: string | null) {
+  const key = normalize(org);
   return useQuery({
-    queryKey: keys.modes,
-    queryFn: ({ signal }) => configApi.listModes(signal),
+    queryKey: keys.modes(key),
+    queryFn: ({ signal }) => configApi.listModes(signal, key),
   });
 }
 
-export function useMode(name: string | null) {
+export function useMode(name: string | null, org?: string | null) {
+  const key = normalize(org);
   return useQuery({
-    queryKey: keys.mode(name ?? ""),
-    queryFn: ({ signal }) => configApi.getMode(name!, signal),
+    queryKey: keys.mode(name ?? "", key),
+    queryFn: ({ signal }) => configApi.getMode(name!, signal, key),
     enabled: !!name,
   });
 }
@@ -43,19 +55,21 @@ export function useMode(name: string | null) {
 // Mutations
 // ---------------------------------------------------------------------------
 
-export function useUpdateOrgOverrides() {
+export function useUpdateOrgOverrides(org?: string | null) {
   const qc = useQueryClient();
+  const key = normalize(org);
   return useMutation({
     mutationFn: (overrides: PromptOverrides) =>
-      configApi.putOrgOverrides(overrides),
+      configApi.putOrgOverrides(overrides, undefined, key),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: keys.orgOverrides });
+      void qc.invalidateQueries({ queryKey: keys.orgOverrides(key) });
     },
   });
 }
 
-export function useSaveMode() {
+export function useSaveMode(org?: string | null) {
   const qc = useQueryClient();
+  const key = normalize(org);
   return useMutation({
     mutationFn: ({
       name,
@@ -68,10 +82,10 @@ export function useSaveMode() {
         document: string;
         published?: boolean;
       };
-    }) => configApi.putMode(name, body),
+    }) => configApi.putMode(name, body, undefined, key),
     onSuccess: (_data, { name }) => {
-      void qc.invalidateQueries({ queryKey: keys.modes });
-      void qc.invalidateQueries({ queryKey: keys.mode(name) });
+      void qc.invalidateQueries({ queryKey: keys.modes(key) });
+      void qc.invalidateQueries({ queryKey: keys.mode(name, key) });
     },
   });
 }
@@ -83,25 +97,29 @@ export function useSaveMode() {
 // is no longer expressible. Mirrors the languages-side pattern — see
 // `useSaveLanguage`.
 
-export function useDeleteMode() {
+export function useDeleteMode(org?: string | null) {
   const qc = useQueryClient();
+  const key = normalize(org);
   return useMutation({
-    mutationFn: (name: string) => configApi.deleteMode(name),
+    mutationFn: (name: string) => configApi.deleteMode(name, undefined, key),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: keys.modes });
+      void qc.invalidateQueries({ queryKey: keys.modes(key) });
     },
   });
 }
 
-export function useSetUserMode() {
+export function useSetUserMode(org?: string | null) {
+  const key = normalize(org);
   return useMutation({
     mutationFn: ({ userId, mode }: { userId: string; mode: string }) =>
-      configApi.setUserMode(userId, mode),
+      configApi.setUserMode(userId, mode, undefined, key),
   });
 }
 
-export function useClearUserMode() {
+export function useClearUserMode(org?: string | null) {
+  const key = normalize(org);
   return useMutation({
-    mutationFn: (userId: string) => configApi.clearUserMode(userId),
+    mutationFn: (userId: string) =>
+      configApi.clearUserMode(userId, undefined, key),
   });
 }

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -1,3 +1,4 @@
+import { buildConfigUrl } from "@/lib/config-url";
 import type { MemoryResponse } from "@/types/memory";
 import type {
   OrgModes,
@@ -31,9 +32,10 @@ function unwrapOverridesResponse(
 }
 
 export async function getOrgOverrides(
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<PromptOverrides> {
-  const res = await fetch("/api/config/prompt-overrides", {
+  const res = await fetch(buildConfigUrl("/api/config/prompt-overrides", org), {
     headers: SAME_ORIGIN_HEADERS,
     signal,
   });
@@ -48,9 +50,10 @@ export async function getOrgOverrides(
 
 export async function putOrgOverrides(
   overrides: PromptOverrides,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<PromptOverrides> {
-  const res = await fetch("/api/config/prompt-overrides", {
+  const res = await fetch(buildConfigUrl("/api/config/prompt-overrides", org), {
     method: "PUT",
     headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
     body: JSON.stringify(overrides),
@@ -65,8 +68,11 @@ export async function putOrgOverrides(
   return unwrapOverridesResponse((await res.json()) as Record<string, unknown>);
 }
 
-export async function deleteOrgOverrides(signal?: AbortSignal): Promise<void> {
-  const res = await fetch("/api/config/prompt-overrides", {
+export async function deleteOrgOverrides(
+  signal?: AbortSignal,
+  org?: string | null
+): Promise<void> {
+  const res = await fetch(buildConfigUrl("/api/config/prompt-overrides", org), {
     method: "DELETE",
     headers: SAME_ORIGIN_HEADERS,
     signal,
@@ -82,8 +88,11 @@ export async function deleteOrgOverrides(signal?: AbortSignal): Promise<void> {
 // Modes
 // ---------------------------------------------------------------------------
 
-export async function listModes(signal?: AbortSignal): Promise<OrgModes> {
-  const res = await fetch("/api/config/modes", {
+export async function listModes(
+  signal?: AbortSignal,
+  org?: string | null
+): Promise<OrgModes> {
+  const res = await fetch(buildConfigUrl("/api/config/modes", org), {
     headers: SAME_ORIGIN_HEADERS,
     signal,
   });
@@ -109,12 +118,16 @@ function unwrapModeResponse(data: Record<string, unknown>): PromptMode {
 
 export async function getMode(
   name: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<PromptMode> {
-  const res = await fetch(`/api/config/modes/${encodeURIComponent(name)}`, {
-    headers: SAME_ORIGIN_HEADERS,
-    signal,
-  });
+  const res = await fetch(
+    buildConfigUrl(`/api/config/modes/${encodeURIComponent(name)}`, org),
+    {
+      headers: SAME_ORIGIN_HEADERS,
+      signal,
+    }
+  );
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -132,14 +145,18 @@ export async function putMode(
     document: string;
     published?: boolean;
   },
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<PromptMode> {
-  const res = await fetch(`/api/config/modes/${encodeURIComponent(name)}`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
-    body: JSON.stringify(body),
-    signal,
-  });
+  const res = await fetch(
+    buildConfigUrl(`/api/config/modes/${encodeURIComponent(name)}`, org),
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+      body: JSON.stringify(body),
+      signal,
+    }
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
@@ -154,13 +171,17 @@ export async function putMode(
 
 export async function deleteMode(
   name: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<void> {
-  const res = await fetch(`/api/config/modes/${encodeURIComponent(name)}`, {
-    method: "DELETE",
-    headers: SAME_ORIGIN_HEADERS,
-    signal,
-  });
+  const res = await fetch(
+    buildConfigUrl(`/api/config/modes/${encodeURIComponent(name)}`, org),
+    {
+      method: "DELETE",
+      headers: SAME_ORIGIN_HEADERS,
+      signal,
+    }
+  );
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -174,9 +195,13 @@ export async function deleteMode(
 
 export async function getUserMemory(
   userId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<MemoryResponse> {
-  const url = `/api/config/user-memory/${encodeURIComponent(userId)}`;
+  const url = buildConfigUrl(
+    `/api/config/user-memory/${encodeURIComponent(userId)}`,
+    org
+  );
   const res = await fetch(url, {
     headers: SAME_ORIGIN_HEADERS,
     signal,
@@ -192,9 +217,13 @@ export async function getUserMemory(
 
 export async function deleteUserMemory(
   userId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<void> {
-  const url = `/api/config/user-memory/${encodeURIComponent(userId)}`;
+  const url = buildConfigUrl(
+    `/api/config/user-memory/${encodeURIComponent(userId)}`,
+    org
+  );
   const res = await fetch(url, {
     method: "DELETE",
     headers: SAME_ORIGIN_HEADERS,
@@ -214,9 +243,13 @@ export async function deleteUserMemory(
 export async function setUserMode(
   userId: string,
   mode: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<void> {
-  const url = `/api/config/user-mode/${encodeURIComponent(userId)}`;
+  const url = buildConfigUrl(
+    `/api/config/user-mode/${encodeURIComponent(userId)}`,
+    org
+  );
   const res = await fetch(url, {
     method: "PUT",
     headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
@@ -232,9 +265,13 @@ export async function setUserMode(
 
 export async function clearUserMode(
   userId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<void> {
-  const url = `/api/config/user-mode/${encodeURIComponent(userId)}`;
+  const url = buildConfigUrl(
+    `/api/config/user-mode/${encodeURIComponent(userId)}`,
+    org
+  );
   const res = await fetch(url, {
     method: "DELETE",
     headers: SAME_ORIGIN_HEADERS,

--- a/src/lib/config-url.ts
+++ b/src/lib/config-url.ts
@@ -1,0 +1,17 @@
+// Builds a /api/config/* URL with an optional `?org=` query suffix for the
+// super-admin cross-org override path. The worker validates and gates the
+// param (worker/config.ts `resolveOrg`); the helper exists so every callsite
+// shares one encoding rule and the optional-param branching doesn't litter
+// each API helper.
+//
+// Empty/whitespace-only orgs are dropped silently rather than appended — a
+// stale `contextOrg` shouldn't poison every URL with a guaranteed-400 param.
+// The selector is the only writer in normal flow, but defense-in-depth here
+// keeps the contract honest for callers that pass `contextOrg ?? undefined`
+// without checking the trim.
+export function buildConfigUrl(path: string, org?: string | null): string {
+  if (org === undefined || org === null) return path;
+  const trimmed = org.trim();
+  if (!trimmed) return path;
+  return `${path}?org=${encodeURIComponent(trimmed)}`;
+}

--- a/src/lib/context-org-guard.ts
+++ b/src/lib/context-org-guard.ts
@@ -1,0 +1,24 @@
+// Decision helper for the org-context dirty-guard wired into Modes and
+// Languages pages. Without this guard a super-admin half a sentence into
+// an edit would silently lose it when the OrgContextSelector dropdown
+// fired (Frank P1, PR #186 review).
+//
+// Pure function so the contract is testable without a React renderer —
+// the repo doesn't yet have RTL set up, and the existing pendingSwitch
+// (per-mode/language) pattern has no equivalent coverage either, so this
+// helper exists primarily to pin the rule. Pages branch on the return
+// value: `no-op` exits early, `apply` calls setContextOrg directly,
+// `confirm` opens an AlertDialog and stashes the pending value.
+
+export type ContextChangeOutcome = "no-op" | "apply" | "confirm";
+
+export function decideContextChange(
+  current: string | null,
+  next: string | null,
+  isDirty: boolean,
+  isSaving: boolean
+): ContextChangeOutcome {
+  if (next === current) return "no-op";
+  if (isDirty || isSaving) return "confirm";
+  return "apply";
+}

--- a/src/lib/language-scaffold-api.ts
+++ b/src/lib/language-scaffold-api.ts
@@ -1,3 +1,4 @@
+import { buildConfigUrl } from "@/lib/config-url";
 import type { LanguageScaffold } from "@/types/language-scaffold";
 
 const SAME_ORIGIN_HEADERS = {
@@ -5,12 +6,16 @@ const SAME_ORIGIN_HEADERS = {
 } as const;
 
 export async function getLanguageScaffold(
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<LanguageScaffold> {
-  const res = await fetch("/api/config/language-scaffold", {
-    headers: SAME_ORIGIN_HEADERS,
-    signal,
-  });
+  const res = await fetch(
+    buildConfigUrl("/api/config/language-scaffold", org),
+    {
+      headers: SAME_ORIGIN_HEADERS,
+      signal,
+    }
+  );
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -1,3 +1,4 @@
+import { buildConfigUrl } from "@/lib/config-url";
 import type { Language, OrgLanguages } from "@/types/language";
 
 const SAME_ORIGIN_HEADERS = {
@@ -18,9 +19,10 @@ export class LanguageForbiddenError extends Error {
 }
 
 export async function listLanguages(
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<OrgLanguages> {
-  const res = await fetch("/api/config/languages", {
+  const res = await fetch(buildConfigUrl("/api/config/languages", org), {
     headers: SAME_ORIGIN_HEADERS,
     signal,
   });
@@ -35,12 +37,16 @@ export async function listLanguages(
 
 export async function getLanguage(
   name: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<Language> {
-  const res = await fetch(`/api/config/languages/${encodeURIComponent(name)}`, {
-    headers: SAME_ORIGIN_HEADERS,
-    signal,
-  });
+  const res = await fetch(
+    buildConfigUrl(`/api/config/languages/${encodeURIComponent(name)}`, org),
+    {
+      headers: SAME_ORIGIN_HEADERS,
+      signal,
+    }
+  );
 
   if (res.status === 403) {
     throw new LanguageForbiddenError(name, "read");
@@ -67,14 +73,18 @@ export async function putLanguage(
     document: string;
     published?: boolean;
   },
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<Language> {
-  const res = await fetch(`/api/config/languages/${encodeURIComponent(name)}`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
-    body: JSON.stringify(body),
-    signal,
-  });
+  const res = await fetch(
+    buildConfigUrl(`/api/config/languages/${encodeURIComponent(name)}`, org),
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+      body: JSON.stringify(body),
+      signal,
+    }
+  );
 
   if (res.status === 403) {
     throw new LanguageForbiddenError(name, "write");
@@ -96,13 +106,17 @@ export async function putLanguage(
 
 export async function deleteLanguage(
   name: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  org?: string | null
 ): Promise<void> {
-  const res = await fetch(`/api/config/languages/${encodeURIComponent(name)}`, {
-    method: "DELETE",
-    headers: SAME_ORIGIN_HEADERS,
-    signal,
-  });
+  const res = await fetch(
+    buildConfigUrl(`/api/config/languages/${encodeURIComponent(name)}`, org),
+    {
+      method: "DELETE",
+      headers: SAME_ORIGIN_HEADERS,
+      signal,
+    }
+  );
 
   if (res.status === 403) {
     throw new LanguageForbiddenError(name, "delete");

--- a/src/lib/ui-store.ts
+++ b/src/lib/ui-store.ts
@@ -16,6 +16,16 @@ interface UiState {
   setSelectedMode: (mode: string | null) => void;
   selectedLanguage: string | null;
   setSelectedLanguage: (language: string | null) => void;
+  // Super-admin cross-org override for /api/config/* fetches. `null` is the
+  // everyday same-org path: hooks omit the `?org=` param and the worker
+  // resolves the caller's session.org. When set to a non-null slug, the
+  // Modes / Languages / Prompt-Overrides pages operate on that org instead
+  // (worker gates on isSuperAdmin per #166 PR A). `setContextOrg` clears
+  // selectedMode + selectedLanguage so org-A state doesn't bleed into
+  // org-B fetches — otherwise the per-mode draft would briefly display
+  // stale content from the previous context.
+  contextOrg: string | null;
+  setContextOrg: (org: string | null) => void;
   chatMode: string | null;
   chatModeSeeded: boolean;
   setChatMode: (mode: string | null) => void;
@@ -38,6 +48,7 @@ type InitialUiState = Pick<
   | "testChatOpen"
   | "selectedMode"
   | "selectedLanguage"
+  | "contextOrg"
   | "chatMode"
   | "chatModeSeeded"
   | "testChatUserId"
@@ -70,6 +81,7 @@ const initialState: InitialUiState = {
   testChatOpen: false,
   selectedMode: null,
   selectedLanguage: null,
+  contextOrg: null,
   chatMode: null,
   chatModeSeeded: false,
   // Placeholder — reset() always generates a fresh UUID; this value is only
@@ -100,6 +112,18 @@ export const useUiStore = create<UiState>()((set) => ({
     })),
   setSelectedMode: (selectedMode) => set({ selectedMode }),
   setSelectedLanguage: (selectedLanguage) => set({ selectedLanguage }),
+  // Changing context clears selectedMode/selectedLanguage. Without this, a
+  // user who selected `spoken` while in their home org would see the
+  // freshly-fetched cross-org `spoken` (if any) display under the same
+  // selection — the editor would briefly show org-A document content while
+  // the cross-org query was in flight, then snap to org-B content. Better
+  // to land on the empty-selection state and let the user re-pick.
+  setContextOrg: (contextOrg) =>
+    set((state) =>
+      state.contextOrg === contextOrg
+        ? state
+        : { contextOrg, selectedMode: null, selectedLanguage: null }
+    ),
   setChatMode: (chatMode) => set({ chatMode }),
   setTestChatPanelWidth: (width) => {
     const clamped = Math.max(

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -424,3 +424,120 @@ describe("clearUserMode", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-org override threading (#166 PR B)
+// ---------------------------------------------------------------------------
+//
+// The portal-side switch ships in two pieces — worker (PR A, merged) and UI
+// (this PR). These tests pin the wire format that the worker's `resolveOrg`
+// expects: `?org=<encoded>` only when the caller supplies a non-empty slug;
+// otherwise the URL is identical to the legacy same-org call so the existing
+// org-admin path is byte-for-byte unchanged.
+
+describe("config-api cross-org threading", () => {
+  function urlOf(spy: { mock: { calls: unknown[][] } }, call = 0): string {
+    return String(spy.mock.calls[call]![0]);
+  }
+
+  it("listModes(undefined, undefined) → no ?org=", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ modes: [] })));
+    await listModes();
+    expect(urlOf(spy)).toBe("/api/config/modes");
+  });
+
+  it("listModes(_, 'word-collective') → ?org=word-collective", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ modes: [] })));
+    await listModes(undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/modes?org=word-collective");
+  });
+
+  it("getMode encodes both the path segment and the org param", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ mode: { name: "kids-mode", document: "" } })
+        )
+      );
+    await getMode("kids-mode", undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/modes/kids-mode?org=word-collective");
+  });
+
+  it("putMode threads org through (mutations must use the same ?org=)", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ mode: { name: "spoken", document: "x" } })
+        )
+      );
+    await putMode("spoken", { document: "x" }, undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/modes/spoken?org=word-collective");
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("deleteMode threads org through", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await deleteMode("legacy", undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/modes/legacy?org=word-collective");
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("getOrgOverrides threads org through", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({})));
+    await getOrgOverrides(undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/prompt-overrides?org=word-collective");
+  });
+
+  it("putOrgOverrides threads org through", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({})));
+    await putOrgOverrides({ identity: "x" }, undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/prompt-overrides?org=word-collective");
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("getUserMemory threads org through", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ memory: {} })));
+    await getUserMemory(SAMPLE_UUID, undefined, "word-collective");
+    expect(urlOf(spy)).toBe(
+      `/api/config/user-memory/${SAMPLE_UUID}?org=word-collective`
+    );
+  });
+
+  it("setUserMode threads org through", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await setUserMode(SAMPLE_UUID, "spoken", undefined, "word-collective");
+    expect(urlOf(spy)).toBe(
+      `/api/config/user-mode/${SAMPLE_UUID}?org=word-collective`
+    );
+  });
+
+  it("listModes with null org acts identically to omitted org", async () => {
+    // The UI passes `contextOrg ?? null` through hooks; `null` must hash to
+    // the same URL as `undefined` so the same-org cache and the unset cache
+    // don't double-fetch.
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ modes: [] })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ modes: [] })));
+    await listModes(undefined, null);
+    await listModes();
+    expect(urlOf(spy, 0)).toBe("/api/config/modes");
+    expect(urlOf(spy, 1)).toBe("/api/config/modes");
+  });
+});

--- a/tests/config-url.test.ts
+++ b/tests/config-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { buildConfigUrl } from "../src/lib/config-url";
+
+describe("buildConfigUrl", () => {
+  it("returns the path unchanged when org is undefined", () => {
+    expect(buildConfigUrl("/api/config/modes")).toBe("/api/config/modes");
+  });
+
+  it("returns the path unchanged when org is null", () => {
+    expect(buildConfigUrl("/api/config/modes", null)).toBe("/api/config/modes");
+  });
+
+  it("returns the path unchanged when org is empty string", () => {
+    expect(buildConfigUrl("/api/config/modes", "")).toBe("/api/config/modes");
+  });
+
+  it("returns the path unchanged when org is whitespace-only", () => {
+    // Defense-in-depth: a stale `contextOrg = "  "` shouldn't poison every
+    // URL with a guaranteed-400 param. The selector is the sole writer in
+    // normal flow but the helper is the last line.
+    expect(buildConfigUrl("/api/config/modes", "   ")).toBe(
+      "/api/config/modes"
+    );
+  });
+
+  it("appends ?org= when org is provided", () => {
+    expect(buildConfigUrl("/api/config/modes", "word-collective")).toBe(
+      "/api/config/modes?org=word-collective"
+    );
+  });
+
+  it("trims the slug before encoding", () => {
+    // Trim parity with the worker's resolveOrg — both sides accept the
+    // same input shape so a stray space at either end doesn't yield a
+    // hard 400.
+    expect(buildConfigUrl("/api/config/modes", "  acme  ")).toBe(
+      "/api/config/modes?org=acme"
+    );
+  });
+
+  it("URL-encodes characters in the slug", () => {
+    expect(buildConfigUrl("/api/config/modes", "word collective")).toBe(
+      "/api/config/modes?org=word%20collective"
+    );
+    expect(buildConfigUrl("/api/config/modes", "a&b")).toBe(
+      "/api/config/modes?org=a%26b"
+    );
+  });
+
+  it("works for paths that already contain encoded segments", () => {
+    expect(buildConfigUrl("/api/config/modes/spoken%20mode", "acme")).toBe(
+      "/api/config/modes/spoken%20mode?org=acme"
+    );
+  });
+});

--- a/tests/context-org-guard.test.ts
+++ b/tests/context-org-guard.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { decideContextChange } from "../src/lib/context-org-guard";
+
+describe("decideContextChange", () => {
+  // The no-op branch must fire before any dirty/saving check — picking
+  // the already-selected value is the most common selector tick (e.g.,
+  // React re-renders + Radix Select dispatches even when nothing
+  // changed) and shouldn't ever prompt a confirmation dialog.
+  describe("no-op when next === current", () => {
+    it("home → home", () => {
+      expect(decideContextChange(null, null, false, false)).toBe("no-op");
+    });
+
+    it("same other-org → same other-org", () => {
+      expect(decideContextChange("acme", "acme", false, false)).toBe("no-op");
+    });
+
+    it("no-op even when dirty (a re-pick of the active org isn't a switch)", () => {
+      expect(decideContextChange("acme", "acme", true, false)).toBe("no-op");
+      expect(decideContextChange(null, null, true, true)).toBe("no-op");
+    });
+  });
+
+  describe("apply when clean and changing", () => {
+    it("home → other-org", () => {
+      expect(decideContextChange(null, "acme", false, false)).toBe("apply");
+    });
+
+    it("other-org → home", () => {
+      expect(decideContextChange("acme", null, false, false)).toBe("apply");
+    });
+
+    it("other-org → different other-org", () => {
+      expect(decideContextChange("acme", "word-collective", false, false)).toBe(
+        "apply"
+      );
+    });
+  });
+
+  describe("confirm when dirty or saving", () => {
+    it("dirty alone triggers confirm", () => {
+      expect(decideContextChange(null, "acme", true, false)).toBe("confirm");
+    });
+
+    it("saving alone triggers confirm (mid-flight save would race)", () => {
+      // Without this, a switch fired during an in-flight save could land
+      // the save in org-A while the page already shows org-B's content,
+      // and an autosave triggered after the response would PUT org-B's
+      // draft to org-A's namespace.
+      expect(decideContextChange(null, "acme", false, true)).toBe("confirm");
+    });
+
+    it("dirty AND saving triggers confirm", () => {
+      expect(decideContextChange("acme", null, true, true)).toBe("confirm");
+    });
+
+    it("confirm fires for every kind of switch (other→home, home→other, other→other)", () => {
+      expect(decideContextChange("acme", null, true, false)).toBe("confirm");
+      expect(decideContextChange(null, "acme", true, false)).toBe("confirm");
+      expect(decideContextChange("acme", "word-collective", true, false)).toBe(
+        "confirm"
+      );
+    });
+  });
+});

--- a/tests/language-scaffold-api.test.ts
+++ b/tests/language-scaffold-api.test.ts
@@ -68,4 +68,30 @@ describe("getLanguageScaffold", () => {
     await getLanguageScaffold(controller.signal);
     expect(spy.mock.calls[0]![1]).toMatchObject({ signal: controller.signal });
   });
+
+  // -------------------------------------------------------------------------
+  // Cross-org override (#166 PR B)
+  // -------------------------------------------------------------------------
+
+  it("no org → /api/config/language-scaffold (no ?org=)", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ scaffold: { document: "" } }))
+      );
+    await getLanguageScaffold();
+    expect(String(spy.mock.calls[0]![0])).toBe("/api/config/language-scaffold");
+  });
+
+  it("with org → /api/config/language-scaffold?org=<encoded>", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ scaffold: { document: "" } }))
+      );
+    await getLanguageScaffold(undefined, "word-collective");
+    expect(String(spy.mock.calls[0]![0])).toBe(
+      "/api/config/language-scaffold?org=word-collective"
+    );
+  });
 });

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -227,3 +227,91 @@ describe("deleteLanguage", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-org override threading (#166 PR B)
+// ---------------------------------------------------------------------------
+
+describe("languages-api cross-org threading", () => {
+  function urlOf(spy: { mock: { calls: unknown[][] } }, call = 0): string {
+    return String(spy.mock.calls[call]![0]);
+  }
+
+  it("listLanguages() with no org → no ?org=", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ languages: [] })));
+    await listLanguages();
+    expect(urlOf(spy)).toBe("/api/config/languages");
+  });
+
+  it("listLanguages with org → ?org=word-collective", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ languages: [] })));
+    await listLanguages(undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/languages?org=word-collective");
+  });
+
+  it("getLanguage threads org through and still encodes the name", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ language: { name: "arabic", document: "" } })
+        )
+      );
+    await getLanguage("arabic", undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/languages/arabic?org=word-collective");
+  });
+
+  it("putLanguage threads org through (mutation must use same ?org=)", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ language: { name: "arabic", document: "x" } })
+        )
+      );
+    await putLanguage(
+      "arabic",
+      { document: "x" },
+      undefined,
+      "word-collective"
+    );
+    expect(urlOf(spy)).toBe("/api/config/languages/arabic?org=word-collective");
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("deleteLanguage threads org through", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await deleteLanguage("arabic", undefined, "word-collective");
+    expect(urlOf(spy)).toBe("/api/config/languages/arabic?org=word-collective");
+    expect((spy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("LanguageForbiddenError still surfaces under cross-org (server-side gate intact)", async () => {
+    // PR A's worker carve-out lets super admins bypass `hasLanguageRights`
+    // ONLY when ?org= is set AND the target differs from session.org. A
+    // 403 from upstream still needs to land as LanguageForbiddenError so
+    // the UI renders the inline permission message instead of the
+    // generic save-failed error — the cross-org code path must not eat
+    // the error-class plumbing.
+    mockFetchOnce(403, { error: "Forbidden" });
+    try {
+      await putLanguage(
+        "arabic",
+        { document: "x" },
+        undefined,
+        "word-collective"
+      );
+      throw new Error("expected rejection");
+    } catch (e) {
+      expect(e).toBeInstanceOf(LanguageForbiddenError);
+      const err = e as LanguageForbiddenError;
+      expect(err.operation).toBe("write");
+    }
+  });
+});

--- a/tests/ui-store.test.ts
+++ b/tests/ui-store.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+// The cloudflare workers test pool has no localStorage. The store reads it
+// at module load (testChatPanelWidth + showDrafts persistence), so stub
+// before the dynamic import or the module will throw.
+const storage = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  value: {
+    getItem: (k: string) => storage.get(k) ?? null,
+    setItem: (k: string, v: string) => storage.set(k, v),
+    removeItem: (k: string) => storage.delete(k),
+    clear: () => storage.clear(),
+  },
+  configurable: true,
+});
+
+const { useUiStore } = await import("../src/lib/ui-store");
+
+// The store is module-scoped so successive tests share state. Reset before
+// each test to keep assertions hermetic.
+beforeEach(() => {
+  useUiStore.getState().reset();
+});
+
+describe("ui-store setContextOrg (#166 PR B)", () => {
+  it("defaults contextOrg to null (same-org path)", () => {
+    expect(useUiStore.getState().contextOrg).toBe(null);
+  });
+
+  it("clears selectedMode + selectedLanguage when switching context", () => {
+    // Without the clear, a super admin who picked `spoken` in their home
+    // org would see the editor render the home-org `spoken` document
+    // briefly when the cross-org query lands. Pin the invariant so a
+    // future store refactor can't quietly drop the clear.
+    const s = useUiStore.getState();
+    s.setSelectedMode("spoken");
+    s.setSelectedLanguage("arabic");
+    expect(useUiStore.getState().selectedMode).toBe("spoken");
+    expect(useUiStore.getState().selectedLanguage).toBe("arabic");
+
+    s.setContextOrg("word-collective");
+
+    expect(useUiStore.getState().contextOrg).toBe("word-collective");
+    expect(useUiStore.getState().selectedMode).toBe(null);
+    expect(useUiStore.getState().selectedLanguage).toBe(null);
+  });
+
+  it("clears selections when going back to same-org (null)", () => {
+    const s = useUiStore.getState();
+    s.setContextOrg("word-collective");
+    s.setSelectedMode("spoken");
+    s.setSelectedLanguage("arabic");
+
+    s.setContextOrg(null);
+
+    expect(useUiStore.getState().contextOrg).toBe(null);
+    expect(useUiStore.getState().selectedMode).toBe(null);
+    expect(useUiStore.getState().selectedLanguage).toBe(null);
+  });
+
+  it("no-ops when set to the current value (selections preserved)", () => {
+    // Setting the same value is idempotent — don't churn selections just
+    // because the selector fired a redundant onValueChange. Mirrors the
+    // pattern in `setSelectedMode` etc. which are plain setters.
+    const s = useUiStore.getState();
+    s.setContextOrg("word-collective");
+    s.setSelectedMode("spoken");
+    s.setSelectedLanguage("arabic");
+
+    s.setContextOrg("word-collective");
+
+    expect(useUiStore.getState().selectedMode).toBe("spoken");
+    expect(useUiStore.getState().selectedLanguage).toBe("arabic");
+  });
+
+  it("reset() clears contextOrg back to null (logout path)", () => {
+    const s = useUiStore.getState();
+    s.setContextOrg("word-collective");
+    expect(useUiStore.getState().contextOrg).toBe("word-collective");
+
+    s.reset();
+
+    expect(useUiStore.getState().contextOrg).toBe(null);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import path from "path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -19,6 +20,16 @@ export default defineConfig({
       },
     }),
   ],
+  resolve: {
+    // Mirror the main vite.config.ts alias so tests-under-pool resolve
+    // value imports through the `@/` prefix. Type-only `@/...` imports
+    // are erased before runtime so they didn't surface this gap until
+    // the first sibling-lib value import landed (#166 PR B,
+    // `src/lib/config-api.ts` → `src/lib/config-url.ts`).
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     include: ["tests/**/*.test.ts"],
   },


### PR DESCRIPTION
## Summary

Closes #166. Wires the worker side from PR A (#185, merged at `6c3b720`) into the UI. Super admins now get an "Org context" dropdown on **Modes**, **Languages**, and **Prompt Overrides**; picking a different org makes every `/api/config/*` fetch on those pages carry `?org=<slug>`. Org admins see no change — same-org code path is byte-for-byte unchanged.

## Touchpoints

| File | Change |
|---|---|
| `src/lib/config-url.ts` | **new** — `buildConfigUrl(path, org)`, the only place that appends `?org=`. Empty/whitespace silently dropped (defense-in-depth against a stale store value); trims to match worker `resolveOrg`'s input shape. |
| `src/lib/config-api.ts` / `languages-api.ts` / `language-scaffold-api.ts` | Trailing optional `org?: string \| null` on every helper. Per-user endpoints (`user-memory`, `user-mode`) get the param for parity even though no UI consumes it yet. |
| `src/hooks/use-prompt-config.ts` / `use-languages.ts` / `use-language-scaffold.ts` | Each hook accepts `org?` and threads it through. Query keys include the org so org-A and org-B caches don't collide. `null` and `undefined` normalize to the same key. |
| `src/lib/ui-store.ts` | New `contextOrg: string \| null`, default `null` (= use session.org). `setContextOrg` clears `selectedMode` + `selectedLanguage` on a *real* change so org-A state can't flash in the editor while the org-B query lands. No-ops on a redundant tick. Cleared by `reset()` on logout. |
| `src/components/org-context-selector.tsx` | **new** — Returns `null` for non-super sessions so org-admin pages render identically to before. Otherwise renders the home org + every other org that has ≥1 user (derived from `useAdminUsers`, gated on `callerIsSuperAdmin`). `HOME_ORG_SENTINEL` bridges Radix Select's no-empty-string rule with the store's `null = home` model. |
| `src/app/pages/{modes,languages,manual-config}.tsx` | Inline `<OrgContextSelector />`; pass `contextOrg` to every hook. |
| `src/app/pages/languages.tsx` (carve-out) | Mirrors the worker's PR A carve-out: when cross-org, `effectiveRights = "*"` so the page filter, the `hasAccess` gate, and the stale-selection guard don't block a super-admin with restricted same-org shepherd rights from operating on another org's languages. |
| `vitest.config.ts` | Mirrored the `@` → `./src` alias from `vite.config.ts`. The test pool hadn't needed it before because the only `@/` imports under `src/lib` were type-only (erased before runtime). The first sibling-lib value import (`config-api.ts` → `config-url.ts`) surfaced the gap. |

## Test plan

- [x] `npx vitest run` — **241 / 241 pass** (was 210; +31 new)
- [x] `npm run lint` — clean (`--max-warnings 0`)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Pre-commit hook (lint-staged + typecheck + build) — pass
- [ ] **Manual smoke on the ephemeral PR deploy** (super admin): on each of Modes / Languages / Prompt Overrides, switch context to another org, confirm DevTools Network shows `?org=<other>` on the fetches and the editor renders the cross-org document. Switch back to home org → no `?org=` on the wire.

## Test additions (31)

- **`tests/config-url.test.ts`** (new, 7) — URL builder rules: undefined/null/empty/whitespace → no `?org=`; non-empty appended and trimmed; encoding preserved.
- **`tests/config-api.test.ts`** (+10) — every helper threads org through the URL (modes list, mode read/write/delete, prompt-overrides read/write, user-memory, user-mode); `null` and `undefined` hash to identical URLs so the same-org and unset caches don't double-fetch.
- **`tests/languages-api.test.ts`** (+6) — same threading + a `LanguageForbiddenError` regression check pinning that a 403 under cross-org still surfaces as `LanguageForbiddenError` (the UI's inline permission-message flow must not be bypassed by the new code path).
- **`tests/language-scaffold-api.test.ts`** (+2) — scaffold URL with and without `?org=`.
- **`tests/ui-store.test.ts`** (new, 5) — `setContextOrg` clears selections on a real change, idempotent on redundant ticks, `reset()` zeros the field. Polyfills `localStorage` since the cloudflare workers test pool doesn't ship one.

## Scope

Per the issue body's three named touchpoints (Modes / Languages / Prompt Overrides). The per-user endpoints have `?org=` available at the helper layer for future use, but no UI is wired — chat / test-chat consumers are deliberately out of scope.

## Follow-ups (not in this PR)

- Visual cross-org indicator beyond the dropdown's selected value (e.g. a banner near `PageHeader`) — held until reviewers tell me the current cue is too subtle.
- Wiring cross-org `?org=` into chat / test-chat consumers of the per-user endpoints — separate decision (intersects with #117, chat-stream user_id ownership, which is still pending design).

## Related

- PR A (worker side): #185, merged at `6c3b720`
- Issue: #166
- Tracks #138 epic (super-admin role)
- Prerequisite for #149 (Mode Library) and #153 (Governance)
- Independent of fork-vs-cascade (#170)