### PR TITLE
chore: bump version 1.5.1 → 1.9.0 (catch-up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.5.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-admin-portal",
-      "version": "1.5.1",
+      "version": "1.9.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.5.1",
+  "version": "1.9.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

The version field has been stuck at **1.5.1 since 2026-04-23** (Ian's `Bump MAX_SLOT_LENGTH` commit, `d9d154e` — last day of solo-dev). In the 5 weeks since, **~23 marquee features have shipped** without a single bump. All three environments (Dev/Staging/Prod) currently display v1.5.1 despite containing significantly different code, which leaves Elsy with no way to tell environments apart at a glance — explicitly flagged in the Zulip thread today as a demo-prep blocker (_"That's why we need versioning tight. So that I know."_).

## Why 1.9.0

Calibrated to Ian's prior cadence: he bumped 1.0 → 1.5 across ~6 weeks of comparable scope. 5 weeks of Seth-era shipments maps to roughly the same 5-minor jump. 1.9.0 splits the difference between the most conservative reading (1.6.0, undersells) and the SemVer-honest reading (1.10.0 – 1.12.0).

## What's in the 5-week backlog (since 1.5.1)

| Sprint | Shipments |
|---|---|
| 2026-05-07 | Markdown editor + TOC (#75), Per-PR ephemeral workers (#83) |
| 2026-05-08 | Auto-staging deploy (#89), Languages CRUD (#79), Languages sidebar (#73), Users admin UI (#96), Mode/language accents (#78), Language-shepherd permissions (#80) |
| 2026-05-11 | Language scaffold preload (#74), Test chat trigger wiring (#81), AlertDialogAction sweep (#102), Mode markdown editor + TOC (#76, #82), Admin password reset (#99), Prompt Overrides Phase 1 (#125), Retrospective audit batch (#112-#120) |
| 2026-05-13 | Node 24 actions bump (#91), Dark mode polish (#133), Chat panes cleanup (#31, #48, #50) |
| 2026-05-20 | New-org CLI (#139), Super-admin role + UI (#138) |
| 2026-05-27 | Cross-org config edits (#166) |
| 2026-05-28 | CM6 editor migration (#167, #77), Export Config (#187), worker #191 language persistence (worker-side) |

## After this merges

- Staging auto-deploys → reads **v1.9.0**
- Prod stays at **v1.5.1** until Elsy comfort-signals → manual workflow dispatch
- Visual lag is now obvious; Elsy can disambiguate environments at a glance

## Follow-up PR (queued for afternoon)

GitHub Action wiring conventional-commit auto-bump on squash-merge to main:
- `feat(...)` → `npm version minor`
- `fix(...)` → `npm version patch`
- `feat!:` → `npm version major`

After that lands, this catch-up never has to happen again. Zero human tax.

## Diff

```
package.json      | 2 +-
package-lock.json | 4 ++--
```

`npm version 1.9.0 --no-git-tag-version` only — no other files touched. No code changes; CI just runs the standard checks.

## Test plan

- [x] Diff scope verified (package.json + lock only)
- [x] `npm version` ran cleanly (no auxiliary generated files in this repo)
- [ ] CI confirmation