### PR TITLE
chore: delete orphan McpServerConfig type

### DIFF
--- a/src/types/mcp-server.ts
+++ b/src/types/mcp-server.ts
@@ -1,9 +1,0 @@
-export interface McpServerConfig {
-  id: string;
-  name: string;
-  url: string;
-  authToken?: string;
-  enabled: boolean;
-  priority: number;
-  allowedTools?: string[];
-}


### PR DESCRIPTION
## Summary

- Deletes `src/types/mcp-server.ts`, an unused interface from the project's initial UI shell scaffolding.

## Evidence

- **Added in:** commit `0a8ce41` ("Add UI shell: VS Code theme, layout, routing, and placeholder pages") — original kickoff scaffolding, never wired up.
- **Zero usage:** `grep -rn "McpServerConfig" .` returns only the defining file.
- **No tracking issue:** no open or closed portal issue describes an MCP-server-config UI feature. (#230 is per-mode resource curation — a different concept that would model resources, not server configs.)
- **Worker copy is independent:** `bt-servant-worker/src/types/mcp.ts:26` defines its own `MCPServerConfig` which is in active use at runtime (`src/durable-objects/user-do.ts:1523` sorts servers by `priority`). Deleting the portal copy does not affect the worker.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (zero warnings)
- [x] `npm run build` — clean
- [ ] Dev deploy succeeds (per-PR worker)