### PR TITLE
feat(#187): Export Config button on Modes page

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Save } from "lucide-react";
+import { Download, Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
+import {
+  buildModeExportContent,
+  buildModeExportFilename,
+} from "@/lib/mode-export";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
 import { useUiStore } from "@/lib/ui-store";
 import { OrgContextSelector } from "@/components/org-context-selector";
@@ -40,6 +44,7 @@ const AUTO_SAVE_DEBOUNCE_MS = 800;
 
 export function ModesPage() {
   const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
+  const homeOrg = useAuthStore((s) => s.user?.org);
   const selectedMode = useUiStore((s) => s.selectedMode);
   const setSelectedMode = useUiStore((s) => s.setSelectedMode);
   const showDrafts = useUiStore((s) => s.showDrafts);
@@ -152,6 +157,49 @@ export function ModesPage() {
     if (!isDirty || isSaving) return;
     performSave(draft);
   }, [draft, isDirty, isSaving, performSave]);
+
+  // Export captures what's currently on screen — draft (including unsaved
+  // edits) + last-synced metadata. The export's `org` is the effective
+  // context (cross-org if a super-admin has switched orgs; otherwise the
+  // caller's home org).
+  const effectiveOrg = contextOrg ?? homeOrg ?? null;
+  const handleExport = useCallback(() => {
+    if (!selectedMode || !modeQuery.data || !effectiveOrg) return;
+    // Single `Date` instance so the frontmatter `exported_at` and the
+    // filename timestamp can never drift by a second across the call.
+    const ctx = { org: effectiveOrg, exportedAt: new Date() };
+    const content = buildModeExportContent(
+      {
+        name: selectedMode,
+        label: serverLabel,
+        description: serverDescription,
+        document: draft,
+        published: lastSyncedPublished,
+      },
+      ctx
+    );
+    const filename = buildModeExportFilename(
+      { name: selectedMode, document: draft },
+      ctx
+    );
+    const blob = new Blob([content], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [
+    draft,
+    effectiveOrg,
+    lastSyncedPublished,
+    modeQuery.data,
+    selectedMode,
+    serverDescription,
+    serverLabel,
+  ]);
 
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
@@ -317,6 +365,16 @@ export function ModesPage() {
               >
                 {saveStatus}
               </span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleExport}
+                disabled={!effectiveOrg}
+                title="Download a Markdown snapshot of this mode's config"
+              >
+                <Download className="mr-1.5 size-3.5" />
+                Export
+              </Button>
               <Button
                 size="sm"
                 onClick={flushSave}

--- a/src/lib/mode-export.ts
+++ b/src/lib/mode-export.ts
@@ -1,0 +1,66 @@
+// Pure helpers for the Modes page's "Export Config" action (#187).
+// Produces a structured Markdown snapshot of a mode — YAML frontmatter
+// for metadata, the mode's document as the body. Format is human-readable
+// and round-trips through any standard Markdown-with-frontmatter parser.
+// Import path is intentionally out of scope (separate issue per #187 ACs).
+
+import type { PromptMode } from "@/types/prompt-override";
+
+export const MODE_EXPORT_VERSION = 1;
+
+export interface ModeExportContext {
+  org: string;
+  exportedAt: Date;
+}
+
+export function buildModeExportContent(
+  mode: PromptMode,
+  ctx: ModeExportContext
+): string {
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`name: ${yamlScalar(mode.name)}`);
+  if (mode.label !== undefined) {
+    lines.push(`label: ${yamlScalar(mode.label)}`);
+  }
+  if (mode.description !== undefined) {
+    lines.push(`description: ${yamlScalar(mode.description)}`);
+  }
+  lines.push(`published: ${mode.published === true ? "true" : "false"}`);
+  lines.push(`org: ${yamlScalar(ctx.org)}`);
+  lines.push(`exported_at: ${ctx.exportedAt.toISOString()}`);
+  lines.push(`export_version: ${MODE_EXPORT_VERSION}`);
+  lines.push("---");
+  lines.push("");
+  lines.push(mode.document);
+  return lines.join("\n");
+}
+
+export function buildModeExportFilename(
+  mode: PromptMode,
+  ctx: ModeExportContext
+): string {
+  const ts = ctx.exportedAt
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+  return `${sanitize(ctx.org)}-mode-${sanitize(mode.name)}-${ts}.md`;
+}
+
+// YAML scalar emitter. Always double-quotes user-controlled strings so
+// any colon, hash, leading dash, or other YAML special character can't
+// produce a surprise parse on re-import. Escapes \, ", \n, \r, \t.
+function yamlScalar(value: string): string {
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
+}
+
+function sanitize(s: string): string {
+  const cleaned = s.replace(/[^A-Za-z0-9._-]/g, "_").replace(/^_+|_+$/g, "");
+  return cleaned || "untitled";
+}

--- a/tests/mode-export.test.ts
+++ b/tests/mode-export.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MODE_EXPORT_VERSION,
+  buildModeExportContent,
+  buildModeExportFilename,
+} from "../src/lib/mode-export";
+import type { PromptMode } from "../src/types/prompt-override";
+
+const FIXED_DATE = new Date("2026-05-28T15:30:00.000Z");
+
+const baseMode: PromptMode = {
+  name: "spoken",
+  label: "Spoken Mode",
+  description: "Conversational responses tuned for spoken delivery.",
+  document: "# Spoken mode\n\nUse natural prose.",
+  published: true,
+};
+
+describe("buildModeExportContent — frontmatter", () => {
+  it("emits all PromptMode fields when populated", () => {
+    const out = buildModeExportContent(baseMode, {
+      org: "unfoldingWord",
+      exportedAt: FIXED_DATE,
+    });
+    expect(out).toContain('name: "spoken"');
+    expect(out).toContain('label: "Spoken Mode"');
+    expect(out).toContain(
+      'description: "Conversational responses tuned for spoken delivery."'
+    );
+    expect(out).toContain("published: true");
+    expect(out).toContain('org: "unfoldingWord"');
+    expect(out).toContain("exported_at: 2026-05-28T15:30:00.000Z");
+    expect(out).toContain(`export_version: ${MODE_EXPORT_VERSION}`);
+  });
+
+  it("omits optional fields that are undefined", () => {
+    const out = buildModeExportContent(
+      { name: "minimal", document: "body" },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(out).not.toContain("label:");
+    expect(out).not.toContain("description:");
+    // `published` is always emitted (boolean defaults to false when undefined).
+    expect(out).toContain("published: false");
+  });
+
+  it("emits published as the literal boolean — false when undefined or false", () => {
+    const undef = buildModeExportContent(
+      { name: "x", document: "" },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    const explicit = buildModeExportContent(
+      { name: "x", document: "", published: false },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(undef).toContain("published: false");
+    expect(explicit).toContain("published: false");
+  });
+
+  it("wraps frontmatter in the standard --- fences", () => {
+    const out = buildModeExportContent(baseMode, {
+      org: "unfoldingWord",
+      exportedAt: FIXED_DATE,
+    });
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("---");
+    const closingIdx = lines.indexOf("---", 1);
+    expect(closingIdx).toBeGreaterThan(0);
+    // Blank line separates frontmatter from body.
+    expect(lines[closingIdx + 1]).toBe("");
+  });
+
+  it("appends the document verbatim after the frontmatter", () => {
+    const out = buildModeExportContent(baseMode, {
+      org: "unfoldingWord",
+      exportedAt: FIXED_DATE,
+    });
+    expect(out.endsWith(baseMode.document)).toBe(true);
+  });
+});
+
+describe("buildModeExportContent — YAML escaping", () => {
+  it("escapes double quotes inside string values", () => {
+    const out = buildModeExportContent(
+      { name: "x", label: 'has "quotes" here', document: "" },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(out).toContain('label: "has \\"quotes\\" here"');
+  });
+
+  it("escapes backslashes", () => {
+    const out = buildModeExportContent(
+      { name: "x", label: "C:\\path\\to\\thing", document: "" },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(out).toContain('label: "C:\\\\path\\\\to\\\\thing"');
+  });
+
+  it("escapes newlines, carriage returns, and tabs in metadata strings", () => {
+    const out = buildModeExportContent(
+      { name: "x", description: "line1\nline2\rline3\twith-tab", document: "" },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(out).toContain('description: "line1\\nline2\\rline3\\twith-tab"');
+  });
+
+  it("survives YAML special characters that would break unquoted scalars", () => {
+    const out = buildModeExportContent(
+      {
+        name: "x",
+        label: "value: with: colons # and hash & ampersand",
+        document: "",
+      },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(out).toContain(
+      'label: "value: with: colons # and hash & ampersand"'
+    );
+  });
+
+  it("leaves the document body unescaped (it's the markdown payload)", () => {
+    const docWithSpecials = '# Heading\n\n"quoted text"\n\n```\ncode\n```';
+    const out = buildModeExportContent(
+      { name: "x", document: docWithSpecials },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(out).toContain(docWithSpecials);
+  });
+});
+
+describe("buildModeExportFilename", () => {
+  it("uses the {org}-mode-{name}-{ts}.md pattern", () => {
+    expect(
+      buildModeExportFilename(baseMode, {
+        org: "unfoldingWord",
+        exportedAt: FIXED_DATE,
+      })
+    ).toBe("unfoldingWord-mode-spoken-20260528T153000Z.md");
+  });
+
+  it("sanitizes filesystem-unsafe characters and trims leading/trailing underscores", () => {
+    expect(
+      buildModeExportFilename(
+        { name: "mode/with slashes & spaces", document: "" },
+        { org: "weird org!", exportedAt: FIXED_DATE }
+      )
+    ).toBe("weird_org-mode-mode_with_slashes___spaces-20260528T153000Z.md");
+  });
+
+  it("falls back to 'untitled' if sanitization eats every character", () => {
+    expect(
+      buildModeExportFilename(
+        { name: "✨", document: "" },
+        { org: "🙂", exportedAt: FIXED_DATE }
+      )
+    ).toBe("untitled-mode-untitled-20260528T153000Z.md");
+  });
+
+  it("produces ISO-derived timestamps with no separators (sortable)", () => {
+    // Two close-together exports sort lexicographically in time order.
+    const earlier = buildModeExportFilename(baseMode, {
+      org: "uW",
+      exportedAt: new Date("2026-05-28T15:30:00.000Z"),
+    });
+    const later = buildModeExportFilename(baseMode, {
+      org: "uW",
+      exportedAt: new Date("2026-05-28T15:30:01.000Z"),
+    });
+    expect(earlier < later).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Closes #187** — adds an Export Config button to the Modes page that downloads a structured Markdown snapshot of the selected mode's full config (name, label, description, document, published).
- Manual safety net pending #154 (versioned-config) and #156 (revision states). Import path is tracked separately at **#198** per #187 AC #4.
- Day-8 candidate from the [tuning plan](https://github.com/unfoldingWord/bt-servant-admin-portal/blob/main/docs/tuning-project-plan.md) — pulled forward into Day 1 with bandwidth freed by D-007.

## What's in the export

YAML frontmatter + the mode's markdown document as the body. Format is human-readable and round-trips through any standard Markdown-with-frontmatter parser.

```markdown
---
name: "spoken"
label: "Spoken Mode"
description: "Conversational responses tuned for spoken delivery."
published: true
org: "unfoldingWord"
exported_at: 2026-05-28T15:30:00.000Z
export_version: 1
---

# Mode document content
...
```

YAML scalars for user-controlled metadata are always double-quoted with full escape coverage (`\`, `"`, `\n`, `\r`, `\t`) so labels and descriptions can contain any chars without parse surprises on re-import. The body is the literal document — no escaping (it's the markdown payload).

**Filename:** `{org}-mode-{name}-{ISO-timestamp}.md` (e.g., `unfoldingWord-mode-spoken-20260528T153000Z.md`). Sanitizer collapses non-alphanumerics to underscore, trims leading/trailing underscores, falls back to `untitled` if nothing survives. Timestamps are ISO-derived with separators stripped — lexicographic sort matches chronological.

## UX choices

- Button lives next to Save in the toolbar; **outline** variant to mark it as a utility action vs primary Save.
- Visible only when a mode is selected; enabled even while saving — **export-what-you-see** (captures the current draft, including unsaved edits). Author wanting the saved state can save first.
- `effectiveOrg = contextOrg ?? user.org` — exports reflect the org context being viewed (cross-org if a super-admin has switched).
- Single `new Date()` instance for both the frontmatter `exported_at` and the filename timestamp so they can never drift across a second boundary.

## Test plan

- [x] Pre-commit hook (lint-staged + prettier + typecheck + build) — pass
- [x] All quality gates green locally: lint 0 warnings, typecheck clean, 277/277 tests (263 → 277, +14 new pure tests), build clean, prettier clean
- [ ] **Browser smoke** (Frank / Seth):
  - [ ] Select any mode → Export button appears next to Save
  - [ ] Click Export → browser downloads `{org}-mode-{name}-{ts}.md`
  - [ ] File opens cleanly with frontmatter + body preserved
  - [ ] Type unsaved edits → export captures the draft (not the cached server state)
  - [ ] In cross-org context → exported `org` matches the viewed org, not the home org
  - [ ] Label/description with special chars (`"`, `:`, `#`, `\n`) → frontmatter parses on re-read

## Test coverage (`tests/mode-export.test.ts`, 14 tests)

- Frontmatter: all fields populated, optional omission, published-always-emitted, fence wrapping, body verbatim
- YAML escaping: double quotes, backslashes, newlines + CR + tabs, YAML special chars in unquoted positions, body unescaped
- Filename: pattern, sanitization + trim, `untitled` fallback for emoji-only inputs, sortable timestamps

## Not in this PR (called out for reviewer awareness)

- **Import / re-upload path** — tracked separately at **#198** per #187 AC #4 (filed alongside this PR; open design questions enumerated in the issue body for the next agent)
- **Languages-side parallel** — helper generalizes cleanly, but the issue is modes-only; a follow-up could mirror trivially
- **Worker companion #141** — original tracking issue; suggest close-in-favor-of #187 after this lands

## Plan + decision-log references

- Plan: `docs/tuning-project-plan.md` — Track A.2 (editor polish, demo POLISH)
- Plan Q-001 default: first sibling-repo PR asks for the merge nod; this is portal so the standard "ask before merge" rule applies