### PR TITLE
feat(perms): add verb-perms schema + lazy migration (#181 PR 1)

### DIFF
--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -16,5 +16,13 @@ export interface AuthUser {
   // the same powers regardless of UI state (worker/admin.ts +
   // worker/config.ts both honor the "super trumps isAdmin" rule).
   isSuperAdmin?: boolean;
+  // Legacy single-bit rights, kept as the lazy-migration source for the
+  // four verb-perms fields below. Pre-#181 sessions only carry this one;
+  // the BFF (`worker/auth.ts`) lazy-maps it into the verb-perms fields on
+  // every request so the client always sees both shapes. See #181.
   language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
 }

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -15,6 +15,10 @@ interface SeedUserInput {
   isAdmin?: boolean;
   isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
 }
 
 async function seedUser(input: SeedUserInput): Promise<StoredUser> {
@@ -30,6 +34,10 @@ async function seedUser(input: SeedUserInput): Promise<StoredUser> {
     isAdmin: input.isAdmin ?? false,
     isSuperAdmin: input.isSuperAdmin ?? false,
     language_rights: input.language_rights,
+    language_edit_rights: input.language_edit_rights,
+    language_publish_rights: input.language_publish_rights,
+    mode_edit_rights: input.mode_edit_rights,
+    mode_publish_rights: input.mode_publish_rights,
   };
   await env.AUTH_KV.put(`user:${input.email}`, JSON.stringify(stored));
   return stored;
@@ -1293,5 +1301,200 @@ describe("admin auth — X-Admin-Secret retains super powers post-#138", () => {
     expect(
       (body as { user: { isSuperAdmin: boolean } }).user.isSuperAdmin
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verb-perms fields (#181 PR 1 — schema + lazy migration)
+// ---------------------------------------------------------------------------
+//
+// Covers the create/update/list surface for the four new fields:
+//   language_edit_rights, language_publish_rights, mode_edit_rights,
+//   mode_publish_rights
+//
+// All four use the existing `LanguageRights = string[] | "*"` shape, share
+// the renamed `parseRights(value, fieldName)` validator, and round-trip
+// through `safeUser`. Lazy-mapping at the read path (validateSession +
+// handleMe) is covered in tests/auth.test.ts.
+
+interface UserWithVerbPerms {
+  language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
+}
+
+describe("verb-perms — create + update round-trip", () => {
+  it("create user with all four verb-perms fields → 201, safeUser returns them verbatim", async () => {
+    const { status, body } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: {
+        email: "verb@acme.com",
+        password: "test-password",
+        name: "Verb",
+        org: "acme",
+        language_edit_rights: ["en", "es"],
+        language_publish_rights: "*",
+        mode_edit_rights: ["bible-study"],
+        mode_publish_rights: ["bible-study", "trainer"],
+      },
+    });
+    expect(status).toBe(201);
+    const user = (body as { user: UserWithVerbPerms }).user;
+    expect(user.language_edit_rights).toEqual(["en", "es"]);
+    expect(user.language_publish_rights).toBe("*");
+    expect(user.mode_edit_rights).toEqual(["bible-study"]);
+    expect(user.mode_publish_rights).toEqual(["bible-study", "trainer"]);
+  });
+
+  it("update user assigns all four verb-perms fields → 200, persists alongside language_rights", async () => {
+    await seedUser({
+      email: "carol@acme.com",
+      name: "Carol",
+      org: "acme",
+      language_rights: ["en"],
+    });
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: "/api/admin/users/carol@acme.com",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: {
+        language_edit_rights: ["en"],
+        language_publish_rights: "*",
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: ["spoken"],
+      },
+    });
+    expect(status).toBe(200);
+    const user = (body as { user: UserWithVerbPerms }).user;
+    expect(user.language_rights).toEqual(["en"]); // legacy field untouched
+    expect(user.language_edit_rights).toEqual(["en"]);
+    expect(user.language_publish_rights).toBe("*");
+    expect(user.mode_edit_rights).toEqual(["spoken"]);
+    expect(user.mode_publish_rights).toEqual(["spoken"]);
+  });
+
+  // Without this, a PUT with only `name` changes could accidentally wipe
+  // verb-perms — exactly the bug pattern the existing language_rights
+  // handler already guards against (see "can assign language_rights" test).
+  it("update user with only `name` in body leaves all verb-perms untouched", async () => {
+    await seedUser({
+      email: "eve@acme.com",
+      name: "Eve",
+      org: "acme",
+      language_rights: ["en"],
+      language_edit_rights: ["en", "ar"],
+      mode_publish_rights: ["trainer"],
+    });
+
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: "/api/admin/users/eve@acme.com",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: { name: "Eve Updated" },
+    });
+    expect(status).toBe(200);
+    const user = (body as { user: { name: string } & UserWithVerbPerms }).user;
+    expect(user.name).toBe("Eve Updated");
+    expect(user.language_edit_rights).toEqual(["en", "ar"]);
+    expect(user.mode_publish_rights).toEqual(["trainer"]);
+  });
+
+  it("listUsers reflects verb-perms fields (undefined on legacy users)", async () => {
+    await seedUser({
+      email: "legacy@acme.com",
+      name: "Legacy",
+      org: "acme",
+      language_rights: ["en"],
+    });
+
+    const { status, body } = await call({
+      method: "GET",
+      pathname: "/api/admin/users",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+    });
+    expect(status).toBe(200);
+    const users = (body as { users: ({ email: string } & UserWithVerbPerms)[] })
+      .users;
+    const legacy = users.find((u) => u.email === "legacy@acme.com");
+    expect(legacy).toBeDefined();
+    // safeUser returns the raw StoredUser fields. Lazy migration applies at
+    // the session-read path, not at user-list — legacy users show
+    // verb-perms as undefined here. The lazy fallback shows up in
+    // handleMe (see tests/auth.test.ts).
+    expect(legacy?.language_rights).toEqual(["en"]);
+    expect(legacy?.language_edit_rights).toBeUndefined();
+    expect(legacy?.language_publish_rights).toBeUndefined();
+    expect(legacy?.mode_edit_rights).toBeUndefined();
+    expect(legacy?.mode_publish_rights).toBeUndefined();
+  });
+});
+
+describe("verb-perms — parseRights validation errors", () => {
+  it.each([
+    ["language_edit_rights", { language_edit_rights: 42 }],
+    ["language_publish_rights", { language_publish_rights: "yes" }],
+    ["mode_edit_rights", { mode_edit_rights: { a: true } }],
+    ["mode_publish_rights", { mode_publish_rights: [""] }],
+  ])(
+    "create user with malformed %s → 400 with the field name in the error",
+    async (fieldName, badField) => {
+      const { status, body } = await call({
+        method: "POST",
+        pathname: "/api/admin/users",
+        headers: { "X-Admin-Secret": ADMIN_SECRET },
+        body: {
+          email: "bad@acme.com",
+          password: "test-password",
+          name: "Bad",
+          org: "acme",
+          ...badField,
+        },
+      });
+      expect(status).toBe(400);
+      expect((body as { error: string }).error).toContain(fieldName);
+    }
+  );
+
+  it.each([
+    ["language_edit_rights", { language_edit_rights: 42 }],
+    ["mode_publish_rights", { mode_publish_rights: "all" }],
+  ])(
+    "update user with malformed %s → 400 with the field name in the error",
+    async (fieldName, badField) => {
+      await seedUser({ email: "dan@acme.com", name: "Dan", org: "acme" });
+
+      const { status, body } = await call({
+        method: "PUT",
+        pathname: "/api/admin/users/dan@acme.com",
+        headers: { "X-Admin-Secret": ADMIN_SECRET },
+        body: badField,
+      });
+      expect(status).toBe(400);
+      expect((body as { error: string }).error).toContain(fieldName);
+    }
+  );
+
+  it("create user with valid array containing non-string entry → 400 with field name", async () => {
+    const { status, body } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: {
+        email: "mixed@acme.com",
+        password: "test-password",
+        name: "Mixed",
+        org: "acme",
+        mode_edit_rights: ["valid", 7],
+      },
+    });
+    expect(status).toBe(400);
+    expect((body as { error: string }).error).toMatch(
+      /mode_edit_rights.*must be strings/
+    );
   });
 });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,189 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { handleMe } from "../worker/auth";
+import { generateSalt, hashPassword } from "../worker/crypto";
+import type { LanguageRights, SessionData, StoredUser } from "../worker/types";
+
+// Covers the lazy-mapping in validateSession (#181 PR 1) by exercising it
+// through handleMe — the simplest endpoint that surfaces session shape to
+// the client. The same fallback runs in handleLogin's session-construction
+// path; admin-auth tests cover the create/update/list surface.
+
+interface SeedUserInput {
+  email: string;
+  name: string;
+  org: string;
+  language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
+}
+
+async function seedUser(input: SeedUserInput): Promise<StoredUser> {
+  const salt = generateSalt();
+  const passwordHash = await hashPassword("test-password", salt);
+  const stored: StoredUser = {
+    id: crypto.randomUUID(),
+    email: input.email,
+    name: input.name,
+    org: input.org,
+    passwordHash,
+    salt,
+    isAdmin: false,
+    isSuperAdmin: false,
+    language_rights: input.language_rights,
+    language_edit_rights: input.language_edit_rights,
+    language_publish_rights: input.language_publish_rights,
+    mode_edit_rights: input.mode_edit_rights,
+    mode_publish_rights: input.mode_publish_rights,
+  };
+  await env.AUTH_KV.put(`user:${input.email}`, JSON.stringify(stored));
+  return stored;
+}
+
+// Seeds a SessionData record with the legacy (pre-#181) shape — only
+// `language_rights`, no verb-perms fields. This mirrors what's actually in
+// KV for sessions issued before #181 ships, and verifies the lazy-mapping
+// runs at re-hydration time rather than depending on the persisted shape.
+async function seedLegacySession(user: StoredUser): Promise<string> {
+  const sessionId = crypto.randomUUID();
+  const session: SessionData = {
+    userId: user.id,
+    email: user.email,
+    name: user.name,
+    org: user.org,
+    isAdmin: user.isAdmin,
+    isSuperAdmin: user.isSuperAdmin,
+    createdAt: new Date().toISOString(),
+    language_rights: user.language_rights,
+  };
+  await env.AUTH_KV.put(`session:${sessionId}`, JSON.stringify(session));
+  return sessionId;
+}
+
+interface MeUserResponse {
+  language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
+}
+
+async function callMe(sessionId: string): Promise<MeUserResponse> {
+  const res = await handleMe(
+    new Request("https://portal.example.test/api/me", {
+      method: "GET",
+      headers: { Cookie: `session=${sessionId}` },
+    }),
+    env
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { user: MeUserResponse };
+  return body.user;
+}
+
+beforeEach(async () => {
+  let cursor: string | undefined;
+  do {
+    const list = await env.AUTH_KV.list({ cursor });
+    for (const key of list.keys) {
+      await env.AUTH_KV.delete(key.name);
+    }
+    cursor = list.list_complete ? undefined : list.cursor;
+  } while (cursor);
+});
+
+describe("validateSession lazy-mapping (#181) — via handleMe", () => {
+  it("legacy user with language_rights: ['en'] → both language verb-perms fields map to ['en']", async () => {
+    const user = await seedUser({
+      email: "legacy@acme.com",
+      name: "Legacy",
+      org: "acme",
+      language_rights: ["en"],
+    });
+    const session = await seedLegacySession(user);
+
+    const me = await callMe(session);
+    expect(me.language_rights).toEqual(["en"]);
+    expect(me.language_edit_rights).toEqual(["en"]);
+    expect(me.language_publish_rights).toEqual(["en"]);
+    // Mode rights have no legacy source — stay undefined.
+    expect(me.mode_edit_rights).toBeUndefined();
+    expect(me.mode_publish_rights).toBeUndefined();
+  });
+
+  it("legacy user with language_rights: '*' → both language verb-perms fields map to '*'", async () => {
+    const user = await seedUser({
+      email: "wildcard@acme.com",
+      name: "Wildcard",
+      org: "acme",
+      language_rights: "*",
+    });
+    const session = await seedLegacySession(user);
+
+    const me = await callMe(session);
+    expect(me.language_rights).toBe("*");
+    expect(me.language_edit_rights).toBe("*");
+    expect(me.language_publish_rights).toBe("*");
+    expect(me.mode_edit_rights).toBeUndefined();
+    expect(me.mode_publish_rights).toBeUndefined();
+  });
+
+  // `undefined` is the pre-permission-system default and means "full access
+  // for back-compat" per worker/types.ts. The lazy fallback must preserve
+  // that — propagating `undefined` to both verb-perms fields so the
+  // existing back-compat behavior is unchanged.
+  it("legacy user with language_rights: undefined → both language verb-perms stay undefined", async () => {
+    const user = await seedUser({
+      email: "pre-perms@acme.com",
+      name: "Pre Perms",
+      org: "acme",
+    });
+    const session = await seedLegacySession(user);
+
+    const me = await callMe(session);
+    expect(me.language_rights).toBeUndefined();
+    expect(me.language_edit_rights).toBeUndefined();
+    expect(me.language_publish_rights).toBeUndefined();
+    expect(me.mode_edit_rights).toBeUndefined();
+    expect(me.mode_publish_rights).toBeUndefined();
+  });
+
+  // Once an admin has set the verb-perms fields explicitly (PR 2 path), the
+  // lazy fallback must not clobber them — explicit value wins over the
+  // legacy source. Catches the bug shape where the `??` was accidentally
+  // reversed.
+  it("user with explicit language_edit_rights → fallback does NOT override the explicit value", async () => {
+    const user = await seedUser({
+      email: "explicit@acme.com",
+      name: "Explicit",
+      org: "acme",
+      language_rights: ["en"], // legacy says "en"
+      language_edit_rights: ["en", "es", "fr"], // but explicit says "en, es, fr"
+    });
+    const session = await seedLegacySession(user);
+
+    const me = await callMe(session);
+    expect(me.language_edit_rights).toEqual(["en", "es", "fr"]);
+    // Publish has no explicit value — still falls back to legacy.
+    expect(me.language_publish_rights).toEqual(["en"]);
+  });
+
+  it("user with explicit mode_edit_rights → passes through verbatim (no legacy source to interfere)", async () => {
+    const user = await seedUser({
+      email: "mode-perms@acme.com",
+      name: "Mode Perms",
+      org: "acme",
+      language_rights: ["en"],
+      mode_edit_rights: ["bible-study", "trainer"],
+      mode_publish_rights: "*",
+    });
+    const session = await seedLegacySession(user);
+
+    const me = await callMe(session);
+    expect(me.mode_edit_rights).toEqual(["bible-study", "trainer"]);
+    expect(me.mode_publish_rights).toBe("*");
+  });
+});

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -4,11 +4,15 @@ import type { Env } from "./helpers";
 import { errorResponse, jsonResponse } from "./helpers";
 import type { LanguageRights, StoredUser } from "./types";
 
-// Accepts `"*"` or an array of non-empty trimmed strings. Returns null if
-// the input is unset (caller should treat as "leave existing value alone")
-// or a validation error message if the shape is invalid.
-function parseLanguageRights(
-  value: unknown
+// Accepts `"*"` or an array of non-empty trimmed strings. Returns `undefined`
+// when the input is unset so the caller can treat that as "leave existing
+// value alone". Shared by `language_rights` (legacy) and the four verb-perms
+// fields added in #181 — they all use the same `LanguageRights` shape.
+// `fieldName` is interpolated into error messages so a bad `mode_edit_rights`
+// payload doesn't surface as a misleading "language_rights" error.
+function parseRights(
+  value: unknown,
+  fieldName: string
 ):
   | { ok: true; value: LanguageRights | undefined }
   | { ok: false; error: string } {
@@ -20,14 +24,14 @@ function parseLanguageRights(
       if (typeof entry !== "string") {
         return {
           ok: false,
-          error: "language_rights array entries must be strings",
+          error: `${fieldName} array entries must be strings`,
         };
       }
       const trimmed = entry.trim();
       if (!trimmed) {
         return {
           ok: false,
-          error: "language_rights array entries must be non-empty",
+          error: `${fieldName} array entries must be non-empty`,
         };
       }
       cleaned.push(trimmed);
@@ -36,9 +40,22 @@ function parseLanguageRights(
   }
   return {
     ok: false,
-    error: 'language_rights must be "*" or an array of strings',
+    error: `${fieldName} must be "*" or an array of strings`,
   };
 }
+
+// The four verb-perms fields share `parseRights`'s shape. Listing them as
+// `[bodyKey, storedKey]` so the create/update handlers can loop instead of
+// repeating five near-identical parse blocks. `language_rights` (legacy)
+// stays out of this table; it's parsed inline because its lazy-migration
+// role is different.
+const VERB_PERMS_FIELDS = [
+  "language_edit_rights",
+  "language_publish_rights",
+  "mode_edit_rights",
+  "mode_publish_rights",
+] as const;
+type VerbPermsField = (typeof VERB_PERMS_FIELDS)[number];
 
 // ---------------------------------------------------------------------------
 // Auth — tri-mode
@@ -162,6 +179,10 @@ function safeUser(user: StoredUser) {
     isAdmin: user.isAdmin ?? false,
     isSuperAdmin: user.isSuperAdmin ?? false,
     language_rights: user.language_rights,
+    language_edit_rights: user.language_edit_rights,
+    language_publish_rights: user.language_publish_rights,
+    mode_edit_rights: user.mode_edit_rights,
+    mode_publish_rights: user.mode_publish_rights,
   };
 }
 
@@ -186,6 +207,10 @@ async function createUser(
     isAdmin?: boolean;
     isSuperAdmin?: boolean;
     language_rights?: unknown;
+    language_edit_rights?: unknown;
+    language_publish_rights?: unknown;
+    mode_edit_rights?: unknown;
+    mode_publish_rights?: unknown;
   };
   try {
     body = (await request.json()) as typeof body;
@@ -222,9 +247,19 @@ async function createUser(
     return errorResponse(passwordError, 400);
   }
 
-  const rightsResult = parseLanguageRights(body.language_rights);
+  const rightsResult = parseRights(body.language_rights, "language_rights");
   if (!rightsResult.ok) {
     return errorResponse(rightsResult.error, 400);
+  }
+
+  const verbPerms: Partial<Record<VerbPermsField, LanguageRights | undefined>> =
+    {};
+  for (const field of VERB_PERMS_FIELDS) {
+    const result = parseRights(body[field], field);
+    if (!result.ok) {
+      return errorResponse(result.error, 400);
+    }
+    verbPerms[field] = result.value;
   }
 
   const existing = await env.AUTH_KV.get(`user:${email}`);
@@ -244,6 +279,10 @@ async function createUser(
     isAdmin: body.isAdmin ?? false,
     isSuperAdmin: body.isSuperAdmin ?? false,
     language_rights: rightsResult.value,
+    language_edit_rights: verbPerms.language_edit_rights,
+    language_publish_rights: verbPerms.language_publish_rights,
+    mode_edit_rights: verbPerms.mode_edit_rights,
+    mode_publish_rights: verbPerms.mode_publish_rights,
   };
 
   await env.AUTH_KV.put(`user:${email}`, JSON.stringify(user));
@@ -313,6 +352,10 @@ async function updateUser(
     isAdmin?: boolean;
     isSuperAdmin?: boolean;
     language_rights?: unknown;
+    language_edit_rights?: unknown;
+    language_publish_rights?: unknown;
+    mode_edit_rights?: unknown;
+    mode_publish_rights?: unknown;
   };
   try {
     body = (await request.json()) as typeof body;
@@ -393,11 +436,19 @@ async function updateUser(
     user.passwordHash = await hashPassword(body.password as string, user.salt);
   }
   if (body.language_rights !== undefined) {
-    const rightsResult = parseLanguageRights(body.language_rights);
+    const rightsResult = parseRights(body.language_rights, "language_rights");
     if (!rightsResult.ok) {
       return errorResponse(rightsResult.error, 400);
     }
     user.language_rights = rightsResult.value;
+  }
+  for (const field of VERB_PERMS_FIELDS) {
+    if (body[field] === undefined) continue;
+    const result = parseRights(body[field], field);
+    if (!result.ok) {
+      return errorResponse(result.error, 400);
+    }
+    user[field] = result.value;
   }
 
   await env.AUTH_KV.put(`user:${email}`, JSON.stringify(user));

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -123,6 +123,12 @@ export async function validateSession(
     return null;
   }
 
+  // Lazy-migrate the legacy single-bit `language_rights` into the two
+  // verb-perms fields when the stored record predates #181. Identity copy
+  // — same shape (`string[] | "*"`) — so old rights become both edit and
+  // publish access until an admin edits the user explicitly. Mode rights
+  // have no legacy source; absent ⇒ undefined ⇒ treated as full access
+  // until PR 2 enforces per-mode gating.
   return {
     userId: data.userId,
     createdAt: data.createdAt,
@@ -132,6 +138,11 @@ export async function validateSession(
     isAdmin: user.isAdmin ?? false,
     isSuperAdmin: user.isSuperAdmin ?? false,
     language_rights: user.language_rights,
+    language_edit_rights: user.language_edit_rights ?? user.language_rights,
+    language_publish_rights:
+      user.language_publish_rights ?? user.language_rights,
+    mode_edit_rights: user.mode_edit_rights,
+    mode_publish_rights: user.mode_publish_rights,
   };
 }
 
@@ -179,6 +190,10 @@ export async function handleLogin(
   }
 
   const sessionId = crypto.randomUUID();
+  // Same lazy-migration semantics as validateSession — pre-#181 users only
+  // have `language_rights` set; new verb-perms fields fall back to it so
+  // the session created here is shaped identically to one re-hydrated on a
+  // later request.
   const sessionData: SessionData = {
     userId: user.id,
     email: user.email,
@@ -188,6 +203,11 @@ export async function handleLogin(
     isSuperAdmin: user.isSuperAdmin ?? false,
     createdAt: new Date().toISOString(),
     language_rights: user.language_rights,
+    language_edit_rights: user.language_edit_rights ?? user.language_rights,
+    language_publish_rights:
+      user.language_publish_rights ?? user.language_rights,
+    mode_edit_rights: user.mode_edit_rights,
+    mode_publish_rights: user.mode_publish_rights,
   };
 
   await env.AUTH_KV.put(`session:${sessionId}`, JSON.stringify(sessionData), {
@@ -203,6 +223,10 @@ export async function handleLogin(
       isAdmin: user.isAdmin ?? false,
       isSuperAdmin: user.isSuperAdmin ?? false,
       language_rights: sessionData.language_rights,
+      language_edit_rights: sessionData.language_edit_rights,
+      language_publish_rights: sessionData.language_publish_rights,
+      mode_edit_rights: sessionData.mode_edit_rights,
+      mode_publish_rights: sessionData.mode_publish_rights,
     },
   });
   response.headers.set("Set-Cookie", sessionCookie(sessionId, request.url));
@@ -246,6 +270,10 @@ export async function handleMe(request: Request, env: Env): Promise<Response> {
       isAdmin: session.isAdmin ?? false,
       isSuperAdmin: session.isSuperAdmin ?? false,
       language_rights: session.language_rights,
+      language_edit_rights: session.language_edit_rights,
+      language_publish_rights: session.language_publish_rights,
+      mode_edit_rights: session.mode_edit_rights,
+      mode_publish_rights: session.mode_publish_rights,
     },
   });
 }

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -23,7 +23,20 @@ export interface StoredUser {
   // via the X-Admin-Secret CLI (PUT /api/admin/users/<email>); revocation
   // is via the same path or via another super-admin from the UI.
   isSuperAdmin?: boolean;
+  // Legacy single-bit rights, kept as the lazy-migration source for the
+  // four verb-perms fields below. Pre-#181 records only set this one; new
+  // writes since #181 set the verb-perms fields directly. validateSession
+  // falls back to `language_rights` when a verb-perms field is absent so
+  // existing users keep their access without a one-shot migration script.
   language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  // Mode rights have no legacy fallback — pre-#181 there was no per-mode
+  // permission concept at all (all admins could edit/publish any mode).
+  // Treated as full access when absent for back-compat with that prior
+  // behavior; enforcement lands in PR 2.
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
 }
 
 export interface SessionData {
@@ -38,4 +51,8 @@ export interface SessionData {
   isSuperAdmin?: boolean;
   createdAt: string;
   language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
 }


### PR DESCRIPTION
## Summary

**PR 1 of 2 for #181** — pure type expansion + lazy migration. No enforcement change at any gate; existing `language_rights` continues to gate `worker/config.ts:171`. PR 2 will split that gate into edit/publish, add the parallel mode gate, and surface the new fields in the AdminUserEditDialog matrix UI.

Implements the design locked in [this comment](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/181#issuecomment-4791780928).

## What's in

- **`worker/types.ts`**: adds four new optional fields to `StoredUser` and `SessionData`:
  - `language_edit_rights`
  - `language_publish_rights`
  - `mode_edit_rights`
  - `mode_publish_rights`

  All reuse the existing `LanguageRights = string[] | "*"` shape — identity-copy lazy migration, not a shape conversion.

- **`worker/auth.ts`**:
  - `validateSession` lazy-maps `language_*_rights ?? language_rights` per request (the existing rehydration pattern at line 118–135).
  - `handleLogin` constructs the same shape at initial session creation.
  - Both `/api/auth/login` and `/api/me` response shapes include the four new fields so the client can read them.

- **`worker/admin.ts`**:
  - `parseLanguageRights` → `parseRights(value, fieldName)` so a bad `mode_edit_rights` payload doesn't surface as a misleading `language_rights` error. Same validation logic.
  - `safeUser` returns the four new fields.
  - `POST /api/admin/users` (create) accepts + validates them.
  - `PUT /api/admin/users/{email}` (update) accepts + validates them with the existing "undefined ⇒ leave alone" semantic.

- **`src/types/auth.ts`**: mirrors the four new optional fields on `AuthUser` so the client side has the types ready when PR 2 wires UI.

## Lazy migration semantics

| Stored field absent | Resolved to |
|---|---|
| `language_edit_rights` | falls back to `language_rights` (legacy users keep edit access) |
| `language_publish_rights` | falls back to `language_rights` (legacy users keep publish access) |
| `mode_edit_rights` | stays `undefined` (no legacy source — no per-mode permission existed pre-#181) |
| `mode_publish_rights` | stays `undefined` (same reason) |

No write-on-read — the fallback applies on every request. Persisted shape catches up only when an admin edits the user explicitly via PR 2's UI.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (zero warnings)
- [x] `npm run build` clean
- [ ] Dev deploy succeeds (per-PR worker)
- [ ] Smoke: existing user with `language_rights: ["en"]` — `GET /api/me` returns both `language_edit_rights` and `language_publish_rights` as `["en"]` on next request
- [ ] Smoke: existing user with `language_rights: "*"` — `GET /api/me` returns `"*"` on all `*_rights` fields
- [ ] Smoke: existing user with `language_rights: undefined` — `GET /api/me` returns all four `*_rights` as `undefined`
- [ ] Smoke: admin `PUT /api/admin/users/{email}` with `mode_edit_rights: ["bible-study"]` persists and round-trips
- [ ] Smoke: admin `PUT` with malformed `language_publish_rights: 42` returns 400 with the correct field name in the error

## Out of scope (deferred to PR 2)

- Splitting `worker/config.ts:171` `hasLanguageRights` into edit/publish gates
- Adding the parallel `mode_*_rights` gate to `/api/config/modes/{name}` PUT/DELETE
- `RightsSelector` matrix component + AdminUserEditDialog / AdminUserCreateDialog wiring
- Tests covering edit-without-publish, publish-without-edit, legacy-grandfather, admin/super trump rules