### PR TITLE
feat(perms): enforce verb-perms gate + 4-selector dialog (#181 PR 2)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,7 @@ import { useSessionGuard } from "@/hooks/use-session-guard";
 import { AppShell } from "@/components/app-shell";
 import { RequireAdmin } from "@/components/require-admin";
 import { RequireAuth } from "@/components/require-auth";
+import { RequireModeAccess } from "@/components/require-mode-access";
 import { AdminUsersPage } from "@/app/pages/admin-users";
 import { BaruchPage } from "@/app/pages/baruch";
 import { LanguagesPage } from "@/app/pages/languages";
@@ -50,9 +51,9 @@ const router = createBrowserRouter([
           {
             path: "modes",
             element: (
-              <RequireAdmin>
+              <RequireModeAccess>
                 <ModesPage />
-              </RequireAdmin>
+              </RequireModeAccess>
             ),
           },
           {

--- a/src/app/pages/admin-users.tsx
+++ b/src/app/pages/admin-users.tsx
@@ -11,6 +11,12 @@ import {
 } from "@/lib/admin-users-api";
 import type { LanguageRights } from "@/types/auth";
 import { useAuthStore } from "@/lib/auth-store";
+import {
+  effectiveLanguageEditRights,
+  effectiveLanguagePublishRights,
+  effectiveModeEditRights,
+  effectiveModePublishRights,
+} from "@/lib/permissions";
 import { useAdminUsers, useDeleteAdminUser } from "@/hooks/use-admin-users";
 import {
   AlertDialog,
@@ -352,18 +358,23 @@ function UserRow({
 // Verb-perms summary cell — shows effective access on both axes
 // (language + mode) and both verbs. For each verb the badge collapses
 // to one of: All / None / N items / Default (full, legacy back-compat).
-// Mirrors the lazy-fallback chain the worker applies: explicit verb-
-// perm → legacy `language_rights` for languages → undefined for modes.
+// Mirrors the worker's partner-aware lazy-fallback chain (Frank rd-2
+// P1): explicit verb-perm → `[]` when partner is explicit but this
+// verb isn't → legacy `language_rights` for languages with both unset
+// → undefined for modes with both unset.
 function AccessSummary({ user }: { user: AdminUser }) {
-  const langEdit = user.language_edit_rights ?? user.language_rights;
-  const langPublish = user.language_publish_rights ?? user.language_rights;
-  const modeEdit = user.mode_edit_rights;
-  const modePublish = user.mode_publish_rights;
-
   return (
     <div className="space-y-1.5 text-xs">
-      <AccessRow label="Lang" edit={langEdit} publish={langPublish} />
-      <AccessRow label="Mode" edit={modeEdit} publish={modePublish} />
+      <AccessRow
+        label="Lang"
+        edit={effectiveLanguageEditRights(user)}
+        publish={effectiveLanguagePublishRights(user)}
+      />
+      <AccessRow
+        label="Mode"
+        edit={effectiveModeEditRights(user)}
+        publish={effectiveModePublishRights(user)}
+      />
     </div>
   );
 }

--- a/src/app/pages/admin-users.tsx
+++ b/src/app/pages/admin-users.tsx
@@ -12,6 +12,7 @@ import {
 import { useAuthStore } from "@/lib/auth-store";
 import { useAdminUsers, useDeleteAdminUser } from "@/hooks/use-admin-users";
 import { useLanguages } from "@/hooks/use-languages";
+import { useModes } from "@/hooks/use-prompt-config";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -41,6 +42,7 @@ export function AdminUsersPage() {
 
   const usersQuery = useAdminUsers();
   const languagesQuery = useLanguages();
+  const modesQuery = useModes();
   const deleteUser = useDeleteAdminUser();
 
   const [editingEmail, setEditingEmail] = useState<string | null>(null);
@@ -209,6 +211,7 @@ export function AdminUsersPage() {
         callerOrg={callerOrg}
         callerIsSuperAdmin={callerIsSuperAdmin}
         availableLanguages={languagesQuery.data?.languages}
+        availableModes={modesQuery.data?.modes}
       />
 
       <AdminUserEditDialog
@@ -220,6 +223,7 @@ export function AdminUsersPage() {
         callerEmail={callerEmail}
         callerIsSuperAdmin={callerIsSuperAdmin}
         availableLanguages={languagesQuery.data?.languages}
+        availableModes={modesQuery.data?.modes}
       />
 
       <AlertDialog

--- a/src/app/pages/admin-users.tsx
+++ b/src/app/pages/admin-users.tsx
@@ -9,10 +9,9 @@ import {
   AdminUsersRequestError,
   ORG_FILTER_ALL_SENTINEL,
 } from "@/lib/admin-users-api";
+import type { LanguageRights } from "@/types/auth";
 import { useAuthStore } from "@/lib/auth-store";
 import { useAdminUsers, useDeleteAdminUser } from "@/hooks/use-admin-users";
-import { useLanguages } from "@/hooks/use-languages";
-import { useModes } from "@/hooks/use-prompt-config";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -41,8 +40,6 @@ export function AdminUsersPage() {
   const callerIsSuperAdmin = useAuthStore((s) => s.user?.isSuperAdmin ?? false);
 
   const usersQuery = useAdminUsers();
-  const languagesQuery = useLanguages();
-  const modesQuery = useModes();
   const deleteUser = useDeleteAdminUser();
 
   const [editingEmail, setEditingEmail] = useState<string | null>(null);
@@ -180,9 +177,7 @@ export function AdminUsersPage() {
                   <th className="px-6 py-3 text-left font-medium">Org</th>
                 )}
                 <th className="px-6 py-3 text-left font-medium">Role</th>
-                <th className="px-6 py-3 text-left font-medium">
-                  Language access
-                </th>
+                <th className="px-6 py-3 text-left font-medium">Access</th>
                 <th className="px-6 py-3 text-right font-medium">Actions</th>
               </tr>
             </thead>
@@ -210,8 +205,6 @@ export function AdminUsersPage() {
         onOpenChange={setCreateOpen}
         callerOrg={callerOrg}
         callerIsSuperAdmin={callerIsSuperAdmin}
-        availableLanguages={languagesQuery.data?.languages}
-        availableModes={modesQuery.data?.modes}
       />
 
       <AdminUserEditDialog
@@ -222,8 +215,6 @@ export function AdminUsersPage() {
         }}
         callerEmail={callerEmail}
         callerIsSuperAdmin={callerIsSuperAdmin}
-        availableLanguages={languagesQuery.data?.languages}
-        availableModes={modesQuery.data?.modes}
       />
 
       <AlertDialog
@@ -334,7 +325,7 @@ function UserRow({
         </div>
       </td>
       <td className="px-6 py-3">
-        <LanguageRightsBadge value={user.language_rights} />
+        <AccessSummary user={user} />
       </td>
       <td className="px-6 py-3 text-right">
         <div className="flex justify-end gap-1">
@@ -358,38 +349,81 @@ function UserRow({
   );
 }
 
-function LanguageRightsBadge({
+// Verb-perms summary cell — shows effective access on both axes
+// (language + mode) and both verbs. For each verb the badge collapses
+// to one of: All / None / N items / Default (full, legacy back-compat).
+// Mirrors the lazy-fallback chain the worker applies: explicit verb-
+// perm → legacy `language_rights` for languages → undefined for modes.
+function AccessSummary({ user }: { user: AdminUser }) {
+  const langEdit = user.language_edit_rights ?? user.language_rights;
+  const langPublish = user.language_publish_rights ?? user.language_rights;
+  const modeEdit = user.mode_edit_rights;
+  const modePublish = user.mode_publish_rights;
+
+  return (
+    <div className="space-y-1.5 text-xs">
+      <AccessRow label="Lang" edit={langEdit} publish={langPublish} />
+      <AccessRow label="Mode" edit={modeEdit} publish={modePublish} />
+    </div>
+  );
+}
+
+function AccessRow({
+  label,
+  edit,
+  publish,
+}: {
+  label: string;
+  edit: LanguageRights | undefined;
+  publish: LanguageRights | undefined;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground w-10 font-medium tracking-wide uppercase">
+        {label}
+      </span>
+      <VerbBadge verb="E" value={edit} />
+      <VerbBadge verb="P" value={publish} />
+    </div>
+  );
+}
+
+function VerbBadge({
+  verb,
   value,
 }: {
-  value: AdminUser["language_rights"];
+  verb: "E" | "P";
+  value: LanguageRights | undefined;
 }) {
   if (value === undefined) {
     return (
-      <span className="text-muted-foreground text-xs">Default (full)</span>
+      <span className="text-muted-foreground font-mono text-[10px]">
+        {verb}:default
+      </span>
     );
   }
   if (value === "*") {
-    return <Badge>All languages</Badge>;
+    return (
+      <Badge className="px-1.5 py-0 font-mono text-[10px]">{verb}:all</Badge>
+    );
   }
   if (value.length === 0) {
     return (
-      <Badge variant="outline" className="border-destructive text-destructive">
-        None
+      <Badge
+        variant="outline"
+        className="border-destructive text-destructive px-1.5 py-0 font-mono text-[10px]"
+      >
+        {verb}:none
       </Badge>
     );
   }
   return (
-    <div className="flex flex-wrap gap-1">
-      {value.slice(0, 4).map((name) => (
-        <Badge key={name} variant="outline" className="font-mono text-xs">
-          {name}
-        </Badge>
-      ))}
-      {value.length > 4 && (
-        <Badge variant="outline" className="text-xs">
-          +{value.length - 4}
-        </Badge>
-      )}
-    </div>
+    <Badge
+      variant="outline"
+      className="px-1.5 py-0 font-mono text-[10px]"
+      title={value.join(", ")}
+    >
+      {verb}:{value.length}
+    </Badge>
   );
 }

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -8,9 +8,9 @@ import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
-  filterAuthorizedLanguages,
-  hasAnyLanguageRights,
-  hasLanguageRights,
+  filterByAnyRights,
+  hasAnyLanguageAccess,
+  hasRights,
 } from "@/lib/permissions";
 import { useUiStore } from "@/lib/ui-store";
 import { useDebounced } from "@/hooks/use-debounced";
@@ -46,7 +46,7 @@ const AUTO_SAVE_DEBOUNCE_MS = 800;
 
 export function LanguagesPage() {
   const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
-  const languageRights = useAuthStore((s) => s.user?.language_rights);
+  const user = useAuthStore((s) => s.user);
   const selectedLanguage = useUiStore((s) => s.selectedLanguage);
   const setSelectedLanguage = useUiStore((s) => s.setSelectedLanguage);
   const showDrafts = useUiStore((s) => s.showDrafts);
@@ -55,14 +55,22 @@ export function LanguagesPage() {
   const setContextOrg = useUiStore((s) => s.setContextOrg);
 
   // Cross-org reuses the worker's PR A carve-out: super-admins bypass
-  // `hasLanguageRights` when editing a different org's languages, because
-  // shepherd rights are scoped to the user's home org and don't translate
-  // to a foreign namespace. Treat the effective rights as full-access in
-  // that case so the same filter/gate logic continues to work without a
-  // separate cross-org code path.
+  // per-row rights when editing a different org's languages, because
+  // shepherd rights are scoped to the user's home org and don't
+  // translate to a foreign namespace. Treat both verb rights as "*" in
+  // that case so the same filter/gate logic works without a separate
+  // cross-org branch.
+  //
+  // #181: each verb-perm falls back to legacy `language_rights` for pre-
+  // PR-1 users, mirroring the worker's rightsFor language logic.
   const isCrossOrg = contextOrg !== null;
-  const effectiveRights = isCrossOrg ? "*" : languageRights;
-  const hasAccess = hasAnyLanguageRights(effectiveRights);
+  const editRights = isCrossOrg
+    ? "*"
+    : (user?.language_edit_rights ?? user?.language_rights);
+  const publishRights = isCrossOrg
+    ? "*"
+    : (user?.language_publish_rights ?? user?.language_rights);
+  const hasAccess = isCrossOrg || hasAnyLanguageAccess(user);
 
   // Queries / mutations
   const languagesQuery = useLanguages(contextOrg);
@@ -71,19 +79,23 @@ export function LanguagesPage() {
   const deleteLanguage = useDeleteLanguage(contextOrg);
   const scaffoldQuery = useLanguageScaffold(contextOrg);
 
-  // Filter the language list to only those the user has rights to. Engine
-  // #207 will eventually filter server-side too, but until then this is the
-  // primary gate against showing forbidden entries in the dropdown.
+  // Filter the language list to those the user has any verb on. Union
+  // semantic: an edit-only or publish-only grant still surfaces the
+  // language (the worker further gates the specific action). Engine
+  // #207 will eventually filter server-side too, but until then this
+  // is the primary gate against showing forbidden entries in the
+  // dropdown.
   const authorizedLanguagesData = useMemo(() => {
     if (!languagesQuery.data) return languagesQuery.data;
     return {
       ...languagesQuery.data,
-      languages: filterAuthorizedLanguages(
+      languages: filterByAnyRights(
         languagesQuery.data.languages,
-        effectiveRights
+        editRights,
+        publishRights
       ),
     };
-  }, [languagesQuery.data, effectiveRights]);
+  }, [languagesQuery.data, editRights, publishRights]);
 
   // Local document draft (auto-save target).
   //
@@ -273,13 +285,25 @@ export function LanguagesPage() {
   // Skip the gate under cross-org context: `setContextOrg` already cleared
   // `selectedLanguage` to null when the user switched orgs, and any new
   // selection in cross-org mode is gated server-side via the worker's
-  // super-admin carve-out (PR A) rather than by `language_rights`.
+  // super-admin carve-out (PR A) rather than by per-row rights. Union
+  // semantic: at least one of edit / publish on the row is enough to
+  // keep the selection — the worker further gates the specific verb.
   useEffect(() => {
     if (selectedLanguage === null) return;
     if (isCrossOrg) return;
-    if (hasLanguageRights(languageRights, selectedLanguage)) return;
+    if (
+      hasRights(editRights, selectedLanguage) ||
+      hasRights(publishRights, selectedLanguage)
+    )
+      return;
     setSelectedLanguage(null);
-  }, [isCrossOrg, languageRights, selectedLanguage, setSelectedLanguage]);
+  }, [
+    isCrossOrg,
+    editRights,
+    publishRights,
+    selectedLanguage,
+    setSelectedLanguage,
+  ]);
 
   const confirmSwitch = useCallback(() => {
     setSelectedLanguage(pendingSwitch);

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -10,6 +10,7 @@ import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
   filterByAnyRights,
   hasAnyLanguageAccess,
+  hasAnyRights,
   hasRights,
 } from "@/lib/permissions";
 import { useUiStore } from "@/lib/ui-store";
@@ -45,7 +46,6 @@ import { PageHeader } from "@/components/page-header";
 const AUTO_SAVE_DEBOUNCE_MS = 800;
 
 export function LanguagesPage() {
-  const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
   const user = useAuthStore((s) => s.user);
   const selectedLanguage = useUiStore((s) => s.selectedLanguage);
   const setSelectedLanguage = useUiStore((s) => s.setSelectedLanguage);
@@ -71,6 +71,19 @@ export function LanguagesPage() {
     ? "*"
     : (user?.language_publish_rights ?? user?.language_rights);
   const hasAccess = isCrossOrg || hasAnyLanguageAccess(user);
+
+  // Per-row capability gates passed to LanguageSelector. Languages
+  // don't carry an admin trump (PR #185 enforced per-row even for
+  // super-admins), so these are pure verb-perm reads. The Frank P1
+  // review flagged the prior `isAdmin`-only gating as making non-admin
+  // publish/delete shepherds unreachable.
+  const canCreate = hasAnyRights(editRights);
+  const canPublishSelected =
+    selectedLanguage !== null && hasRights(publishRights, selectedLanguage);
+  const canDeleteSelected =
+    selectedLanguage !== null &&
+    hasRights(editRights, selectedLanguage) &&
+    hasRights(publishRights, selectedLanguage);
 
   // Queries / mutations
   const languagesQuery = useLanguages(contextOrg);
@@ -433,7 +446,9 @@ export function LanguagesPage() {
               isSettingPublished={saveLanguage.isPending}
               showDrafts={showDrafts}
               onToggleShowDrafts={setShowDrafts}
-              isAdmin={isAdmin}
+              canCreate={canCreate}
+              canPublishSelected={canPublishSelected}
+              canDeleteSelected={canDeleteSelected}
               isScaffoldReady={scaffoldQuery.isSuccess}
               scaffoldError={scaffoldQuery.isError}
             />
@@ -508,7 +523,7 @@ export function LanguagesPage() {
           </div>
         ) : !hasSelection ? (
           <EmptyState
-            isAdmin={isAdmin}
+            canCreate={canCreate}
             hasAny={(authorizedLanguagesData?.languages.length ?? 0) > 0}
           />
         ) : (
@@ -622,17 +637,17 @@ export function LanguagesPage() {
 }
 
 interface EmptyStateProps {
-  isAdmin: boolean;
+  canCreate: boolean;
   hasAny: boolean;
 }
 
-function EmptyState({ isAdmin, hasAny }: EmptyStateProps) {
+function EmptyState({ canCreate, hasAny }: EmptyStateProps) {
   return (
     <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
       <p className="text-sm">
         {hasAny
           ? "Pick a language above to start editing."
-          : isAdmin
+          : canCreate
             ? "No languages yet. Create one to get started."
             : "No languages are available for your account."}
       </p>

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -8,6 +8,8 @@ import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
+  effectiveLanguageEditRights,
+  effectiveLanguagePublishRights,
   filterByAnyRights,
   hasAnyLanguageAccess,
   hasAnyRights,
@@ -64,26 +66,24 @@ export function LanguagesPage() {
   // #181: each verb-perm falls back to legacy `language_rights` for pre-
   // PR-1 users, mirroring the worker's rightsFor language logic.
   const isCrossOrg = contextOrg !== null;
-  const editRights = isCrossOrg
-    ? "*"
-    : (user?.language_edit_rights ?? user?.language_rights);
-  const publishRights = isCrossOrg
-    ? "*"
-    : (user?.language_publish_rights ?? user?.language_rights);
+  // Worker-effective verb-perms — applies the partner-aware rule so a
+  // user with `language_rights:"*"` plus only an explicit edit grant
+  // sees publish=[] in the UI (matching what the worker sees), not
+  // publish="*" via the naive `?? language_rights` fallback (Frank
+  // rd-2 P1).
+  const editRights = isCrossOrg ? "*" : effectiveLanguageEditRights(user);
+  const publishRights = isCrossOrg ? "*" : effectiveLanguagePublishRights(user);
   const hasAccess = isCrossOrg || hasAnyLanguageAccess(user);
 
   // Per-row capability gates passed to LanguageSelector. Languages
   // don't carry an admin trump (PR #185 enforced per-row even for
-  // super-admins), so these are pure verb-perm reads. The Frank P1
-  // review flagged the prior `isAdmin`-only gating as making non-admin
-  // publish/delete shepherds unreachable.
+  // super-admins), so these are pure verb-perm reads.
   const canCreate = hasAnyRights(editRights);
+  const canEditSelected =
+    selectedLanguage !== null && hasRights(editRights, selectedLanguage);
   const canPublishSelected =
     selectedLanguage !== null && hasRights(publishRights, selectedLanguage);
-  const canDeleteSelected =
-    selectedLanguage !== null &&
-    hasRights(editRights, selectedLanguage) &&
-    hasRights(publishRights, selectedLanguage);
+  const canDeleteSelected = canEditSelected && canPublishSelected;
 
   // Queries / mutations
   const languagesQuery = useLanguages(contextOrg);
@@ -225,6 +225,12 @@ export function LanguagesPage() {
     if (saveLanguage.isPending) return;
     if (debouncedDraft === lastSyncedDoc) return;
     if (debouncedDraft === lastFailedDoc) return;
+    // Frank rd-2 P2: skip autosave when the user has no edit rights on
+    // the selected row. Without this gate, a publish-only shepherd's
+    // accidental keystroke triggers an autosave that 403s — the
+    // editor below is also rendered readOnly so this branch only
+    // fires if the gate state changed mid-edit.
+    if (!canEditSelected) return;
     performSave(debouncedDraft);
   }, [
     debouncedDraft,
@@ -233,12 +239,14 @@ export function LanguagesPage() {
     lastFailedDoc,
     performSave,
     selectedLanguage,
+    canEditSelected,
   ]);
 
   const flushSave = useCallback(() => {
     if (!isDirty || isSaving) return;
+    if (!canEditSelected) return;
     performSave(draft);
-  }, [draft, isDirty, isSaving, performSave]);
+  }, [canEditSelected, draft, isDirty, isSaving, performSave]);
 
   // Block route changes while there are pending edits or an in-flight save.
   // The blocker fires only when navigating to a different pathname (selecting
@@ -465,7 +473,12 @@ export function LanguagesPage() {
               <Button
                 size="sm"
                 onClick={flushSave}
-                disabled={!isDirty || isSaving}
+                disabled={!isDirty || isSaving || !canEditSelected}
+                title={
+                  canEditSelected
+                    ? undefined
+                    : "You don't have edit rights on this language."
+                }
               >
                 <Save className="mr-1.5 size-3.5" />
                 Save
@@ -540,6 +553,7 @@ export function LanguagesPage() {
                 onChange={setDraft}
                 onHeadingsChange={setHeadings}
                 onActiveLineChange={setActiveLine}
+                readOnly={!canEditSelected}
               />
             </div>
           </>

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/lib/mode-export";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
 import {
+  effectiveModeEditRights,
+  effectiveModePublishRights,
   filterByAnyRights,
   hasAdminPowers,
   hasAnyRights,
@@ -63,11 +65,15 @@ export function ModesPage() {
   // bypasses per-mode gate for admins) and a cross-org bypass (super-
   // admin viewing another org sees everything; their home-org mode
   // rights don't translate). Both bypasses surface as "*" so the same
-  // filter/gate logic works without separate code paths.
+  // filter/gate logic works without separate code paths. For non-
+  // admin same-org users the effective helpers apply the worker's
+  // partner-aware rule (one explicit verb makes the unset partner
+  // [], not legacy back-compat — Frank rd-2 P1).
   const isCrossOrg = contextOrg !== null;
-  const modeEditRights = isAdmin || isCrossOrg ? "*" : user?.mode_edit_rights;
+  const modeEditRights =
+    isAdmin || isCrossOrg ? "*" : effectiveModeEditRights(user);
   const modePublishRights =
-    isAdmin || isCrossOrg ? "*" : user?.mode_publish_rights;
+    isAdmin || isCrossOrg ? "*" : effectiveModePublishRights(user);
 
   const modesQuery = useModes(contextOrg);
   const modeQuery = useMode(selectedMode, contextOrg);
@@ -90,14 +96,14 @@ export function ModesPage() {
     };
   }, [modesQuery.data, modeEditRights, modePublishRights]);
 
-  // Per-row capability gates passed to ModeSelector.
+  // Per-row capability gates passed to ModeSelector + used for
+  // editor/save gating.
   const canCreate = hasAnyRights(modeEditRights);
+  const canEditSelected =
+    selectedMode !== null && hasRights(modeEditRights, selectedMode);
   const canPublishSelected =
     selectedMode !== null && hasRights(modePublishRights, selectedMode);
-  const canDeleteSelected =
-    selectedMode !== null &&
-    hasRights(modeEditRights, selectedMode) &&
-    hasRights(modePublishRights, selectedMode);
+  const canDeleteSelected = canEditSelected && canPublishSelected;
 
   // Local document draft (auto-save target).
   //
@@ -185,6 +191,10 @@ export function ModesPage() {
     if (saveMode.isPending) return;
     if (debouncedDraft === lastSyncedDoc) return;
     if (debouncedDraft === lastFailedDoc) return;
+    // Frank rd-2 P2: skip autosave when the user has no edit rights on
+    // the selected mode. The editor below is also rendered readOnly,
+    // so this branch only fires if the gate state changed mid-edit.
+    if (!canEditSelected) return;
     performSave(debouncedDraft);
   }, [
     debouncedDraft,
@@ -193,12 +203,14 @@ export function ModesPage() {
     lastFailedDoc,
     performSave,
     selectedMode,
+    canEditSelected,
   ]);
 
   const flushSave = useCallback(() => {
     if (!isDirty || isSaving) return;
+    if (!canEditSelected) return;
     performSave(draft);
-  }, [draft, isDirty, isSaving, performSave]);
+  }, [canEditSelected, draft, isDirty, isSaving, performSave]);
 
   // Export captures what's currently on screen — draft (including unsaved
   // edits) + last-synced metadata. The export's `org` is the effective
@@ -439,7 +451,12 @@ export function ModesPage() {
               <Button
                 size="sm"
                 onClick={flushSave}
-                disabled={!isDirty || isSaving}
+                disabled={!isDirty || isSaving || !canEditSelected}
+                title={
+                  canEditSelected
+                    ? undefined
+                    : "You don't have edit rights on this mode."
+                }
               >
                 <Save className="mr-1.5 size-3.5" />
                 Save
@@ -496,6 +513,7 @@ export function ModesPage() {
                 onChange={setDraft}
                 onHeadingsChange={setHeadings}
                 onActiveLineChange={setActiveLine}
+                readOnly={!canEditSelected}
               />
             </div>
           </>

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -11,6 +11,12 @@ import {
   buildModeExportFilename,
 } from "@/lib/mode-export";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
+import {
+  filterByAnyRights,
+  hasAdminPowers,
+  hasAnyRights,
+  hasRights,
+} from "@/lib/permissions";
 import { useUiStore } from "@/lib/ui-store";
 import { OrgContextSelector } from "@/components/org-context-selector";
 import { useDebounced } from "@/hooks/use-debounced";
@@ -43,7 +49,8 @@ import { PageHeader } from "@/components/page-header";
 const AUTO_SAVE_DEBOUNCE_MS = 800;
 
 export function ModesPage() {
-  const isAdmin = useAuthStore((s) => s.user?.isAdmin ?? false);
+  const user = useAuthStore((s) => s.user);
+  const isAdmin = hasAdminPowers(user);
   const homeOrg = useAuthStore((s) => s.user?.org);
   const selectedMode = useUiStore((s) => s.selectedMode);
   const setSelectedMode = useUiStore((s) => s.setSelectedMode);
@@ -52,10 +59,45 @@ export function ModesPage() {
   const contextOrg = useUiStore((s) => s.contextOrg);
   const setContextOrg = useUiStore((s) => s.setContextOrg);
 
+  // Effective mode verb-perms. Modes carry an admin trump (worker
+  // bypasses per-mode gate for admins) and a cross-org bypass (super-
+  // admin viewing another org sees everything; their home-org mode
+  // rights don't translate). Both bypasses surface as "*" so the same
+  // filter/gate logic works without separate code paths.
+  const isCrossOrg = contextOrg !== null;
+  const modeEditRights = isAdmin || isCrossOrg ? "*" : user?.mode_edit_rights;
+  const modePublishRights =
+    isAdmin || isCrossOrg ? "*" : user?.mode_publish_rights;
+
   const modesQuery = useModes(contextOrg);
   const modeQuery = useMode(selectedMode, contextOrg);
   const saveMode = useSaveMode(contextOrg);
   const deleteMode = useDeleteMode(contextOrg);
+
+  // Filter modes to those the user has any verb on (admin/cross-org
+  // sees everything via the `*` short-circuit above). Mirrors
+  // languages.tsx — without this, the dropdown lists modes the user
+  // can't act on and the editor 403s on autosave (Frank P2).
+  const authorizedModesData = useMemo(() => {
+    if (!modesQuery.data) return modesQuery.data;
+    return {
+      ...modesQuery.data,
+      modes: filterByAnyRights(
+        modesQuery.data.modes,
+        modeEditRights,
+        modePublishRights
+      ),
+    };
+  }, [modesQuery.data, modeEditRights, modePublishRights]);
+
+  // Per-row capability gates passed to ModeSelector.
+  const canCreate = hasAnyRights(modeEditRights);
+  const canPublishSelected =
+    selectedMode !== null && hasRights(modePublishRights, selectedMode);
+  const canDeleteSelected =
+    selectedMode !== null &&
+    hasRights(modeEditRights, selectedMode) &&
+    hasRights(modePublishRights, selectedMode);
 
   // Local document draft (auto-save target).
   //
@@ -264,6 +306,23 @@ export function ModesPage() {
     setSelectedMode(null);
   }, [selectedMode, modesQuery.data, setSelectedMode]);
 
+  // #181 Frank P2: drop the selection if the user has no verb-perm on
+  // the row. Without this gate, a non-admin shepherd with
+  // `mode_edit_rights: ["spoken"]` could carry a persisted selection
+  // of "written" across a refresh and see the editor render — only to
+  // have autosave 403. Union semantic: at least one verb on the row
+  // is enough to render (the worker further gates the specific
+  // action). Skip under admin/cross-org (the `*` short-circuit above).
+  useEffect(() => {
+    if (selectedMode === null) return;
+    if (
+      hasRights(modeEditRights, selectedMode) ||
+      hasRights(modePublishRights, selectedMode)
+    )
+      return;
+    setSelectedMode(null);
+  }, [selectedMode, modeEditRights, modePublishRights, setSelectedMode]);
+
   const handleCreateMode = useCallback(
     (name: string, label: string, description: string) => {
       saveMode.mutate(
@@ -342,7 +401,7 @@ export function ModesPage() {
           <OrgContextSelector onRequestChange={handleRequestContextChange} />
           <div className="min-w-0 flex-1">
             <ModeSelector
-              modesData={modesQuery.data}
+              modesData={authorizedModesData}
               selectedMode={selectedMode}
               onSelectMode={handleSelectMode}
               onCreateMode={handleCreateMode}
@@ -353,7 +412,9 @@ export function ModesPage() {
               isSettingPublished={saveMode.isPending}
               showDrafts={showDrafts}
               onToggleShowDrafts={setShowDrafts}
-              isAdmin={isAdmin}
+              canCreate={canCreate}
+              canPublishSelected={canPublishSelected}
+              canDeleteSelected={canDeleteSelected}
             />
           </div>
 

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -11,7 +11,11 @@ import { faUsers as faUsersSolid } from "@fortawesome/pro-solid-svg-icons";
 import { useNavigate } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
-import { hasAdminPowers, hasAnyLanguageRights } from "@/lib/permissions";
+import {
+  hasAdminPowers,
+  hasAnyLanguageAccess,
+  hasAnyModeAccess,
+} from "@/lib/permissions";
 import { useUiStore } from "@/lib/ui-store";
 import { Separator } from "@/components/ui/separator";
 import { ActivityBarItem } from "@/components/activity-bar-item";
@@ -23,11 +27,19 @@ export function ActivityBar() {
   const setActiveSection = useUiStore((s) => s.setActiveSection);
   const testChatOpen = useUiStore((s) => s.testChatOpen);
   const toggleTestChat = useUiStore((s) => s.toggleTestChat);
-  const languageRights = useAuthStore((s) => s.user?.language_rights);
+  const user = useAuthStore((s) => s.user);
   // Uses hasAdminPowers so super admins (even without isAdmin) see the
-  // Modes + Users entries. Mirrors worker's "super trumps" rule.
-  const isAdmin = useAuthStore((s) => hasAdminPowers(s.user));
-  const canAccessLanguages = hasAnyLanguageRights(languageRights);
+  // Users entry. Mirrors worker's "super trumps" rule.
+  const isAdmin = hasAdminPowers(user);
+  // #181 — sidebar gates now consult the verb-perms union helpers so
+  // users granted via the new dialog (no legacy `language_rights`)
+  // correctly see their entry points. `hasAnyLanguageAccess` retains
+  // the legacy `undefined → full access` rule for pre-#181 users;
+  // `hasAnyModeAccess` does NOT (modes had no per-row pre-#181 so
+  // undefined-undefined means "no access" for non-admins), which is
+  // why the Modes entry combines it with the admin trump.
+  const canAccessLanguages = hasAnyLanguageAccess(user);
+  const canEditModes = isAdmin || hasAnyModeAccess(user);
 
   return (
     <div className="bg-card relative z-10 flex h-full w-12 flex-col items-center py-3 shadow-[2px_0_12px_rgba(0,0,0,0.2)] dark:shadow-[2px_0_12px_rgba(0,0,0,0.35)]">
@@ -42,7 +54,7 @@ export function ActivityBar() {
             void navigate("/");
           }}
         />
-        {isAdmin && (
+        {canEditModes && (
           <ActivityBarItem
             icon={faPenToSquareLight}
             activeIcon={faPenToSquareSolid}

--- a/src/components/admin-user-create-dialog.tsx
+++ b/src/components/admin-user-create-dialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import type { Language } from "@/types/language";
 import type { LanguageRights } from "@/types/auth";
+import type { PromptMode } from "@/types/prompt-override";
 import {
   AdminUsersForbiddenError,
   AdminUsersRequestError,
@@ -19,7 +20,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { LanguageRightsSelector } from "@/components/language-rights-selector";
+import { RightsSelector } from "@/components/rights-selector";
 
 interface CreateUserDialogProps {
   open: boolean;
@@ -34,8 +35,13 @@ interface CreateUserDialogProps {
   // When false, the dialog matches the original org-admin shape exactly.
   callerIsSuperAdmin: boolean;
   availableLanguages: Language[] | undefined;
+  availableModes: PromptMode[] | undefined;
   onCreated?: (email: string) => void;
 }
+
+// New users default to no access on every axis — matches the pre-PR-1
+// "[]" default for `language_rights`. Admin must explicitly grant.
+const EMPTY_RIGHTS: LanguageRights = [];
 
 export function AdminUserCreateDialog({
   open,
@@ -43,6 +49,7 @@ export function AdminUserCreateDialog({
   callerOrg,
   callerIsSuperAdmin,
   availableLanguages,
+  availableModes,
   onCreated,
 }: CreateUserDialogProps) {
   const createUser = useCreateAdminUser();
@@ -53,7 +60,10 @@ export function AdminUserCreateDialog({
   const [org, setOrg] = useState(callerOrg);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isSuperAdmin, setIsSuperAdmin] = useState(false);
-  const [rights, setRights] = useState<LanguageRights>([]);
+  const [langEdit, setLangEdit] = useState<LanguageRights>(EMPTY_RIGHTS);
+  const [langPublish, setLangPublish] = useState<LanguageRights>(EMPTY_RIGHTS);
+  const [modeEdit, setModeEdit] = useState<LanguageRights>(EMPTY_RIGHTS);
+  const [modePublish, setModePublish] = useState<LanguageRights>(EMPTY_RIGHTS);
   const [errorText, setErrorText] = useState<string | null>(null);
 
   // Re-sync the Org default if callerOrg changes while the dialog is
@@ -70,7 +80,10 @@ export function AdminUserCreateDialog({
     setOrg(callerOrg);
     setIsAdmin(false);
     setIsSuperAdmin(false);
-    setRights([]);
+    setLangEdit(EMPTY_RIGHTS);
+    setLangPublish(EMPTY_RIGHTS);
+    setModeEdit(EMPTY_RIGHTS);
+    setModePublish(EMPTY_RIGHTS);
     setErrorText(null);
     createUser.reset();
   };
@@ -121,7 +134,14 @@ export function AdminUserCreateDialog({
         // get a 403 from the worker (it rejects any non-undefined
         // isSuperAdmin from org-scoped admins).
         ...(callerIsSuperAdmin && isSuperAdmin ? { isSuperAdmin: true } : {}),
-        language_rights: rights,
+        // Send all four verb-perms explicitly. Omitting any field on a
+        // brand-new user would leave the worker fallback computing
+        // `undefined ?? undefined === undefined === full access` — silently
+        // widening the user's verb scope past what the admin intended.
+        language_edit_rights: langEdit,
+        language_publish_rights: langPublish,
+        mode_edit_rights: modeEdit,
+        mode_publish_rights: modePublish,
       },
       {
         onSuccess: (user) => {
@@ -264,10 +284,33 @@ export function AdminUserCreateDialog({
               </label>
             )}
 
-            <LanguageRightsSelector
-              value={rights}
-              onChange={setRights}
-              availableLanguages={availableLanguages}
+            <RightsSelector
+              kind="language"
+              verb="edit"
+              value={langEdit}
+              onChange={setLangEdit}
+              availableItems={availableLanguages}
+            />
+            <RightsSelector
+              kind="language"
+              verb="publish"
+              value={langPublish}
+              onChange={setLangPublish}
+              availableItems={availableLanguages}
+            />
+            <RightsSelector
+              kind="mode"
+              verb="edit"
+              value={modeEdit}
+              onChange={setModeEdit}
+              availableItems={availableModes}
+            />
+            <RightsSelector
+              kind="mode"
+              verb="publish"
+              value={modePublish}
+              onChange={setModePublish}
+              availableItems={availableModes}
             />
 
             {errorText && (

--- a/src/components/admin-user-create-dialog.tsx
+++ b/src/components/admin-user-create-dialog.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 
-import type { Language } from "@/types/language";
 import type { LanguageRights } from "@/types/auth";
-import type { PromptMode } from "@/types/prompt-override";
 import {
   AdminUsersForbiddenError,
   AdminUsersRequestError,
   isReservedOrgSlug,
 } from "@/lib/admin-users-api";
 import { useCreateAdminUser } from "@/hooks/use-admin-users";
+import { useLanguages } from "@/hooks/use-languages";
+import { useModes } from "@/hooks/use-prompt-config";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -34,8 +34,6 @@ interface CreateUserDialogProps {
   // When true, render the editable Org field and the Super-admin checkbox.
   // When false, the dialog matches the original org-admin shape exactly.
   callerIsSuperAdmin: boolean;
-  availableLanguages: Language[] | undefined;
-  availableModes: PromptMode[] | undefined;
   onCreated?: (email: string) => void;
 }
 
@@ -48,8 +46,6 @@ export function AdminUserCreateDialog({
   onOpenChange,
   callerOrg,
   callerIsSuperAdmin,
-  availableLanguages,
-  availableModes,
   onCreated,
 }: CreateUserDialogProps) {
   const createUser = useCreateAdminUser();
@@ -65,6 +61,15 @@ export function AdminUserCreateDialog({
   const [modeEdit, setModeEdit] = useState<LanguageRights>(EMPTY_RIGHTS);
   const [modePublish, setModePublish] = useState<LanguageRights>(EMPTY_RIGHTS);
   const [errorText, setErrorText] = useState<string | null>(null);
+
+  // Item lists scoped to the TARGET org. For super-admins typing a
+  // new org slug, the lists refetch as `org` changes so verb-perms
+  // are granted against names that actually exist in the destination
+  // (#181 review F8). React Query caches by query key, so re-typing
+  // the same slug is free.
+  const orgForFetch = (callerIsSuperAdmin ? org : callerOrg).trim() || null;
+  const languagesQuery = useLanguages(orgForFetch);
+  const modesQuery = useModes(orgForFetch);
 
   // Re-sync the Org default if callerOrg changes while the dialog is
   // mounted (rare — only on auth changes). Without this, a stale org
@@ -227,7 +232,8 @@ export function AdminUserCreateDialog({
                 />
                 <p className="text-muted-foreground text-xs">
                   Free-text slug. Type the name of an existing org to add the
-                  user there, or a new slug to create a fresh org.
+                  user there, or a new slug to create a fresh org. The
+                  mode/language lists below refresh as you type.
                 </p>
               </div>
             )}
@@ -289,28 +295,28 @@ export function AdminUserCreateDialog({
               verb="edit"
               value={langEdit}
               onChange={setLangEdit}
-              availableItems={availableLanguages}
+              availableItems={languagesQuery.data?.languages}
             />
             <RightsSelector
               kind="language"
               verb="publish"
               value={langPublish}
               onChange={setLangPublish}
-              availableItems={availableLanguages}
+              availableItems={languagesQuery.data?.languages}
             />
             <RightsSelector
               kind="mode"
               verb="edit"
               value={modeEdit}
               onChange={setModeEdit}
-              availableItems={availableModes}
+              availableItems={modesQuery.data?.modes}
             />
             <RightsSelector
               kind="mode"
               verb="publish"
               value={modePublish}
               onChange={setModePublish}
-              availableItems={availableModes}
+              availableItems={modesQuery.data?.modes}
             />
 
             {errorText && (

--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -10,6 +10,12 @@ import {
 import { useUpdateAdminUser } from "@/hooks/use-admin-users";
 import { useLanguages } from "@/hooks/use-languages";
 import { useModes } from "@/hooks/use-prompt-config";
+import {
+  effectiveLanguageEditRights,
+  effectiveLanguagePublishRights,
+  effectiveModeEditRights,
+  effectiveModePublishRights,
+} from "@/lib/permissions";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -37,17 +43,6 @@ interface EditUserDialogProps {
   // Super-admin checkbox. When false, the dialog matches the original
   // org-admin shape exactly.
   callerIsSuperAdmin: boolean;
-}
-
-// Pre-PR-1 users have only the legacy `language_rights` bit; the worker
-// lazy-migrates it into both verb-perms fields on every request. The
-// dialog mirrors that fallback so the selector populates with the user's
-// effective rights rather than starting blank.
-function effectiveLangRights(
-  user: AdminUser,
-  fallback: LanguageRights | undefined
-) {
-  return fallback ?? user.language_rights;
 }
 
 // Comparable normal form for LanguageRights — undefined → null, arrays
@@ -114,10 +109,14 @@ export function AdminUserEditDialog({
     setOrg(user.org);
     setIsAdmin(user.isAdmin);
     setIsSuperAdmin(user.isSuperAdmin ?? false);
-    setLangEdit(effectiveLangRights(user, user.language_edit_rights));
-    setLangPublish(effectiveLangRights(user, user.language_publish_rights));
-    setModeEdit(user.mode_edit_rights);
-    setModePublish(user.mode_publish_rights);
+    // Populate from the worker-effective rights — applies the
+    // partner-aware rule (one explicit verb makes the unset partner
+    // []) so the dialog shows what the worker actually sees, not the
+    // raw stored value (Frank rd-2 P1).
+    setLangEdit(effectiveLanguageEditRights(user));
+    setLangPublish(effectiveLanguagePublishRights(user));
+    setModeEdit(effectiveModeEditRights(user));
+    setModePublish(effectiveModePublishRights(user));
     setPassword("");
     setErrorText(null);
     updateUser.reset();
@@ -159,22 +158,15 @@ export function AdminUserEditDialog({
     }
 
     // Send BOTH verb-perms when either changed (#181 review F2). The
-    // worker's partner-aware deny rule (rightsFor) treats an unset
-    // verb-perm as `[]` whenever the partner verb is explicit, so a
-    // partial save would silently strip access on the verb the admin
-    // didn't touch. Persisting both with their dialog state — even
-    // unchanged — preserves admin intent exactly. Both fields must be
-    // defined; the dialog state is always defined post-mount via the
-    // effectiveLangRights fallback for languages and the legacy
-    // suppression for modes.
-    const initialLangEdit = effectiveLangRights(
-      user,
-      user.language_edit_rights
-    );
-    const initialLangPublish = effectiveLangRights(
-      user,
-      user.language_publish_rights
-    );
+    // worker's partner-aware deny rule treats an unset verb-perm as
+    // `[]` whenever the partner is explicit, so a partial save would
+    // silently strip access on the verb the admin didn't touch.
+    // Persisting both with their effective initial state preserves
+    // admin intent exactly. Initial values come from the worker-
+    // effective helpers (Frank rd-2 P1) so the diff is against what
+    // the worker ACTUALLY sees, not the raw stored shape.
+    const initialLangEdit = effectiveLanguageEditRights(user);
+    const initialLangPublish = effectiveLanguagePublishRights(user);
     const langEditChanged = diffRights(initialLangEdit, langEdit);
     const langPublishChanged = diffRights(initialLangPublish, langPublish);
     if (langEditChanged || langPublishChanged) {
@@ -182,11 +174,10 @@ export function AdminUserEditDialog({
       if (langPublish !== undefined) body.language_publish_rights = langPublish;
     }
 
-    const modeEditChanged = diffRights(user.mode_edit_rights, modeEdit);
-    const modePublishChanged = diffRights(
-      user.mode_publish_rights,
-      modePublish
-    );
+    const initialModeEdit = effectiveModeEditRights(user);
+    const initialModePublish = effectiveModePublishRights(user);
+    const modeEditChanged = diffRights(initialModeEdit, modeEdit);
+    const modePublishChanged = diffRights(initialModePublish, modePublish);
     if (modeEditChanged || modePublishChanged) {
       if (modeEdit !== undefined) body.mode_edit_rights = modeEdit;
       if (modePublish !== undefined) body.mode_publish_rights = modePublish;

--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import type { AdminUser, UpdateUserBody } from "@/types/admin-users";
 import type { LanguageRights } from "@/types/auth";
 import type { Language } from "@/types/language";
+import type { PromptMode } from "@/types/prompt-override";
 import {
   AdminUsersForbiddenError,
   AdminUsersRequestError,
@@ -20,7 +21,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { LanguageRightsSelector } from "@/components/language-rights-selector";
+import { RightsSelector } from "@/components/rights-selector";
 
 interface EditUserDialogProps {
   user: AdminUser | null;
@@ -37,6 +38,28 @@ interface EditUserDialogProps {
   // org-admin shape exactly.
   callerIsSuperAdmin: boolean;
   availableLanguages: Language[] | undefined;
+  availableModes: PromptMode[] | undefined;
+}
+
+// Pre-PR-1 users have only the legacy `language_rights` bit; the worker
+// lazy-migrates it into both verb-perms fields on every request. The
+// dialog mirrors that fallback so the selector populates with the user's
+// effective rights rather than starting blank.
+function effectiveLangRights(
+  user: AdminUser,
+  fallback: LanguageRights | undefined
+) {
+  return fallback ?? user.language_rights;
+}
+
+// Send a verb-perms field only when the admin actually changed it. JSON
+// round-trip handles the `string[] | "*"` discriminated union without a
+// per-shape comparator.
+function diffRights(
+  current: LanguageRights | undefined,
+  next: LanguageRights | undefined
+): boolean {
+  return JSON.stringify(current ?? null) !== JSON.stringify(next ?? null);
 }
 
 export function AdminUserEditDialog({
@@ -46,6 +69,7 @@ export function AdminUserEditDialog({
   callerEmail,
   callerIsSuperAdmin,
   availableLanguages,
+  availableModes,
 }: EditUserDialogProps) {
   const updateUser = useUpdateAdminUser();
 
@@ -53,7 +77,18 @@ export function AdminUserEditDialog({
   const [org, setOrg] = useState("");
   const [isAdmin, setIsAdmin] = useState(false);
   const [isSuperAdmin, setIsSuperAdmin] = useState(false);
-  const [rights, setRights] = useState<LanguageRights | undefined>(undefined);
+  const [langEdit, setLangEdit] = useState<LanguageRights | undefined>(
+    undefined
+  );
+  const [langPublish, setLangPublish] = useState<LanguageRights | undefined>(
+    undefined
+  );
+  const [modeEdit, setModeEdit] = useState<LanguageRights | undefined>(
+    undefined
+  );
+  const [modePublish, setModePublish] = useState<LanguageRights | undefined>(
+    undefined
+  );
   const [password, setPassword] = useState("");
   const [errorText, setErrorText] = useState<string | null>(null);
 
@@ -65,7 +100,10 @@ export function AdminUserEditDialog({
     setOrg(user.org);
     setIsAdmin(user.isAdmin);
     setIsSuperAdmin(user.isSuperAdmin ?? false);
-    setRights(user.language_rights);
+    setLangEdit(effectiveLangRights(user, user.language_edit_rights));
+    setLangPublish(effectiveLangRights(user, user.language_publish_rights));
+    setModeEdit(user.mode_edit_rights);
+    setModePublish(user.mode_publish_rights);
     setPassword("");
     setErrorText(null);
     updateUser.reset();
@@ -105,13 +143,38 @@ export function AdminUserEditDialog({
     if (callerIsSuperAdmin && isSuperAdmin !== (user.isSuperAdmin ?? false)) {
       body.isSuperAdmin = isSuperAdmin;
     }
-    // Send language_rights when the value differs. Comparing arrays needs
-    // a deep compare; we serialize.
-    const currentSerialized = JSON.stringify(user.language_rights ?? null);
-    const nextSerialized = JSON.stringify(rights ?? null);
-    if (currentSerialized !== nextSerialized && rights !== undefined) {
-      body.language_rights = rights;
+
+    // Send each verb-perm field only when changed AND the new value is
+    // defined. Sending undefined would not flip the persisted state since
+    // worker-side parsing ignores undefined keys; but skipping the send
+    // entirely keeps PUT bodies minimal and the diff readable in logs.
+    const initialLangEdit = effectiveLangRights(
+      user,
+      user.language_edit_rights
+    );
+    const initialLangPublish = effectiveLangRights(
+      user,
+      user.language_publish_rights
+    );
+    if (diffRights(initialLangEdit, langEdit) && langEdit !== undefined) {
+      body.language_edit_rights = langEdit;
     }
+    if (
+      diffRights(initialLangPublish, langPublish) &&
+      langPublish !== undefined
+    ) {
+      body.language_publish_rights = langPublish;
+    }
+    if (diffRights(user.mode_edit_rights, modeEdit) && modeEdit !== undefined) {
+      body.mode_edit_rights = modeEdit;
+    }
+    if (
+      diffRights(user.mode_publish_rights, modePublish) &&
+      modePublish !== undefined
+    ) {
+      body.mode_publish_rights = modePublish;
+    }
+
     // Password is opt-in: only include when the admin actually typed
     // something. Empty = leave the existing hash alone. Mirror the
     // server's 8-char floor (worker rejects shorter with 400).
@@ -150,6 +213,17 @@ export function AdminUserEditDialog({
   };
 
   if (!user) return null;
+
+  // Legacy hint only fires for users who have no rights of any kind set —
+  // not for users whose verb-perm is being populated from the legacy
+  // `language_rights` fallback (which is the populated, intended value).
+  const showLegacyLang =
+    user.language_edit_rights === undefined &&
+    user.language_publish_rights === undefined &&
+    user.language_rights === undefined;
+  const showLegacyMode =
+    user.mode_edit_rights === undefined &&
+    user.mode_publish_rights === undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -242,11 +316,37 @@ export function AdminUserEditDialog({
               </label>
             )}
 
-            <LanguageRightsSelector
-              value={rights}
-              onChange={setRights}
-              availableLanguages={availableLanguages}
-              showLegacyHint
+            <RightsSelector
+              kind="language"
+              verb="edit"
+              value={langEdit}
+              onChange={setLangEdit}
+              availableItems={availableLanguages}
+              showLegacyHint={showLegacyLang}
+            />
+            <RightsSelector
+              kind="language"
+              verb="publish"
+              value={langPublish}
+              onChange={setLangPublish}
+              availableItems={availableLanguages}
+              showLegacyHint={showLegacyLang}
+            />
+            <RightsSelector
+              kind="mode"
+              verb="edit"
+              value={modeEdit}
+              onChange={setModeEdit}
+              availableItems={availableModes}
+              showLegacyHint={showLegacyMode}
+            />
+            <RightsSelector
+              kind="mode"
+              verb="publish"
+              value={modePublish}
+              onChange={setModePublish}
+              availableItems={availableModes}
+              showLegacyHint={showLegacyMode}
             />
 
             <div className="space-y-2">

--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from "react";
 
 import type { AdminUser, UpdateUserBody } from "@/types/admin-users";
 import type { LanguageRights } from "@/types/auth";
-import type { Language } from "@/types/language";
-import type { PromptMode } from "@/types/prompt-override";
 import {
   AdminUsersForbiddenError,
   AdminUsersRequestError,
   isReservedOrgSlug,
 } from "@/lib/admin-users-api";
 import { useUpdateAdminUser } from "@/hooks/use-admin-users";
+import { useLanguages } from "@/hooks/use-languages";
+import { useModes } from "@/hooks/use-prompt-config";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -37,8 +37,6 @@ interface EditUserDialogProps {
   // Super-admin checkbox. When false, the dialog matches the original
   // org-admin shape exactly.
   callerIsSuperAdmin: boolean;
-  availableLanguages: Language[] | undefined;
-  availableModes: PromptMode[] | undefined;
 }
 
 // Pre-PR-1 users have only the legacy `language_rights` bit; the worker
@@ -52,14 +50,22 @@ function effectiveLangRights(
   return fallback ?? user.language_rights;
 }
 
-// Send a verb-perms field only when the admin actually changed it. JSON
-// round-trip handles the `string[] | "*"` discriminated union without a
-// per-shape comparator.
+// Comparable normal form for LanguageRights — undefined → null, arrays
+// sorted so server-stored unsorted ["spanish","english"] doesn't diff
+// against selector-sorted ["english","spanish"] and trigger a spurious
+// PUT on a no-op click. JSON.stringify of the normalized form is the
+// equality test the dialog uses to decide what to send.
+function normRights(value: LanguageRights | undefined): string {
+  if (value === undefined) return "null";
+  if (value === "*") return '"*"';
+  return JSON.stringify([...value].sort());
+}
+
 function diffRights(
   current: LanguageRights | undefined,
   next: LanguageRights | undefined
 ): boolean {
-  return JSON.stringify(current ?? null) !== JSON.stringify(next ?? null);
+  return normRights(current) !== normRights(next);
 }
 
 export function AdminUserEditDialog({
@@ -68,8 +74,6 @@ export function AdminUserEditDialog({
   onOpenChange,
   callerEmail,
   callerIsSuperAdmin,
-  availableLanguages,
-  availableModes,
 }: EditUserDialogProps) {
   const updateUser = useUpdateAdminUser();
 
@@ -91,6 +95,16 @@ export function AdminUserEditDialog({
   );
   const [password, setPassword] = useState("");
   const [errorText, setErrorText] = useState<string | null>(null);
+
+  // Item lists are scoped to the TARGET user's org, not the caller's
+  // home org. For super-admins moving a user to a different org (#181
+  // review F8), this means the selector lists the destination org's
+  // modes/languages — granting names that exist in the target namespace.
+  // For org admins the user.org always equals callerOrg, so this is
+  // identical to the pre-fix behavior.
+  const orgForFetch = user?.org ?? null;
+  const languagesQuery = useLanguages(orgForFetch);
+  const modesQuery = useModes(orgForFetch);
 
   // Re-sync form state from the user prop whenever the target changes
   // (or the dialog reopens with a different user).
@@ -144,10 +158,15 @@ export function AdminUserEditDialog({
       body.isSuperAdmin = isSuperAdmin;
     }
 
-    // Send each verb-perm field only when changed AND the new value is
-    // defined. Sending undefined would not flip the persisted state since
-    // worker-side parsing ignores undefined keys; but skipping the send
-    // entirely keeps PUT bodies minimal and the diff readable in logs.
+    // Send BOTH verb-perms when either changed (#181 review F2). The
+    // worker's partner-aware deny rule (rightsFor) treats an unset
+    // verb-perm as `[]` whenever the partner verb is explicit, so a
+    // partial save would silently strip access on the verb the admin
+    // didn't touch. Persisting both with their dialog state — even
+    // unchanged — preserves admin intent exactly. Both fields must be
+    // defined; the dialog state is always defined post-mount via the
+    // effectiveLangRights fallback for languages and the legacy
+    // suppression for modes.
     const initialLangEdit = effectiveLangRights(
       user,
       user.language_edit_rights
@@ -156,23 +175,21 @@ export function AdminUserEditDialog({
       user,
       user.language_publish_rights
     );
-    if (diffRights(initialLangEdit, langEdit) && langEdit !== undefined) {
-      body.language_edit_rights = langEdit;
+    const langEditChanged = diffRights(initialLangEdit, langEdit);
+    const langPublishChanged = diffRights(initialLangPublish, langPublish);
+    if (langEditChanged || langPublishChanged) {
+      if (langEdit !== undefined) body.language_edit_rights = langEdit;
+      if (langPublish !== undefined) body.language_publish_rights = langPublish;
     }
-    if (
-      diffRights(initialLangPublish, langPublish) &&
-      langPublish !== undefined
-    ) {
-      body.language_publish_rights = langPublish;
-    }
-    if (diffRights(user.mode_edit_rights, modeEdit) && modeEdit !== undefined) {
-      body.mode_edit_rights = modeEdit;
-    }
-    if (
-      diffRights(user.mode_publish_rights, modePublish) &&
-      modePublish !== undefined
-    ) {
-      body.mode_publish_rights = modePublish;
+
+    const modeEditChanged = diffRights(user.mode_edit_rights, modeEdit);
+    const modePublishChanged = diffRights(
+      user.mode_publish_rights,
+      modePublish
+    );
+    if (modeEditChanged || modePublishChanged) {
+      if (modeEdit !== undefined) body.mode_edit_rights = modeEdit;
+      if (modePublish !== undefined) body.mode_publish_rights = modePublish;
     }
 
     // Password is opt-in: only include when the admin actually typed
@@ -214,16 +231,15 @@ export function AdminUserEditDialog({
 
   if (!user) return null;
 
-  // Legacy hint only fires for users who have no rights of any kind set —
-  // not for users whose verb-perm is being populated from the legacy
-  // `language_rights` fallback (which is the populated, intended value).
+  // Legacy hint only fires for users who have no language rights of
+  // any kind set. Modes deliberately skip the hint: pre-#181 non-
+  // admins had no per-mode access (the gate was admin-only), so
+  // "currently full access by default" copy would describe a
+  // privilege that never existed.
   const showLegacyLang =
     user.language_edit_rights === undefined &&
     user.language_publish_rights === undefined &&
     user.language_rights === undefined;
-  const showLegacyMode =
-    user.mode_edit_rights === undefined &&
-    user.mode_publish_rights === undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -321,7 +337,7 @@ export function AdminUserEditDialog({
               verb="edit"
               value={langEdit}
               onChange={setLangEdit}
-              availableItems={availableLanguages}
+              availableItems={languagesQuery.data?.languages}
               showLegacyHint={showLegacyLang}
             />
             <RightsSelector
@@ -329,7 +345,7 @@ export function AdminUserEditDialog({
               verb="publish"
               value={langPublish}
               onChange={setLangPublish}
-              availableItems={availableLanguages}
+              availableItems={languagesQuery.data?.languages}
               showLegacyHint={showLegacyLang}
             />
             <RightsSelector
@@ -337,16 +353,14 @@ export function AdminUserEditDialog({
               verb="edit"
               value={modeEdit}
               onChange={setModeEdit}
-              availableItems={availableModes}
-              showLegacyHint={showLegacyMode}
+              availableItems={modesQuery.data?.modes}
             />
             <RightsSelector
               kind="mode"
               verb="publish"
               value={modePublish}
               onChange={setModePublish}
-              availableItems={availableModes}
-              showLegacyHint={showLegacyMode}
+              availableItems={modesQuery.data?.modes}
             />
 
             <div className="space-y-2">

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -42,7 +42,18 @@ interface LanguageSelectorProps {
   isSettingPublished: boolean;
   showDrafts: boolean;
   onToggleShowDrafts: (showDrafts: boolean) => void;
-  isAdmin: boolean;
+  // #181 verb-perms capabilities, replacing the old `isAdmin` flag.
+  // Languages do NOT carry an admin trump (PR #185 enforced per-row
+  // even for super-admins), so these are pure verb-perm reads computed
+  // by the parent against the user's effective edit/publish rights:
+  //
+  //   canCreate         = user has some edit rights on this org
+  //   canPublishSelected = hasRights(publishRights, selectedLanguage)
+  //   canDeleteSelected  = canPublishSelected && canEditSelected
+  //                       (worker DELETE rule)
+  canCreate: boolean;
+  canPublishSelected: boolean;
+  canDeleteSelected: boolean;
   /** Scaffold template must finish loading before create can fire — new
       languages are pre-populated with the org's scaffold (#74), so creating
       before the scaffold arrives would silently save a blank document. */
@@ -66,7 +77,9 @@ export function LanguageSelector({
   isSettingPublished,
   showDrafts,
   onToggleShowDrafts,
-  isAdmin,
+  canCreate,
+  canPublishSelected,
+  canDeleteSelected,
   isScaffoldReady,
   scaffoldError,
 }: LanguageSelectorProps) {
@@ -182,7 +195,7 @@ export function LanguageSelector({
           {showDrafts ? "Drafts shown" : "Drafts hidden"}
         </Button>
 
-        {isAdmin && (
+        {canCreate && (
           <Button size="sm" onClick={() => setShowCreate(!showCreate)}>
             <Plus className="mr-1.5 size-3.5" />
             New Language
@@ -198,7 +211,7 @@ export function LanguageSelector({
               {selectedIsPublished ? "Published" : "Draft"}
             </Badge>
 
-            {isAdmin &&
+            {canPublishSelected &&
               (selectedIsPublished ? (
                 <AlertDialog
                   open={unpublishOpen}
@@ -271,7 +284,7 @@ export function LanguageSelector({
                 </Button>
               ))}
 
-            {isAdmin && (
+            {canDeleteSelected && (
               <AlertDialog
                 open={deleteOpen}
                 onOpenChange={(next) => {

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -43,7 +43,14 @@ interface ModeSelectorProps {
   isSettingPublished: boolean;
   showDrafts: boolean;
   onToggleShowDrafts: (showDrafts: boolean) => void;
-  isAdmin: boolean;
+  // #181 verb-perms — modes DO carry an admin trump (worker bypasses
+  // the per-mode gate for admins), so the parent should compute these
+  // as `isAdmin || verb-rights-on-row`. Replaces the prior `isAdmin`
+  // flag which made non-admin mode shepherds unable to publish/delete
+  // even when the worker would have allowed them.
+  canCreate: boolean;
+  canPublishSelected: boolean;
+  canDeleteSelected: boolean;
 }
 
 function isPublished(mode: Pick<PromptMode, "published">): boolean {
@@ -62,7 +69,9 @@ export function ModeSelector({
   isSettingPublished,
   showDrafts,
   onToggleShowDrafts,
-  isAdmin,
+  canCreate,
+  canPublishSelected,
+  canDeleteSelected,
 }: ModeSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -183,7 +192,7 @@ export function ModeSelector({
           {showDrafts ? "Drafts shown" : "Drafts hidden"}
         </Button>
 
-        {isAdmin && (
+        {canCreate && (
           <Button size="sm" onClick={() => setShowCreate(!showCreate)}>
             <Plus className="mr-1.5 size-3.5" />
             New Mode
@@ -199,7 +208,7 @@ export function ModeSelector({
               {selectedIsPublished ? "Published" : "Draft"}
             </Badge>
 
-            {isAdmin &&
+            {canPublishSelected &&
               (selectedIsPublished ? (
                 <AlertDialog
                   open={unpublishOpen}
@@ -268,7 +277,7 @@ export function ModeSelector({
                 </Button>
               ))}
 
-            {isAdmin && (
+            {canDeleteSelected && (
               <AlertDialog
                 open={deleteOpen}
                 onOpenChange={(next) => {

--- a/src/components/require-mode-access.tsx
+++ b/src/components/require-mode-access.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+import { Navigate } from "react-router";
+
+import { useAuthStore } from "@/lib/auth-store";
+import { hasAdminPowers, hasAnyModeAccess } from "@/lib/permissions";
+
+// Gates `/modes` on admin OR any explicit mode verb-perm. Mirrors
+// `RequireAdmin` in shape but loosens the predicate to match the
+// post-#181 sidebar gate in activity-bar.tsx — non-admin mode
+// shepherds need to reach the page so ModesPage can apply its
+// per-row verb-perm gates (filter list, drop unauthorized selection,
+// readOnly editor for publish-only users). Without this loosening,
+// the sidebar Modes entry navigates to /modes and `RequireAdmin`
+// bounces non-admins back to `/` before any page-level gating runs
+// (Frank rd-3 review).
+export function RequireModeAccess({ children }: { children: ReactNode }) {
+  const user = useAuthStore((s) => s.user);
+  if (!hasAdminPowers(user) && !hasAnyModeAccess(user)) {
+    return <Navigate to="/" replace />;
+  }
+  return children;
+}

--- a/src/components/rights-selector.tsx
+++ b/src/components/rights-selector.tsx
@@ -132,7 +132,25 @@ export function RightsSelector({
             type="radio"
             name={radioName}
             checked={!isFull && !isLegacy}
-            onChange={() => onChange([...selected].sort())}
+            onChange={() => {
+              if (isLegacy && kind === "language") {
+                // Legacy languages = back-compat full access. Pre-
+                // populate the explicit list with every available
+                // language so the admin's first "Specific" click
+                // PRESERVES the user's current access — they can
+                // then uncheck to revoke. Without this seed, the
+                // click silently collapses their grant to [] (no
+                // access), the literal opposite of what the hint
+                // copy promises. Modes don't pre-populate: legacy
+                // modes had no per-row rights (admin-only baseline),
+                // so [] correctly mirrors the pre-#181 state.
+                const all =
+                  availableItems?.map((item) => item.name).sort() ?? [];
+                onChange(all);
+                return;
+              }
+              onChange([...selected].sort());
+            }}
             className="mt-0.5"
           />
           <div className="flex-1 space-y-2">

--- a/src/components/rights-selector.tsx
+++ b/src/components/rights-selector.tsx
@@ -1,28 +1,84 @@
 import { useMemo } from "react";
 
 import type { LanguageRights } from "@/types/auth";
-import type { Language } from "@/types/language";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 
-interface LanguageRightsSelectorProps {
+// Parameterized rights matrix — one row, one verb. Used four times in the
+// admin user dialogs (language-edit, language-publish, mode-edit,
+// mode-publish). The `kind`+`verb` pair scopes the radio group name so
+// the four selectors don't clobber each other when rendered side-by-side.
+//
+// `value === undefined` is the back-compat "no explicit grant yet" state
+// for languages (treated as legacy full access by the worker) and "no
+// access" for modes (worker/config.ts:rightsFor returns [] for undefined
+// mode verbs past the baseline gate). Picking any option locks the
+// value in explicitly so the rendered state matches what the worker
+// will see, regardless of which kind/verb is selected.
+
+type RightsKind = "language" | "mode";
+type RightsVerb = "edit" | "publish";
+
+interface RightsSelectorProps {
   value: LanguageRights | undefined;
   onChange: (next: LanguageRights) => void;
-  availableLanguages: Language[] | undefined;
+  availableItems: { name: string; label?: string }[] | undefined;
+  kind: RightsKind;
+  verb: RightsVerb;
   disabled?: boolean;
   // When true, show a hint that undefined === full access (legacy users).
   // Once the admin clicks anything the value becomes defined.
   showLegacyHint?: boolean;
 }
 
-export function LanguageRightsSelector({
+const LABELS: Record<
+  RightsKind,
+  Record<
+    RightsVerb,
+    { heading: string; fullDesc: string; specificDesc: string }
+  >
+> = {
+  language: {
+    edit: {
+      heading: "Language edit",
+      fullDesc: "Can save draft changes to every language tuning document.",
+      specificDesc:
+        "Can edit only the languages selected below. Leave all unchecked to deny edits entirely.",
+    },
+    publish: {
+      heading: "Language publish",
+      fullDesc:
+        "Can publish or unpublish every language tuning document, and delete them.",
+      specificDesc:
+        "Can publish only the languages selected below. Leave all unchecked to deny publishing entirely.",
+    },
+  },
+  mode: {
+    edit: {
+      heading: "Mode edit",
+      fullDesc: "Can save draft changes to every prompt mode.",
+      specificDesc:
+        "Can edit only the modes selected below. Leave all unchecked to deny edits entirely.",
+    },
+    publish: {
+      heading: "Mode publish",
+      fullDesc: "Can publish or unpublish every prompt mode, and delete them.",
+      specificDesc:
+        "Can publish only the modes selected below. Leave all unchecked to deny publishing entirely.",
+    },
+  },
+};
+
+export function RightsSelector({
   value,
   onChange,
-  availableLanguages,
+  availableItems,
+  kind,
+  verb,
   disabled = false,
   showLegacyHint = false,
-}: LanguageRightsSelectorProps) {
+}: RightsSelectorProps) {
   const isFull = value === "*";
   const isLegacy = value === undefined;
   const selected = useMemo<Set<string>>(
@@ -30,7 +86,10 @@ export function LanguageRightsSelector({
     [value]
   );
 
-  const toggleLanguage = (name: string) => {
+  const labels = LABELS[kind][verb];
+  const radioName = `${kind}-${verb}-rights-mode`;
+
+  const toggleItem = (name: string) => {
     if (disabled) return;
     const next = new Set(selected);
     if (next.has(name)) next.delete(name);
@@ -41,11 +100,11 @@ export function LanguageRightsSelector({
   return (
     <div className="space-y-3">
       <div className="space-y-2">
-        <Label className="text-sm font-medium">Language access</Label>
+        <Label className="text-sm font-medium">{labels.heading}</Label>
         {isLegacy && showLegacyHint && (
           <p className="text-muted-foreground text-xs">
-            This user predates the language-rights system. They currently have
-            full access by default. Picking any option below will lock that in
+            This user predates verb-based permissions. They currently have full
+            access by default. Picking any option below will lock that in
             explicitly.
           </p>
         )}
@@ -55,7 +114,7 @@ export function LanguageRightsSelector({
         <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors">
           <input
             type="radio"
-            name="language-rights-mode"
+            name={radioName}
             checked={isFull}
             onChange={() => onChange("*")}
             className="mt-0.5"
@@ -63,7 +122,7 @@ export function LanguageRightsSelector({
           <div className="space-y-0.5">
             <div className="text-sm font-medium">Full access</div>
             <div className="text-muted-foreground text-xs">
-              Can read and edit every language tuning document.
+              {labels.fullDesc}
             </div>
           </div>
         </label>
@@ -71,38 +130,37 @@ export function LanguageRightsSelector({
         <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors">
           <input
             type="radio"
-            name="language-rights-mode"
+            name={radioName}
             checked={!isFull && !isLegacy}
             onChange={() => onChange([...selected].sort())}
             className="mt-0.5"
           />
           <div className="flex-1 space-y-2">
             <div className="space-y-0.5">
-              <div className="text-sm font-medium">Specific languages</div>
+              <div className="text-sm font-medium">Specific {kind}s</div>
               <div className="text-muted-foreground text-xs">
-                Only the languages selected below. Leave all unchecked to deny
-                access entirely.
+                {labels.specificDesc}
               </div>
             </div>
 
             {!isFull && !isLegacy && (
               <div className="flex flex-wrap gap-1.5">
-                {availableLanguages === undefined ? (
+                {availableItems === undefined ? (
                   <span className="text-muted-foreground text-xs">
-                    Loading languages…
+                    Loading {kind}s…
                   </span>
-                ) : availableLanguages.length === 0 ? (
+                ) : availableItems.length === 0 ? (
                   <span className="text-muted-foreground text-xs">
-                    No languages defined yet.
+                    No {kind}s defined yet.
                   </span>
                 ) : (
-                  availableLanguages.map((lang) => {
-                    const checked = selected.has(lang.name);
+                  availableItems.map((item) => {
+                    const checked = selected.has(item.name);
                     return (
                       <button
-                        key={lang.name}
+                        key={item.name}
                         type="button"
-                        onClick={() => toggleLanguage(lang.name)}
+                        onClick={() => toggleItem(item.name)}
                         className={cn(
                           "rounded-full border px-2.5 py-1 text-xs transition-colors",
                           checked
@@ -115,7 +173,7 @@ export function LanguageRightsSelector({
                             ✓
                           </span>
                         )}
-                        {lang.label || lang.name}
+                        {item.label || item.name}
                       </button>
                     );
                   })
@@ -129,8 +187,8 @@ export function LanguageRightsSelector({
       {Array.isArray(value) && value.length > 0 && (
         <p className="text-muted-foreground text-xs">
           {value.length === 1
-            ? "1 language granted"
-            : `${value.length} languages granted`}
+            ? `1 ${kind} granted`
+            : `${value.length} ${kind}s granted`}
         </p>
       )}
       {Array.isArray(value) && value.length === 0 && (

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -46,6 +46,86 @@ export function hasAnyLanguageRights(
   return hasAnyRights(rights);
 }
 
+// Effective verb-perm helpers — client-side mirror of
+// worker/auth.ts:lazyMigrateLanguageRights. Return the rights value
+// the WORKER will see for this user at request time, applying the
+// partner-aware rule:
+//
+//   - If the explicit verb-perm is set, use it.
+//   - Else if the PARTNER verb-perm is set, the unset verb is a
+//     deliberate gap (= []), NOT legacy back-compat. Without this
+//     rule, a stored user with `language_rights: "*"` plus an
+//     explicit `language_edit_rights: ["spanish"]` would show as
+//     publish="*" in the admin UI even though the worker treats them
+//     as publish=[] — admin saves through the dialog would then
+//     persist the misleading "*" explicitly, silently widening
+//     access (Frank rd-2 P1).
+//   - Else (both verb-perms unset) fall back to legacy
+//     `language_rights` for languages, or undefined for modes (which
+//     have no legacy fallback).
+export function effectiveLanguageEditRights(
+  user:
+    | {
+        language_edit_rights?: LanguageRights;
+        language_publish_rights?: LanguageRights;
+        language_rights?: LanguageRights;
+      }
+    | null
+    | undefined
+): LanguageRights | undefined {
+  if (!user) return undefined;
+  if (user.language_edit_rights !== undefined) return user.language_edit_rights;
+  if (user.language_publish_rights !== undefined) return [];
+  return user.language_rights;
+}
+
+export function effectiveLanguagePublishRights(
+  user:
+    | {
+        language_edit_rights?: LanguageRights;
+        language_publish_rights?: LanguageRights;
+        language_rights?: LanguageRights;
+      }
+    | null
+    | undefined
+): LanguageRights | undefined {
+  if (!user) return undefined;
+  if (user.language_publish_rights !== undefined)
+    return user.language_publish_rights;
+  if (user.language_edit_rights !== undefined) return [];
+  return user.language_rights;
+}
+
+export function effectiveModeEditRights(
+  user:
+    | {
+        mode_edit_rights?: LanguageRights;
+        mode_publish_rights?: LanguageRights;
+      }
+    | null
+    | undefined
+): LanguageRights | undefined {
+  if (!user) return undefined;
+  if (user.mode_edit_rights !== undefined) return user.mode_edit_rights;
+  if (user.mode_publish_rights !== undefined) return [];
+  return undefined;
+}
+
+export function effectiveModePublishRights(
+  user:
+    | {
+        mode_edit_rights?: LanguageRights;
+        mode_publish_rights?: LanguageRights;
+      }
+    | null
+    | undefined
+): LanguageRights | undefined {
+  if (!user) return undefined;
+  if (user.mode_publish_rights !== undefined) return user.mode_publish_rights;
+  if (user.mode_edit_rights !== undefined) return [];
+  return undefined;
+}
+
 // Union helpers — "user has *some* access via *either* verb on *some*
 // item." Used by page-level / sidebar gates that just decide whether to
 // render the surface at all; finer-grained gates (per-item edit vs

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -13,9 +13,11 @@ export function hasAdminPowers(
   return (user.isAdmin ?? false) || (user.isSuperAdmin ?? false);
 }
 
-// `undefined` is the back-compat default until bt-servant-engine#207 lands —
-// treat it as full access so existing users aren't locked out.
-export function hasLanguageRights(
+// `undefined` is the back-compat default for users predating the rights
+// system — treat it as full access so they aren't locked out. The worker
+// applies the same rule, including the lazy migration from legacy
+// `language_rights` to the four verb-perms fields (`worker/auth.ts`).
+export function hasRights(
   rights: LanguageRights | undefined,
   name: string
 ): boolean {
@@ -23,11 +25,83 @@ export function hasLanguageRights(
   return rights.includes(name);
 }
 
+export function hasAnyRights(rights: LanguageRights | undefined): boolean {
+  if (rights === undefined || rights === "*") return true;
+  return rights.length > 0;
+}
+
+// Pre-verb-perms helper — equivalent to `hasRights` on the legacy
+// `language_rights` field. New call sites should prefer the verb-specific
+// helpers below so edit and publish gates stay separable.
+export function hasLanguageRights(
+  rights: LanguageRights | undefined,
+  name: string
+): boolean {
+  return hasRights(rights, name);
+}
+
 export function hasAnyLanguageRights(
   rights: LanguageRights | undefined
 ): boolean {
-  if (rights === undefined || rights === "*") return true;
-  return rights.length > 0;
+  return hasAnyRights(rights);
+}
+
+// Union helpers — "user has *some* access via *either* verb on *some*
+// item." Used by page-level / sidebar gates that just decide whether to
+// render the surface at all; finer-grained gates (per-item edit vs
+// publish) use the verb-specific helpers directly.
+export function hasAnyLanguageAccess(
+  user:
+    | {
+        language_edit_rights?: LanguageRights;
+        language_publish_rights?: LanguageRights;
+      }
+    | null
+    | undefined
+): boolean {
+  if (!user) return false;
+  return (
+    hasAnyRights(user.language_edit_rights) ||
+    hasAnyRights(user.language_publish_rights)
+  );
+}
+
+export function hasAnyModeAccess(
+  user:
+    | {
+        mode_edit_rights?: LanguageRights;
+        mode_publish_rights?: LanguageRights;
+      }
+    | null
+    | undefined
+): boolean {
+  if (!user) return false;
+  return (
+    hasAnyRights(user.mode_edit_rights) ||
+    hasAnyRights(user.mode_publish_rights)
+  );
+}
+
+// Filter to items the user can access via *some* verb. Mirrors the
+// per-language list filter applied before rendering the dropdown — we
+// don't want to show entries the user can neither edit nor publish.
+export function filterByAnyRights<T extends { name: string }>(
+  items: T[],
+  edit: LanguageRights | undefined,
+  publish: LanguageRights | undefined
+): T[] {
+  // `undefined` for either side means legacy full access; combined that's
+  // also full access.
+  if (
+    edit === undefined ||
+    edit === "*" ||
+    publish === undefined ||
+    publish === "*"
+  ) {
+    return items;
+  }
+  const allowed = new Set<string>([...edit, ...publish]);
+  return items.filter((i) => allowed.has(i.name));
 }
 
 export function filterAuthorizedLanguages<T extends { name: string }>(

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -50,22 +50,35 @@ export function hasAnyLanguageRights(
 // item." Used by page-level / sidebar gates that just decide whether to
 // render the surface at all; finer-grained gates (per-item edit vs
 // publish) use the verb-specific helpers directly.
+//
+// Languages preserve the pre-#181 "undefined → legacy full access" rule
+// — both verbs unset and no legacy `language_rights` means the user
+// predates the rights system and gets default full access. Same as the
+// worker's rightsFor language path.
 export function hasAnyLanguageAccess(
   user:
     | {
         language_edit_rights?: LanguageRights;
         language_publish_rights?: LanguageRights;
+        language_rights?: LanguageRights;
       }
     | null
     | undefined
 ): boolean {
   if (!user) return false;
   return (
-    hasAnyRights(user.language_edit_rights) ||
-    hasAnyRights(user.language_publish_rights)
+    hasAnyRights(user.language_edit_rights ?? user.language_rights) ||
+    hasAnyRights(user.language_publish_rights ?? user.language_rights)
   );
 }
 
+// Modes have NO legacy fallback — pre-#181 the mode gate was admin-
+// only. `mode_edit_rights = undefined && mode_publish_rights = undefined`
+// for a non-admin means "no access" (worker's mode-baseline gate
+// returns 403). The sidebar/page entry-point must NOT enable for
+// undefined-undefined non-admin users; admins are gated separately via
+// hasAdminPowers. Calling code typically combines:
+//   `hasAdminPowers(user) || hasAnyModeAccess(user)`
 export function hasAnyModeAccess(
   user:
     | {
@@ -76,6 +89,12 @@ export function hasAnyModeAccess(
     | undefined
 ): boolean {
   if (!user) return false;
+  if (
+    user.mode_edit_rights === undefined &&
+    user.mode_publish_rights === undefined
+  ) {
+    return false;
+  }
   return (
     hasAnyRights(user.mode_edit_rights) ||
     hasAnyRights(user.mode_publish_rights)

--- a/src/types/admin-users.ts
+++ b/src/types/admin-users.ts
@@ -2,6 +2,12 @@ import type { LanguageRights } from "@/types/auth";
 
 // Mirrors the worker `safeUser` response shape from /api/admin/users.
 // Password fields are deliberately not in the API response.
+//
+// `language_rights` is the pre-#181 single-bit field. Verb-perms (the four
+// `*_edit_rights` / `*_publish_rights` fields) layer on top: when absent on
+// a row, the worker lazy-migrates from `language_rights`. The dialog always
+// persists the verb-perms fields explicitly so newly-granted rights don't
+// leak full access via the `undefined === legacy` fallback.
 export interface AdminUser {
   id: string;
   email: string;
@@ -14,6 +20,10 @@ export interface AdminUser {
   // role, not the row's.
   isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
 }
 
 export interface CreateUserBody {
@@ -26,6 +36,10 @@ export interface CreateUserBody {
   // super-by-session. Org admins sending this get a loud 403.
   isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
 }
 
 export interface UpdateUserBody {
@@ -38,4 +52,8 @@ export interface UpdateUserBody {
   // within their own org).
   isSuperAdmin?: boolean;
   language_rights?: LanguageRights;
+  language_edit_rights?: LanguageRights;
+  language_publish_rights?: LanguageRights;
+  mode_edit_rights?: LanguageRights;
+  mode_publish_rights?: LanguageRights;
 }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -155,7 +155,16 @@ describe("validateSession lazy-mapping (#181) — via handleMe", () => {
   // lazy fallback must not clobber them — explicit value wins over the
   // legacy source. Catches the bug shape where the `??` was accidentally
   // reversed.
-  it("user with explicit language_edit_rights → fallback does NOT override the explicit value", async () => {
+  //
+  // Frank P1 (PR 236 review): the partner-aware deny rule means that
+  // when EITHER verb-perm is explicit, the unset partner falls back to
+  // `[]` (deliberate deny), NOT to legacy `language_rights`. Without
+  // this, a stored user with `language_rights: "*"` plus an explicit
+  // edit grant would arrive at worker/config.ts:rightsFor with
+  // `language_publish_rights: "*"` materialized — silently widening
+  // publish past the admin's intent. This test fixture used to expect
+  // the legacy fallback for publish; that behavior is the bug.
+  it("[Frank P1] explicit language_edit_rights → publish becomes [] (partner-aware deny), NOT legacy", async () => {
     const user = await seedUser({
       email: "explicit@acme.com",
       name: "Explicit",
@@ -167,8 +176,45 @@ describe("validateSession lazy-mapping (#181) — via handleMe", () => {
 
     const me = await callMe(session);
     expect(me.language_edit_rights).toEqual(["en", "es", "fr"]);
-    // Publish has no explicit value — still falls back to legacy.
-    expect(me.language_publish_rights).toEqual(["en"]);
+    // Partner-aware deny: edit is explicit, so the unset publish field
+    // is a deliberate gap (= []), NOT legacy ["en"].
+    expect(me.language_publish_rights).toEqual([]);
+  });
+
+  it("[Frank P1] stored language_rights:'*' + language_edit_rights:['spanish'] → publish becomes [] (Frank's verification scenario)", async () => {
+    // Frank's exact scenario: stored user has a legacy wildcard plus
+    // an explicit edit grant on a single language. Pre-fix, the
+    // session would arrive at rightsFor with publish_rights="*" and a
+    // publish flip on ANY language would be allowed. Post-fix, the
+    // session reflects publish=[] and the worker correctly denies.
+    const user = await seedUser({
+      email: "franks-scenario@acme.com",
+      name: "Franks Scenario",
+      org: "acme",
+      language_rights: "*",
+      language_edit_rights: ["spanish"],
+    });
+    const session = await seedLegacySession(user);
+
+    const me = await callMe(session);
+    expect(me.language_rights).toBe("*");
+    expect(me.language_edit_rights).toEqual(["spanish"]);
+    expect(me.language_publish_rights).toEqual([]);
+  });
+
+  it("[Frank P1] stored explicit publish only → edit becomes [] (mirror direction)", async () => {
+    const user = await seedUser({
+      email: "publish-only@acme.com",
+      name: "Publish Only",
+      org: "acme",
+      language_rights: ["en", "fr"],
+      language_publish_rights: ["fr"],
+    });
+    const session = await seedLegacySession(user);
+
+    const me = await callMe(session);
+    expect(me.language_edit_rights).toEqual([]);
+    expect(me.language_publish_rights).toEqual(["fr"]);
   });
 
   it("user with explicit mode_edit_rights → passes through verbatim (no legacy source to interfere)", async () => {

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:test";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { handleConfig } from "../worker/config";
+import { __testInternals, handleConfig } from "../worker/config";
 import type { SessionData } from "../worker/types";
 
 afterEach(() => {
@@ -27,10 +27,17 @@ function makeRequest(method: string, pathname: string): Request {
 // When the gate fires, the worker must NOT touch the upstream engine — that
 // would leak the request through despite the 403. We assert this by spying on
 // fetch and verifying it was never called.
+//
+// `mockImplementation` returns a fresh Response per call: the #181 verb-perms
+// gate does TWO fetches per PUT (one to read current state for the diff, one
+// for the proxy). A single shared Response instance would have its body
+// stream consumed by the first read, then explode on the second.
 function spyFetch() {
   return vi
     .spyOn(globalThis, "fetch")
-    .mockResolvedValue(new Response("{}", { status: 200 }));
+    .mockImplementation(() =>
+      Promise.resolve(new Response("{}", { status: 200 }))
+    );
 }
 
 describe("config authz — /api/config/modes/{name}", () => {
@@ -248,6 +255,556 @@ describe("config authz — super admin trumps isAdmin", () => {
     );
     expect(res.status).toBe(403);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #181 verb-perms — edit vs publish, per language and per mode
+// ---------------------------------------------------------------------------
+//
+// The BFF now splits the single language_rights / admin-only mode gates
+// into per-verb gates: `*_edit_rights` controls draft saves, `*_publish_rights`
+// controls publish-flag flips and (combined with edit rights) DELETEs. The
+// gate diffs the PUT body against engine state to know what actually
+// changed — so an autosave that only touched `document` requires edit
+// rights, while a publish-toggle that only flipped `published` requires
+// publish rights. See worker/config.ts:gateConfigMutation.
+
+// Returns a fetch spy that simulates the engine's current-state response
+// for the first call (which the gate makes to diff) and a generic 200 for
+// any subsequent call (the proxy PUT/DELETE). `current === null` simulates
+// a 404 — engine treats the resource as not-yet-created.
+function spyFetchWithCurrent(
+  kind: "language" | "mode",
+  current: {
+    document?: string;
+    label?: string;
+    description?: string;
+    published?: boolean;
+  } | null
+) {
+  let callCount = 0;
+  return vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+    callCount++;
+    if (callCount === 1) {
+      if (current === null) {
+        return Promise.resolve(new Response("", { status: 404 }));
+      }
+      const wrapped =
+        kind === "language" ? { language: current } : { mode: current };
+      return Promise.resolve(
+        new Response(JSON.stringify(wrapped), { status: 200 })
+      );
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+}
+
+describe("config authz — #181 verb-perms (languages)", () => {
+  it("edit-only PUT (document changed, published unchanged) → 200 with edit rights only", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", {
+      document: "# old\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# new\n", published: false }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect((fetchSpy.mock.calls[1]![1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("edit-only PUT → 403 without edit rights (publish rights alone aren't enough)", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", {
+      document: "# old\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# new\n", published: false }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: [],
+        language_publish_rights: ["spanish"],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(403);
+    // The current-state GET fires (gate needs it to diff); the proxy PUT
+    // does not.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("publish-only PUT (published flipped, document same) → 200 with publish rights only", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", {
+      document: "# same\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# same\n", published: true }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: [],
+        language_publish_rights: ["spanish"],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("publish-only PUT → 403 without publish rights", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", {
+      document: "# same\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# same\n", published: true }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("PUT that changes both document AND published needs both rights", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", {
+      document: "# old\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# new\n", published: true }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("PUT both with both rights → 200", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", {
+      document: "# old\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# new\n", published: true }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: ["spanish"],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("legacy language_rights = ['spanish'] lazy-falls-back to BOTH verbs", async () => {
+    // Pre-#181 sessions carry only `language_rights`. The gate must
+    // accept the autosave (document edit) by falling back to the legacy
+    // bit. Mirror of the worker/auth.ts lazy migration so existing
+    // shepherds keep working until the admin re-saves them through the
+    // new dialog.
+    const fetchSpy = spyFetchWithCurrent("language", {
+      document: "# old\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# new\n", published: true }),
+      }),
+      env,
+      makeSession({ language_rights: ["spanish"] }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("creation (current state 404) needs edit rights when document is set", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", null);
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# brand new\n", published: false }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("creation with published: true needs BOTH edit and publish rights", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", null);
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# brand new\n", published: true }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("DELETE requires BOTH edit and publish rights — missing publish → 403", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("DELETE", "/api/config/languages/spanish"),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("DELETE requires BOTH edit and publish rights — missing edit → 403", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("DELETE", "/api/config/languages/spanish"),
+      env,
+      makeSession({
+        language_edit_rights: [],
+        language_publish_rights: ["spanish"],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("DELETE with both rights → proxies", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequest("DELETE", "/api/config/languages/spanish"),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: ["spanish"],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+});
+
+describe("config authz — #181 verb-perms (modes)", () => {
+  it("non-admin without any explicit mode rights → 403 (preserves pre-#181 admin-only baseline)", async () => {
+    // Modes had no per-row rights pre-#181 — the gate was admin-only. The
+    // "undefined === legacy full access" rule that languages inherit
+    // from `language_rights` is NOT applied for modes; the dialog must
+    // grant at least one of mode_edit_rights / mode_publish_rights for
+    // a non-admin to escape this baseline.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## Identity\n", published: false }),
+      }),
+      env,
+      makeSession({ isAdmin: false }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("admin trumps per-mode rights (mirrors pre-#181 admin-can-edit-all-modes)", async () => {
+    // Admin doesn't need the gate's current-state GET — admin-trump
+    // bypasses the diff entirely, so the proxy is the only fetch.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## new\n", published: true }),
+      }),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-admin with mode_edit_rights=['spoken'] edit-only PUT → 200", async () => {
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## old\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## new\n", published: false }),
+      }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("non-admin with mode_edit_rights=['spoken'] but no publish — publish-flip → 403", async () => {
+    // Footgun guard: pre-fix, mode_publish_rights=undefined fell through
+    // to "legacy full access" and the publish-flip succeeded silently.
+    // worker/config.ts:rightsFor now returns `[]` for any undefined
+    // mode verb when the user is past the mode-baseline gate.
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## same\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## same\n", published: true }),
+      }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken"],
+        // mode_publish_rights deliberately omitted — must NOT fall back
+        // to legacy full access.
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-admin with mode_edit_rights=['spoken'] DELETE → 403 (publish missing)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("DELETE", "/api/config/modes/spoken"),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-admin with both mode rights on 'spoken' can DELETE 'spoken'", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequest("DELETE", "/api/config/modes/spoken"),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("non-admin with mode_publish_rights=['spoken'] can flip published without edit rights", async () => {
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## same\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## same\n", published: true }),
+      }),
+      env,
+      makeSession({
+        mode_edit_rights: [],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("mode label change triggers edit gate (not just document)", async () => {
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## same\n",
+      label: "Old Label",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          document: "## same\n",
+          label: "New Label",
+          published: false,
+        }),
+      }),
+      env,
+      makeSession({
+        mode_edit_rights: [],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("config authz — #181 verb diff (pure function)", () => {
+  const { computeRequiredVerbsForPut } = __testInternals;
+
+  it("update changing only document → ['edit']", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "# new\n", published: false },
+        { document: "# old\n", published: false }
+      )
+    ).toEqual(["edit"]);
+  });
+
+  it("update changing only published → ['publish']", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "# same\n", published: true },
+        { document: "# same\n", published: false }
+      )
+    ).toEqual(["publish"]);
+  });
+
+  it("update changing both → ['edit', 'publish']", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "# new\n", published: true },
+        { document: "# old\n", published: false }
+      )
+    ).toEqual(["edit", "publish"]);
+  });
+
+  it("update with no field changes → []", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "# same\n", published: false },
+        { document: "# same\n", published: false }
+      )
+    ).toEqual([]);
+  });
+
+  it("creation (current=null) with document → ['edit']", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "# brand new\n", published: false },
+        null
+      )
+    ).toEqual(["edit"]);
+  });
+
+  it("creation with published: true → ['edit', 'publish']", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "# brand new\n", published: true },
+        null
+      )
+    ).toEqual(["edit", "publish"]);
+  });
+
+  it("creation with published: false → ['edit'] (default-state isn't a publish)", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "# brand new\n", published: false },
+        null
+      )
+    ).toEqual(["edit"]);
+  });
+
+  it("update changing only mode label → ['edit'] (label is editorial too)", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "## same\n", label: "New", published: false },
+        { document: "## same\n", label: "Old", published: false }
+      )
+    ).toEqual(["edit"]);
+  });
+
+  it("update changing only mode description → ['edit']", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "## same\n", description: "New", published: false },
+        { document: "## same\n", description: "Old", published: false }
+      )
+    ).toEqual(["edit"]);
+  });
+
+  it("body missing a field doesn't trigger that field's verb", () => {
+    // A future client that PUTs `{published: true}` only (no document)
+    // should require publish-only.
+    expect(
+      computeRequiredVerbsForPut(
+        { published: true },
+        { document: "# whatever\n", published: false }
+      )
+    ).toEqual(["publish"]);
   });
 });
 
@@ -488,8 +1045,15 @@ describe("config authz — cross-org via ?org= (#166)", () => {
       "/api/config/languages/spanish"
     );
     expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // Two fetches under #181 verb-perms: GET current state for the diff,
+    // PUT proxy. Both target the same resource — the gate doesn't add
+    // path churn, only verb-aware authz on top.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/languages/spanish"
+    );
+    expect((fetchSpy.mock.calls[1]![1] as RequestInit).method).toBe("PUT");
+    expect(String(fetchSpy.mock.calls[1]![0])).toContain(
       "/api/v1/admin/orgs/acme/languages/spanish"
     );
   });

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -684,6 +684,108 @@ describe("config authz — #181 verb-perms (modes)", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("[review F1] partner-aware deny: language_edit_rights=['en'], no publish rights → publish-flip 403s", async () => {
+    // Without the partner-aware rightsFor rule, `language_publish_rights`
+    // would fall through to `undefined ⇒ legacy full access` (the
+    // pre-#181 back-compat semantic) and silently widen publish to
+    // every language. Verifies the F1 fix: explicit grant of one verb
+    // makes the unset partner verb a deliberate gap (= []), not legacy.
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## same\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# same\n", published: true }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        // language_publish_rights and language_rights deliberately
+        // omitted — must NOT fall back to legacy full access.
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("[review F1] partner-aware deny: language_publish_rights=['en'], no edit rights → edit 403s", async () => {
+    spyFetchWithCurrent("language", {
+      document: "# old\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# new\n", published: false }),
+      }),
+      env,
+      makeSession({ language_publish_rights: ["spanish"] }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("[review F15] PUT against engine row missing `published` works for edit-only shepherd", async () => {
+    // Engine rows predating the `published` field omit it on read.
+    // Without F15's `current.published ?? false`, `false !== undefined`
+    // evaluates true and the gate spuriously demands publish rights on
+    // a normal edit save.
+    const fetchSpy = spyFetchWithCurrent("language", { document: "# old\n" });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# new\n", published: false }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("[review F11] engine GET 5xx → gate treats as creation (no 502 leaked)", async () => {
+    // A transient engine error during the gate's current-state GET
+    // shouldn't add a second failure mode (502 from the BFF). The
+    // gate treats unfetchable current as creation; creation
+    // semantics are stricter than the diff path, so this fall-through
+    // can only deny more, never allow more.
+    let callCount = 0;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(new Response("upstream oops", { status: 500 }));
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/spanish", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# new\n", published: false }),
+      }),
+      env,
+      makeSession({
+        language_edit_rights: ["spanish"],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/spanish"
+    );
+    // Treated as create: `published: false` doesn't require publish
+    // rights, document does require edit (caller has it) → pass.
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("mode label change triggers edit gate (not just document)", async () => {
     const fetchSpy = spyFetchWithCurrent("mode", {
       document: "## same\n",

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -204,6 +204,16 @@ describe("hasAnyLanguageAccess", () => {
       })
     ).toBe(true);
   });
+
+  it("[review F4] legacy language_rights falls back when verb-perms unset", () => {
+    // Pre-#181 sessions only carry `language_rights`; the union helper
+    // must mirror the worker's lazy-fallback chain so legacy shepherds
+    // see the sidebar entry until they're re-saved through the new
+    // dialog.
+    expect(hasAnyLanguageAccess({ language_rights: ["en"] })).toBe(true);
+    expect(hasAnyLanguageAccess({ language_rights: "*" })).toBe(true);
+    expect(hasAnyLanguageAccess({ language_rights: [] })).toBe(false);
+  });
 });
 
 describe("hasAnyModeAccess", () => {
@@ -220,6 +230,21 @@ describe("hasAnyModeAccess", () => {
       hasAnyModeAccess({
         mode_edit_rights: [],
         mode_publish_rights: [],
+      })
+    ).toBe(false);
+  });
+
+  it("[review F12] both undefined → false (modes have no pre-#181 legacy access)", () => {
+    // Unlike languages, modes had no per-row rights pre-#181 — the
+    // gate was admin-only. A non-admin with `mode_edit_rights ===
+    // undefined && mode_publish_rights === undefined` had zero mode
+    // access, and the union helper must match the worker's mode-
+    // baseline gate rather than the language back-compat rule.
+    expect(hasAnyModeAccess({})).toBe(false);
+    expect(
+      hasAnyModeAccess({
+        mode_edit_rights: undefined,
+        mode_publish_rights: undefined,
       })
     ).toBe(false);
   });

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  effectiveLanguageEditRights,
+  effectiveLanguagePublishRights,
+  effectiveModeEditRights,
+  effectiveModePublishRights,
   filterAuthorizedLanguages,
   filterByAnyRights,
   hasAdminPowers,
@@ -213,6 +217,92 @@ describe("hasAnyLanguageAccess", () => {
     expect(hasAnyLanguageAccess({ language_rights: ["en"] })).toBe(true);
     expect(hasAnyLanguageAccess({ language_rights: "*" })).toBe(true);
     expect(hasAnyLanguageAccess({ language_rights: [] })).toBe(false);
+  });
+});
+
+// Effective verb-perm helpers — mirror worker/auth.ts:lazyMigrate-
+// LanguageRights. Required by Frank rd-2 P1: the dialog + AccessSummary
+// must show what the WORKER actually sees, not the raw stored shape.
+
+describe("effectiveLanguageEditRights", () => {
+  it("explicit value wins", () => {
+    expect(
+      effectiveLanguageEditRights({
+        language_edit_rights: ["en"],
+        language_rights: "*",
+      })
+    ).toEqual(["en"]);
+  });
+
+  it("partner explicit + this unset → [] (deliberate deny)", () => {
+    expect(
+      effectiveLanguageEditRights({
+        language_publish_rights: ["en"],
+      })
+    ).toEqual([]);
+  });
+
+  it("[Frank rd-2 P1] legacy '*' + explicit publish → edit becomes [] (not '*')", () => {
+    // The exact scenario that broke the AccessSummary + dialog before
+    // the helpers were introduced: showing "*" for the unset verb
+    // would let an admin re-save and persist "*" explicitly.
+    expect(
+      effectiveLanguageEditRights({
+        language_rights: "*",
+        language_publish_rights: ["spanish"],
+      })
+    ).toEqual([]);
+  });
+
+  it("both unset → legacy language_rights fallback", () => {
+    expect(effectiveLanguageEditRights({ language_rights: "*" })).toBe("*");
+    expect(effectiveLanguageEditRights({ language_rights: ["en"] })).toEqual([
+      "en",
+    ]);
+    expect(effectiveLanguageEditRights({})).toBeUndefined();
+  });
+
+  it("null user → undefined", () => {
+    expect(effectiveLanguageEditRights(null)).toBeUndefined();
+  });
+});
+
+describe("effectiveLanguagePublishRights", () => {
+  it("symmetric: explicit edit + unset publish → [] (Frank's scenario)", () => {
+    expect(
+      effectiveLanguagePublishRights({
+        language_rights: "*",
+        language_edit_rights: ["spanish"],
+      })
+    ).toEqual([]);
+  });
+
+  it("both unset → legacy language_rights fallback", () => {
+    expect(effectiveLanguagePublishRights({ language_rights: "*" })).toBe("*");
+  });
+});
+
+describe("effectiveModeEditRights / effectiveModePublishRights", () => {
+  it("modes have no legacy fallback — both unset → undefined", () => {
+    expect(effectiveModeEditRights({})).toBeUndefined();
+    expect(effectiveModePublishRights({})).toBeUndefined();
+  });
+
+  it("partner explicit + this unset → [] (matches worker rightsFor mode rule)", () => {
+    expect(
+      effectiveModeEditRights({ mode_publish_rights: ["spoken"] })
+    ).toEqual([]);
+    expect(
+      effectiveModePublishRights({ mode_edit_rights: ["spoken"] })
+    ).toEqual([]);
+  });
+
+  it("explicit value wins", () => {
+    expect(effectiveModeEditRights({ mode_edit_rights: ["a", "b"] })).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(effectiveModePublishRights({ mode_publish_rights: "*" })).toBe("*");
   });
 });
 

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   filterAuthorizedLanguages,
+  filterByAnyRights,
   hasAdminPowers,
+  hasAnyLanguageAccess,
   hasAnyLanguageRights,
+  hasAnyModeAccess,
   hasLanguageRights,
 } from "../src/lib/permissions";
 
@@ -149,5 +152,104 @@ describe("filterAuthorizedLanguages", () => {
     expect(out).toEqual([
       { name: "en", label: "English", published: true, document: "..." },
     ]);
+  });
+});
+
+// #181 verb-perms — union helpers for page-level / sidebar gates that
+// don't care about the verb axis, just "can the user touch this surface
+// at all?" Combines edit and publish rights into a single yes/no.
+
+describe("hasAnyLanguageAccess", () => {
+  it("null user → false", () => {
+    expect(hasAnyLanguageAccess(null)).toBe(false);
+    expect(hasAnyLanguageAccess(undefined)).toBe(false);
+  });
+
+  it("user with edit-only access → true", () => {
+    expect(
+      hasAnyLanguageAccess({
+        language_edit_rights: ["en"],
+        language_publish_rights: [],
+      })
+    ).toBe(true);
+  });
+
+  it("user with publish-only access → true", () => {
+    expect(
+      hasAnyLanguageAccess({
+        language_edit_rights: [],
+        language_publish_rights: ["en"],
+      })
+    ).toBe(true);
+  });
+
+  it("user with both empty → false", () => {
+    expect(
+      hasAnyLanguageAccess({
+        language_edit_rights: [],
+        language_publish_rights: [],
+      })
+    ).toBe(false);
+  });
+
+  it("user with no fields set (legacy) → true (back-compat full access)", () => {
+    expect(hasAnyLanguageAccess({})).toBe(true);
+  });
+
+  it("user with '*' on either field → true", () => {
+    expect(
+      hasAnyLanguageAccess({
+        language_edit_rights: "*",
+        language_publish_rights: [],
+      })
+    ).toBe(true);
+  });
+});
+
+describe("hasAnyModeAccess", () => {
+  it("null user → false", () => {
+    expect(hasAnyModeAccess(null)).toBe(false);
+  });
+
+  it("user with mode_edit_rights set → true", () => {
+    expect(hasAnyModeAccess({ mode_edit_rights: ["spoken"] })).toBe(true);
+  });
+
+  it("user with both empty → false", () => {
+    expect(
+      hasAnyModeAccess({
+        mode_edit_rights: [],
+        mode_publish_rights: [],
+      })
+    ).toBe(false);
+  });
+});
+
+describe("filterByAnyRights", () => {
+  const all = [
+    { name: "en", label: "English" },
+    { name: "fr", label: "French" },
+    { name: "es", label: "Spanish" },
+  ];
+
+  it("union of edit and publish names", () => {
+    expect(filterByAnyRights(all, ["en"], ["es"])).toEqual([
+      { name: "en", label: "English" },
+      { name: "es", label: "Spanish" },
+    ]);
+  });
+
+  it("undefined on either side → returns input unchanged", () => {
+    expect(filterByAnyRights(all, undefined, [])).toEqual(all);
+    expect(filterByAnyRights(all, [], undefined)).toEqual(all);
+  });
+
+  it("'*' on either side → returns input unchanged", () => {
+    expect(filterByAnyRights(all, "*", [])).toEqual(all);
+    expect(filterByAnyRights(all, [], "*")).toEqual(all);
+  });
+
+  it("both empty arrays → empty", () => {
+    expect(filterByAnyRights(all, [], [])).toEqual([]);
   });
 });

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -1,7 +1,7 @@
 import { generateSalt, hashPassword, timingSafeEqual } from "./crypto";
 import type { Env } from "./helpers";
 import { errorResponse, jsonResponse } from "./helpers";
-import type { SessionData, StoredUser } from "./types";
+import type { LanguageRights, SessionData, StoredUser } from "./types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -124,11 +124,16 @@ export async function validateSession(
   }
 
   // Lazy-migrate the legacy single-bit `language_rights` into the two
-  // verb-perms fields when the stored record predates #181. Identity copy
-  // — same shape (`string[] | "*"`) — so old rights become both edit and
-  // publish access until an admin edits the user explicitly. Mode rights
-  // have no legacy source; absent ⇒ undefined ⇒ treated as full access
-  // until PR 2 enforces per-mode gating.
+  // verb-perms fields when the stored record predates #181. Partner-
+  // aware: if either verb-perm is explicit, the unset partner falls
+  // back to `[]` (deliberate deny), NOT to legacy `language_rights`.
+  // Without this rule, a stored user with `language_rights: "*"` plus
+  // an explicit `language_edit_rights: ["spanish"]` would arrive at
+  // worker/config.ts:rightsFor with `language_publish_rights: "*"`
+  // already materialized — silently widening publish past the admin's
+  // intent. Only when BOTH verbs are unset (truly pre-#181 user) do we
+  // fall back to legacy, preserving back-compat for unmigrated users.
+  // Mirrors the partner-aware rule in worker/config.ts:rightsFor.
   return {
     userId: data.userId,
     createdAt: data.createdAt,
@@ -138,11 +143,28 @@ export async function validateSession(
     isAdmin: user.isAdmin ?? false,
     isSuperAdmin: user.isSuperAdmin ?? false,
     language_rights: user.language_rights,
-    language_edit_rights: user.language_edit_rights ?? user.language_rights,
-    language_publish_rights:
-      user.language_publish_rights ?? user.language_rights,
+    ...lazyMigrateLanguageRights(user),
     mode_edit_rights: user.mode_edit_rights,
     mode_publish_rights: user.mode_publish_rights,
+  };
+}
+
+// Shared between validateSession and handleLogin so the session shape is
+// identical whether the session is freshly minted or rehydrated from KV.
+function lazyMigrateLanguageRights(user: StoredUser): {
+  language_edit_rights: LanguageRights | undefined;
+  language_publish_rights: LanguageRights | undefined;
+} {
+  const explicitEdit = user.language_edit_rights;
+  const explicitPublish = user.language_publish_rights;
+  const eitherExplicit =
+    explicitEdit !== undefined || explicitPublish !== undefined;
+  // When either verb is explicit, the unset partner is a deliberate
+  // gap (= []); only when both are unset do we fall back to legacy.
+  const fallback = eitherExplicit ? [] : user.language_rights;
+  return {
+    language_edit_rights: explicitEdit ?? fallback,
+    language_publish_rights: explicitPublish ?? fallback,
   };
 }
 
@@ -190,10 +212,9 @@ export async function handleLogin(
   }
 
   const sessionId = crypto.randomUUID();
-  // Same lazy-migration semantics as validateSession — pre-#181 users only
-  // have `language_rights` set; new verb-perms fields fall back to it so
-  // the session created here is shaped identically to one re-hydrated on a
-  // later request.
+  // Same partner-aware lazy migration as validateSession — keeps the
+  // freshly-minted session shape identical to a re-hydrated one so the
+  // worker gate's partner-aware deny isn't bypassed at login time.
   const sessionData: SessionData = {
     userId: user.id,
     email: user.email,
@@ -203,9 +224,7 @@ export async function handleLogin(
     isSuperAdmin: user.isSuperAdmin ?? false,
     createdAt: new Date().toISOString(),
     language_rights: user.language_rights,
-    language_edit_rights: user.language_edit_rights ?? user.language_rights,
-    language_publish_rights:
-      user.language_publish_rights ?? user.language_rights,
+    ...lazyMigrateLanguageRights(user),
     mode_edit_rights: user.mode_edit_rights,
     mode_publish_rights: user.mode_publish_rights,
   };

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -2,17 +2,45 @@ import type { Env } from "./helpers";
 import { errorResponse } from "./helpers";
 import type { LanguageRights, SessionData } from "./types";
 
-// Sole authorization gate for per-language access. Engine is a
-// trusted-portal model (single shared ADMIN_API_TOKEN, no user identity
-// on admin paths), so this check is the only thing standing between a
-// portal user and an engine call. `undefined` is the back-compat default
-// for users predating language_rights — treated as full access.
-function hasLanguageRights(
-  rights: LanguageRights | undefined,
-  name: string
-): boolean {
+// `undefined` is the back-compat default for users predating the rights
+// system (and for fields the worker hasn't lazy-migrated into yet — see
+// worker/auth.ts) — treated as full access. Same rule on the client
+// (src/lib/permissions.ts) so the UI matches the BFF gate.
+function hasRights(rights: LanguageRights | undefined, name: string): boolean {
   if (rights === undefined || rights === "*") return true;
   return rights.includes(name);
+}
+
+type ResourceKind = "language" | "mode";
+type RightsVerb = "edit" | "publish";
+
+function rightsFor(
+  session: SessionData,
+  kind: ResourceKind,
+  verb: RightsVerb
+): LanguageRights | undefined {
+  if (kind === "language") {
+    // Lazy fallback mirrors worker/auth.ts:140-145 exactly — legacy
+    // pre-#181 sessions carry only `language_rights`; verb-perms fall
+    // back to it so existing shepherds keep their access until they're
+    // re-saved through the new dialog. Tests that construct SessionData
+    // directly (skipping auth.ts) get the same semantic.
+    const explicit =
+      verb === "edit"
+        ? session.language_edit_rights
+        : session.language_publish_rights;
+    return explicit ?? session.language_rights;
+  }
+  // Modes: returning `undefined` here would translate to "legacy full
+  // access" via hasRights — which would silently widen a user whose
+  // admin granted, say, mode_edit_rights = ["spoken"] but left
+  // mode_publish_rights unset, into publish-everything. The mode-
+  // baseline gate above catches the truly-legacy (both undefined) case
+  // and returns 403; everywhere downstream, `undefined` for one mode
+  // verb means "no rights for this verb," not legacy full.
+  const own =
+    verb === "edit" ? session.mode_edit_rights : session.mode_publish_rights;
+  return own ?? [];
 }
 
 const UUID_V4_RE =
@@ -26,7 +54,11 @@ async function proxyToEngine(
   request: Request,
   env: Env,
   enginePath: string,
-  allowedMethods: string[]
+  allowedMethods: string[],
+  // Optional pre-parsed body. The verb-perms gate consumes the body to
+  // diff against current state; passing it back in here avoids a
+  // double-read (request bodies are one-shot streams).
+  parsedBody?: unknown
 ): Promise<Response> {
   if (!allowedMethods.includes(request.method)) {
     return errorResponse("Method not allowed", 405);
@@ -39,10 +71,14 @@ async function proxyToEngine(
   let body: string | undefined;
   if (request.method === "PUT" || request.method === "POST") {
     headers["Content-Type"] = "application/json";
-    try {
-      body = JSON.stringify(await request.json());
-    } catch {
-      return errorResponse("Invalid JSON", 400);
+    if (parsedBody !== undefined) {
+      body = JSON.stringify(parsedBody);
+    } else {
+      try {
+        body = JSON.stringify(await request.json());
+      } catch {
+        return errorResponse("Invalid JSON", 400);
+      }
     }
   }
 
@@ -60,6 +96,190 @@ async function proxyToEngine(
 }
 
 // ---------------------------------------------------------------------------
+// Verb-perms gate (#181) — language + mode PUT/DELETE authorization
+// ---------------------------------------------------------------------------
+
+// PUT body shape we diff against current state. Both languages and modes
+// share `document` and `published`; modes additionally carry `label` and
+// `description`. We treat any of those three editorial fields as an edit
+// signal so a future `{label: "new"}` PUT for languages stays on the edit
+// gate even though today's portal only sends `document`.
+interface ResourceShape {
+  document?: string;
+  label?: string;
+  description?: string;
+  published?: boolean;
+}
+
+async function fetchCurrentResource(
+  env: Env,
+  kind: ResourceKind,
+  org: string,
+  name: string
+): Promise<ResourceShape | null> {
+  const enginePath =
+    kind === "language"
+      ? `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(name)}`
+      : `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(name)}`;
+  const res = await fetch(`${env.ENGINE_BASE_URL}${enginePath}`, {
+    headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`Engine fetch failed: ${res.status}`);
+  }
+  const data = (await res.json()) as Record<string, unknown>;
+  // Engine wraps in { org, language|mode: {...} } — mirror of the
+  // unwrap logic in src/lib/languages-api.ts + src/lib/config-api.ts.
+  const wrapped = kind === "language" ? data.language : data.mode;
+  if (wrapped && typeof wrapped === "object") {
+    return wrapped as ResourceShape;
+  }
+  return data as ResourceShape;
+}
+
+// Diff a PUT body against current engine state to determine which verb
+// rights the caller needs. The portal sends the full resource on every
+// PUT — document and published both present even for an autosave that
+// only changed the document — so naive presence-based intent doesn't
+// work. We compare values to compute the actual diff.
+//
+// Creation case (`current === null`): treat any editorial field as an
+// edit, and only require publish if `published: true` is being set
+// (since the engine's create-default is unpublished).
+function computeRequiredVerbsForPut(
+  body: ResourceShape,
+  current: ResourceShape | null
+): RightsVerb[] {
+  const isCreate = current === null;
+  const docChanged =
+    body.document !== undefined &&
+    (isCreate || body.document !== current.document);
+  const labelChanged =
+    body.label !== undefined && (isCreate || body.label !== current.label);
+  const descChanged =
+    body.description !== undefined &&
+    (isCreate || body.description !== current.description);
+  const publishChanged =
+    body.published !== undefined &&
+    (isCreate ? body.published === true : body.published !== current.published);
+
+  const verbs: RightsVerb[] = [];
+  if (docChanged || labelChanged || descChanged) verbs.push("edit");
+  if (publishChanged) verbs.push("publish");
+  return verbs;
+}
+
+// Authorization gate for PUT/DELETE on /api/config/{languages,modes}/{name}.
+// Returns `{ ok: true }` to proceed (with optional `parsedBody` when the
+// gate already consumed it), or `{ error: Response }` to reject.
+//
+// Order of checks (intentionally asymmetric language ↔ mode):
+//   1. crossOrg (super-admin viewing another org's config) — bypass
+//      per-row gates; shepherd rights are home-org-scoped and don't
+//      translate. Same carve-out as the pre-#181 language gate.
+//   2. hasAdminPowers — bypasses the gate FOR MODES ONLY. Pre-#181 the
+//      mode path was admin-only and languages were per-row for everyone
+//      (PR #185 review explicitly assertion: same-org super-admin with
+//      restricted `language_rights` still gets 403 on unauthorized
+//      langs). Preserve that asymmetry — admin doesn't trump per-row
+//      languages, only modes.
+//   3. Mode-baseline gate (modes only) — non-admin with both
+//      mode_*_rights unset → 403, preserving pre-#181 admin-only for
+//      legacy users. Escape by admin-granting at least one explicit
+//      mode verb in the new dialog.
+//   4. Early-deny — if the caller has zero rights on this row across
+//      both verbs, reject before consuming the body. Keeps bodyless
+//      probes (DELETE, GET-with-method-override, malformed PUTs) on
+//      the 403 path rather than a downstream 400.
+//   5. DELETE → requires BOTH edit + publish on the row. Deletion is
+//      strictly more destructive than either alone.
+//   6. PUT → diff body vs current and require the union of verbs the
+//      diff implies (`edit` if any editorial field changed, `publish`
+//      if the published flag flipped).
+async function gateConfigMutation(
+  request: Request,
+  env: Env,
+  session: SessionData,
+  org: string,
+  kind: ResourceKind,
+  name: string,
+  crossOrg: boolean
+): Promise<{ ok: true; parsedBody?: ResourceShape } | { error: Response }> {
+  if (crossOrg) return { ok: true };
+
+  // Admin trumps PER-MODE rights only. Pre-#181, modes were admin-only
+  // and languages were per-row for everyone — including super-admin
+  // shepherds with restricted same-org `language_rights` (PR #185
+  // review). Preserve that asymmetry: a same-org admin doesn't get a
+  // free pass on a language they don't shepherd, but does keep the
+  // legacy "admin can edit any mode" capability.
+  if (kind === "mode" && hasAdminPowers(session)) return { ok: true };
+
+  // Modes had no per-row rights pre-#181 — the gate was admin-only. The
+  // "undefined === legacy full access" rule that languages inherit from
+  // the original per-row `language_rights` field would silently widen
+  // mode access to every non-admin if applied here. Keep the pre-#181
+  // admin-only baseline for any non-admin without an explicit mode
+  // grant; the new dialog must set at least one of mode_edit_rights /
+  // mode_publish_rights to escape this baseline.
+  if (
+    kind === "mode" &&
+    session.mode_edit_rights === undefined &&
+    session.mode_publish_rights === undefined
+  ) {
+    return { error: errorResponse("Forbidden", 403) };
+  }
+
+  // Early-deny: if the caller has zero rights on this row across both
+  // verbs, no PUT diff can let them through. Rejecting before reading
+  // the body keeps the gate side-effect-free in the impossible case and
+  // preserves the pre-#181 same-org "restricted shepherd → 403 on any
+  // unauthorized row" behavior even for bodyless probes.
+  if (
+    !hasRights(rightsFor(session, kind, "edit"), name) &&
+    !hasRights(rightsFor(session, kind, "publish"), name)
+  ) {
+    return { error: errorResponse("Forbidden", 403) };
+  }
+
+  if (request.method === "DELETE") {
+    if (
+      !hasRights(rightsFor(session, kind, "edit"), name) ||
+      !hasRights(rightsFor(session, kind, "publish"), name)
+    ) {
+      return { error: errorResponse("Forbidden", 403) };
+    }
+    return { ok: true };
+  }
+
+  if (request.method === "PUT") {
+    let body: ResourceShape;
+    try {
+      body = (await request.json()) as ResourceShape;
+    } catch {
+      return { error: errorResponse("Invalid JSON", 400) };
+    }
+    let current: ResourceShape | null;
+    try {
+      current = await fetchCurrentResource(env, kind, org, name);
+    } catch {
+      return {
+        error: errorResponse("Upstream error fetching current state", 502),
+      };
+    }
+    for (const verb of computeRequiredVerbsForPut(body, current)) {
+      if (!hasRights(rightsFor(session, kind, verb), name)) {
+        return { error: errorResponse("Forbidden", 403) };
+      }
+    }
+    return { ok: true, parsedBody: body };
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
 // Config route handler
 // ---------------------------------------------------------------------------
 
@@ -73,14 +293,16 @@ function hasAdminPowers(session: SessionData): boolean {
   return session.isAdmin || (session.isSuperAdmin ?? false);
 }
 
-// Mutations on org-wide prompt configuration (modes + prompt-overrides) are
-// admin-only. The trusted-portal model (single shared ADMIN_API_TOKEN
-// upstream, no per-user identity on admin paths) means this worker is the
-// only enforcement point — without this gate, any authenticated user in the
-// org could rewrite or delete the org's modes via direct fetch. GET stays
-// open because non-admins need to read modes for the test-chat / trigger
-// lookup, and prompt-overrides GET carries no sensitive data beyond the
-// org's prompt configuration.
+// Mutations on org-wide prompt-overrides are admin-only. The trusted-portal
+// model (single shared ADMIN_API_TOKEN upstream, no per-user identity on
+// admin paths) means this worker is the only enforcement point — without
+// this gate, any authenticated user in the org could rewrite or delete the
+// org's prompt-overrides via direct fetch. GET stays open because the
+// payload carries no sensitive data beyond the org's prompt configuration.
+//
+// Modes used to share this gate but now have their own per-mode verb-perms
+// gate (gateConfigMutation), so non-admin mode shepherds can edit/publish
+// modes they hold rights on.
 function isAdminMutation(method: string, session: SessionData): boolean {
   return (method === "PUT" || method === "DELETE") && !hasAdminPowers(session);
 }
@@ -147,13 +369,30 @@ export async function handleConfig(
     );
   }
 
-  // /api/config/modes/{name} → GET (any session) / PUT/DELETE (admin)
+  // /api/config/modes/{name} → GET (any session) / PUT/DELETE (per-mode
+  // verb-perms, admin-trump)
   const modeMatch = pathname.match(/^\/api\/config\/modes\/(.+)$/);
   if (modeMatch?.[1]) {
-    if (isAdminMutation(request.method, session)) {
-      return errorResponse("Forbidden", 403);
-    }
     const modeName = decodeURIComponent(modeMatch[1]);
+    if (request.method === "PUT" || request.method === "DELETE") {
+      const gate = await gateConfigMutation(
+        request,
+        env,
+        session,
+        resolved.org,
+        "mode",
+        modeName,
+        resolved.crossOrg
+      );
+      if ("error" in gate) return gate.error;
+      return proxyToEngine(
+        request,
+        env,
+        `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}`,
+        ["GET", "PUT", "DELETE"],
+        gate.parsedBody
+      );
+    }
     return proxyToEngine(
       request,
       env,
@@ -162,15 +401,29 @@ export async function handleConfig(
     );
   }
 
-  // /api/config/languages/{name} → GET/PUT/DELETE
+  // /api/config/languages/{name} → GET / PUT / DELETE
+  // (per-language verb-perms, admin-trump, super-admin cross-org bypass)
   const languageMatch = pathname.match(/^\/api\/config\/languages\/(.+)$/);
   if (languageMatch?.[1]) {
     const languageName = decodeURIComponent(languageMatch[1]);
-    if (
-      !resolved.crossOrg &&
-      !hasLanguageRights(session.language_rights, languageName)
-    ) {
-      return errorResponse("Forbidden", 403);
+    if (request.method === "PUT" || request.method === "DELETE") {
+      const gate = await gateConfigMutation(
+        request,
+        env,
+        session,
+        resolved.org,
+        "language",
+        languageName,
+        resolved.crossOrg
+      );
+      if ("error" in gate) return gate.error;
+      return proxyToEngine(
+        request,
+        env,
+        `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(languageName)}`,
+        ["GET", "PUT", "DELETE"],
+        gate.parsedBody
+      );
     }
     return proxyToEngine(
       request,
@@ -239,3 +492,12 @@ export async function handleConfig(
 
   return errorResponse("Not found", 404);
 }
+
+// Exported for unit tests in tests/config-verb-perms.test.ts. Internal use
+// of these helpers stays inside this module; no other production caller
+// should reach into them.
+export const __testInternals = {
+  computeRequiredVerbsForPut,
+  hasRights,
+  rightsFor,
+};

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -20,21 +20,30 @@ function rightsFor(
   verb: RightsVerb
 ): LanguageRights | undefined {
   if (kind === "language") {
-    // Lazy fallback mirrors worker/auth.ts:140-145 exactly — legacy
-    // pre-#181 sessions carry only `language_rights`; verb-perms fall
-    // back to it so existing shepherds keep their access until they're
-    // re-saved through the new dialog. Tests that construct SessionData
-    // directly (skipping auth.ts) get the same semantic.
     const explicit =
       verb === "edit"
         ? session.language_edit_rights
         : session.language_publish_rights;
-    return explicit ?? session.language_rights;
+    if (explicit !== undefined) return explicit;
+    // Partner-aware deny: if the OTHER verb is explicit, this verb's
+    // unset state is a deliberate gap, not legacy-full. Without this,
+    // an admin who grants `language_edit_rights = ["spanish"]` and
+    // leaves `language_publish_rights` unset would silently give the
+    // user full publish access (undefined → legacy full via the
+    // pre-#181 hasRights rule) — the opposite of what the dialog UI
+    // signals. Only when BOTH verbs are unset do we fall back to the
+    // legacy `language_rights` bit (worker/auth.ts lazy migration
+    // mirror — preserves access for pre-#181 shepherds until they're
+    // re-saved through the new dialog).
+    const partner =
+      verb === "edit"
+        ? session.language_publish_rights
+        : session.language_edit_rights;
+    if (partner !== undefined) return [];
+    return session.language_rights;
   }
   // Modes: returning `undefined` here would translate to "legacy full
-  // access" via hasRights — which would silently widen a user whose
-  // admin granted, say, mode_edit_rights = ["spoken"] but left
-  // mode_publish_rights unset, into publish-everything. The mode-
+  // access" via hasRights — same partner-aware footgun. The mode-
   // baseline gate above catches the truly-legacy (both undefined) case
   // and returns 403; everywhere downstream, `undefined` for one mode
   // verb means "no rights for this verb," not legacy full.
@@ -124,9 +133,18 @@ async function fetchCurrentResource(
   const res = await fetch(`${env.ENGINE_BASE_URL}${enginePath}`, {
     headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` },
   });
-  if (res.status === 404) return null;
   if (!res.ok) {
-    throw new Error(`Engine fetch failed: ${res.status}`);
+    // 404 → resource doesn't exist yet (creation). Any other non-2xx
+    // (auth, 5xx, network blip): treat as null too so the gate falls
+    // through to creation semantics. The downstream proxy PUT will
+    // fail naturally if engine is genuinely down — duplicating the
+    // failure mode at the gate makes verb-restricted shepherds the
+    // first to lose autosave during transient engine flakiness for no
+    // security benefit. Creation semantics demand at minimum edit on
+    // any editorial field and publish on `published: true`, so the
+    // fall-through is conservative (stricter, not laxer) than the
+    // diff path would have produced.
+    return null;
   }
   const data = (await res.json()) as Record<string, unknown>;
   // Engine wraps in { org, language|mode: {...} } — mirror of the
@@ -152,6 +170,11 @@ function computeRequiredVerbsForPut(
   current: ResourceShape | null
 ): RightsVerb[] {
   const isCreate = current === null;
+  // Engine rows predating the `published` field may omit it on read.
+  // Coerce undefined → false so an edit-only autosave that sends
+  // `published: false` against such a row doesn't spuriously demand
+  // publish rights (false !== undefined would otherwise trigger).
+  const currentPublished = current?.published ?? false;
   const docChanged =
     body.document !== undefined &&
     (isCreate || body.document !== current.document);
@@ -162,7 +185,7 @@ function computeRequiredVerbsForPut(
     (isCreate || body.description !== current.description);
   const publishChanged =
     body.published !== undefined &&
-    (isCreate ? body.published === true : body.published !== current.published);
+    (isCreate ? body.published === true : body.published !== currentPublished);
 
   const verbs: RightsVerb[] = [];
   if (docChanged || labelChanged || descChanged) verbs.push("edit");
@@ -260,14 +283,11 @@ async function gateConfigMutation(
     } catch {
       return { error: errorResponse("Invalid JSON", 400) };
     }
-    let current: ResourceShape | null;
-    try {
-      current = await fetchCurrentResource(env, kind, org, name);
-    } catch {
-      return {
-        error: errorResponse("Upstream error fetching current state", 502),
-      };
-    }
+    // `fetchCurrentResource` returns null for any engine non-2xx
+    // (including 5xx / network errors) — the gate then treats the PUT
+    // as a creation, which is conservative (every editorial field
+    // present demands edit; published: true demands publish).
+    const current = await fetchCurrentResource(env, kind, org, name);
     for (const verb of computeRequiredVerbsForPut(body, current)) {
       if (!hasRights(rightsFor(session, kind, verb), name)) {
         return { error: errorResponse("Forbidden", 403) };


### PR DESCRIPTION
## Summary

PR 2 of the verb-based permissions design [locked 2026-06-24](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/181#issuecomment-4791780928) (PR 1 / #234 shipped the schema + lazy migration). This commit makes the new `*_edit_rights` / `*_publish_rights` fields load-bearing end-to-end.

- **BFF gate** in `worker/config.ts` (`gateConfigMutation`): diffs PUT bodies against the engine's current state (the portal sends the full state on every PUT, so presence isn't a discriminator) and demands the union of verbs the diff implies. DELETE requires both verbs. Order of checks is intentionally asymmetric: cross-org super-admin bypasses everything; admin trumps per-row **for MODES ONLY** (preserves pre-#181 "admin can edit all modes" while keeping the per-language same-org gate intact per PR #185).
- **4-selector dialog**: `language-rights-selector.tsx` → `rights-selector.tsx`, parameterized over `kind` ∈ {language, mode} and `verb` ∈ {edit, publish}. Both admin dialogs render four selectors and persist each verb-perm field explicitly so the `undefined ⇒ legacy full access` fallback can't silently widen scope on newly-granted users.
- **Footgun guard**: in `worker/config.ts:rightsFor`, `undefined` for a mode verb past the baseline always means "deny" (not legacy full). Without this, an admin who granted `mode_edit_rights = [\"spoken\"]` but left `mode_publish_rights` unset would accidentally inherit publish-everything.

## Reviewer notes

- **No engine changes required** — all four verb-perms live entirely in the BFF (`worker/types.ts`).
- **Asymmetric admin-trump is deliberate**, not a memo misread. The pre-#181 language gate at `worker/config.ts:171` applied per-row to everyone including super-admins (the same-org tests at `tests/config-authz.test.ts:447-510` were added by Frank in PR #185 review precisely to lock this). Preserving that asymmetry costs nothing semantically and avoids a real regression on restricted-shepherd-with-isAdmin patterns.
- **Two fetches per non-admin same-org language PUT** (gate's GET-current + proxy). One extra round-trip per write on these surfaces, which are low-rate (editor autosaves). The spy helper was updated to `mockImplementation` so each call returns a fresh `Response` (the prior single-instance return disturbed the body stream).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 336 / 336 passing (+43 new)

### New worker enforcement tests (16) covering the matrix from the locked memo:

- edit-only PUT with edit rights only → 200
- edit-only PUT without edit rights → 403
- publish-only PUT with publish rights only → 200
- publish-only PUT without publish rights → 403
- PUT changing both needs both rights → 403 when one missing, 200 when both
- legacy `language_rights = [\"spanish\"]` falls back to both verbs
- creation (404 current) needs edit rights; needs both if `published: true`
- DELETE requires both edit + publish rights
- mode non-admin without explicit grants → 403 (pre-#181 baseline preserved)
- mode admin trump (mirrors pre-#181 admin-can-edit-all-modes)
- mode footgun guard (unset publish doesn't fall through to legacy full)
- mode label/description changes trigger edit gate

### Pure-function unit tests (10) for `computeRequiredVerbsForPut`:

document-only / publish-only / both / no-op / create / create-with-publish-true / label-only / description-only / partial body.

### Permissions helper tests for the new union helpers.

Closes #181