### PR TITLE
feat(modes): rename/reslug modes in place without stranding users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-admin-portal",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -26,6 +26,7 @@ import {
   useDeleteMode,
   useMode,
   useModes,
+  useRenameMode,
   useSaveMode,
 } from "@/hooks/use-prompt-config";
 import type { MarkdownHeading } from "@/types/markdown";
@@ -79,6 +80,7 @@ export function ModesPage() {
   const modeQuery = useMode(selectedMode, contextOrg);
   const saveMode = useSaveMode(contextOrg);
   const deleteMode = useDeleteMode(contextOrg);
+  const renameMode = useRenameMode(contextOrg);
 
   // Filter modes to those the user has any verb on (admin/cross-org
   // sees everything via the `*` short-circuit above). Mirrors
@@ -104,6 +106,9 @@ export function ModesPage() {
   const canPublishSelected =
     selectedMode !== null && hasRights(modePublishRights, selectedMode);
   const canDeleteSelected = canEditSelected && canPublishSelected;
+  // Rename reslugs a published mode's identity — gate it as strictly as
+  // delete (both verbs). Mirrors the worker's edit+publish gate (#232).
+  const canRenameSelected = canEditSelected && canPublishSelected;
 
   // Local document draft (auto-save target).
   //
@@ -382,6 +387,17 @@ export function ModesPage() {
     [deleteMode, selectedMode, setSelectedMode]
   );
 
+  const handleRenameMode = useCallback(
+    async (name: string, newName: string) => {
+      await renameMode.mutateAsync({ name, newName });
+      // Follow the selection to the new slug so the editor re-syncs the
+      // doc under the renamed identity instead of orphaning on the old
+      // (now alias-only) name.
+      if (name === selectedMode) setSelectedMode(newName);
+    },
+    [renameMode, selectedMode, setSelectedMode]
+  );
+
   const handleJumpToLine = useCallback((line: number) => {
     editorRef.current?.jumpToLine(line);
   }, []);
@@ -391,7 +407,7 @@ export function ModesPage() {
 
   const error =
     modesQuery.error || (selectedMode !== null ? modeQuery.error : null);
-  const saveError = saveMode.error ?? deleteMode.error;
+  const saveError = saveMode.error ?? deleteMode.error ?? renameMode.error;
 
   const saveStatus = useMemo(() => {
     if (isSaving) return "Saving…";
@@ -419,14 +435,22 @@ export function ModesPage() {
               onCreateMode={handleCreateMode}
               onDeleteMode={handleDeleteMode}
               onSetPublished={handleSetPublished}
+              onRenameMode={handleRenameMode}
               isCreating={saveMode.isPending}
               isDeleting={deleteMode.isPending}
+              isRenaming={renameMode.isPending}
               isSettingPublished={saveMode.isPending}
               showDrafts={showDrafts}
               onToggleShowDrafts={setShowDrafts}
               canCreate={canCreate}
               canPublishSelected={canPublishSelected}
               canDeleteSelected={canDeleteSelected}
+              canRenameSelected={canRenameSelected}
+              renameDisabledReason={
+                isDirty || isSaving
+                  ? "Save your changes before renaming."
+                  : null
+              }
             />
           </div>
 

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -106,9 +106,11 @@ export function ModesPage() {
   const canPublishSelected =
     selectedMode !== null && hasRights(modePublishRights, selectedMode);
   const canDeleteSelected = canEditSelected && canPublishSelected;
-  // Rename reslugs a published mode's identity — gate it as strictly as
-  // delete (both verbs). Mirrors the worker's edit+publish gate (#232).
-  const canRenameSelected = canEditSelected && canPublishSelected;
+  // Rename is admin/cross-org only (#238 review). Per-user mode rights are
+  // slug-scoped, so a non-admin shepherd renaming a mode would lock
+  // themselves out of the renamed slug. Mirror the worker gate, which
+  // 403s any non-admin same-org rename.
+  const canRenameSelected = isAdmin || isCrossOrg;
 
   // Local document draft (auto-save target).
   //

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -1,7 +1,15 @@
 import { useCallback, useState } from "react";
 import { faLayerGroup } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Eye, EyeOff, Plus, Send, SendHorizontal, Trash2 } from "lucide-react";
+import {
+  Eye,
+  EyeOff,
+  Pencil,
+  Plus,
+  Send,
+  SendHorizontal,
+  Trash2,
+} from "lucide-react";
 
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import type { OrgModes, PromptMode } from "@/types/prompt-override";
@@ -38,8 +46,12 @@ interface ModeSelectorProps {
       and stay open so the user can read it (#102). */
   onDeleteMode: (name: string) => Promise<void>;
   onSetPublished: (name: string, published: boolean) => Promise<void>;
+  /** Reslug a mode in place (#232). Like onDeleteMode, must reject on
+      error so the rename dialog can surface it inline and stay open. */
+  onRenameMode: (name: string, newName: string) => Promise<void>;
   isCreating: boolean;
   isDeleting: boolean;
+  isRenaming: boolean;
   isSettingPublished: boolean;
   showDrafts: boolean;
   onToggleShowDrafts: (showDrafts: boolean) => void;
@@ -51,10 +63,28 @@ interface ModeSelectorProps {
   canCreate: boolean;
   canPublishSelected: boolean;
   canDeleteSelected: boolean;
+  canRenameSelected: boolean;
+  /** Non-null disables the Rename trigger and shows the string as its
+      tooltip — used to block rename while the editor has unsaved edits
+      (renaming re-syncs the doc under the new slug and would drop them). */
+  renameDisabledReason: string | null;
 }
 
 function isPublished(mode: Pick<PromptMode, "published">): boolean {
   return mode.published === true;
+}
+
+// Canonical mode-slug normalization, shared by the create and rename
+// flows: lowercase, spaces → hyphens, drop anything outside
+// [a-z0-9-_], trim leading/trailing hyphens. The engine validates the
+// result again server-side.
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9\-_]/g, "")
+    .replace(/^-+|-+$/g, "");
 }
 
 export function ModeSelector({
@@ -64,14 +94,18 @@ export function ModeSelector({
   onCreateMode,
   onDeleteMode,
   onSetPublished,
+  onRenameMode,
   isCreating,
   isDeleting,
+  isRenaming,
   isSettingPublished,
   showDrafts,
   onToggleShowDrafts,
   canCreate,
   canPublishSelected,
   canDeleteSelected,
+  canRenameSelected,
+  renameDisabledReason,
 }: ModeSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -86,6 +120,9 @@ export function ModeSelector({
   const [unpublishError, setUnpublishError] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
 
   const handleConfirmUnpublish = useCallback(() => {
     if (selectedMode === null) return;
@@ -107,6 +144,28 @@ export function ModeSelector({
     );
   }, [onDeleteMode, selectedMode]);
 
+  const handleConfirmRename = useCallback(() => {
+    if (selectedMode === null) return;
+    const slug = slugify(renameValue);
+    if (!slug) {
+      setRenameError("Enter a valid name (letters, numbers, hyphens).");
+      return;
+    }
+    if (slug === selectedMode) {
+      setRenameError("New name must differ from the current name.");
+      return;
+    }
+    return runConfirmedAction(
+      () => onRenameMode(selectedMode, slug),
+      setRenameError,
+      () => {
+        setRenameOpen(false);
+        setRenameValue("");
+      },
+      "Failed to rename mode."
+    );
+  }, [onRenameMode, renameValue, selectedMode]);
+
   const modes = modesData?.modes ?? [];
   const selectedModeData = modes.find((m) => m.name === selectedMode) ?? null;
   const selectedIsPublished = selectedModeData
@@ -120,12 +179,7 @@ export function ModeSelector({
   );
 
   const handleCreate = useCallback(() => {
-    const slug = newName
-      .trim()
-      .toLowerCase()
-      .replace(/\s+/g, "-")
-      .replace(/[^a-z0-9\-_]/g, "")
-      .replace(/^-+|-+$/g, "");
+    const slug = slugify(newName);
     if (!slug) return;
     onCreateMode(slug, newLabel.trim(), newDescription.trim());
     setNewName("");
@@ -276,6 +330,78 @@ export function ModeSelector({
                   Publish
                 </Button>
               ))}
+
+            {canRenameSelected && (
+              <AlertDialog
+                open={renameOpen}
+                onOpenChange={(next) => {
+                  setRenameOpen(next);
+                  if (next) {
+                    // Prefill with the current slug so the user edits
+                    // from it rather than retyping; clear stale errors.
+                    setRenameValue(selectedMode);
+                    setRenameError(null);
+                  } else {
+                    setRenameError(null);
+                    setRenameValue("");
+                  }
+                }}
+              >
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={isRenaming || renameDisabledReason !== null}
+                    title={renameDisabledReason ?? undefined}
+                  >
+                    <Pencil className="mr-1.5 size-3.5" />
+                    Rename
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Rename mode</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Change the slug for{" "}
+                      <span className="text-foreground font-medium">
+                        &ldquo;{selectedMode}&rdquo;
+                      </span>
+                      . Existing users stay assigned &mdash; the old name keeps
+                      working as an alias, so no one is left without a mode.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="mode-rename" className="text-xs">
+                      New name (slug)
+                    </Label>
+                    <Input
+                      id="mode-rename"
+                      value={renameValue}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      placeholder="e.g. conversation"
+                      className="h-8 text-sm"
+                    />
+                  </div>
+                  {renameError && (
+                    <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                      {renameError}
+                    </p>
+                  )}
+                  <AlertDialogFooter>
+                    <AlertDialogCancel disabled={isRenaming}>
+                      Cancel
+                    </AlertDialogCancel>
+                    {/* Plain Button — see comment in Unpublish dialog above. */}
+                    <Button
+                      onClick={handleConfirmRename}
+                      disabled={isRenaming || !renameValue.trim()}
+                    >
+                      {isRenaming ? "Renaming…" : "Rename"}
+                    </Button>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
 
             {canDeleteSelected && (
               <AlertDialog

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -1,7 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import * as configApi from "@/lib/config-api";
-import type { PromptOverrides } from "@/types/prompt-override";
+import type {
+  OrgModes,
+  PromptMode,
+  PromptOverrides,
+} from "@/types/prompt-override";
 
 // ---------------------------------------------------------------------------
 // Query keys
@@ -108,17 +112,45 @@ export function useDeleteMode(org?: string | null) {
   });
 }
 
-// Reslug a mode in place (#232). Invalidate the list plus BOTH the old and
-// new per-mode caches: the old slug's entry is now stale (the engine keeps
-// it only as an alias), and the new slug needs a fresh fetch so the editor
-// re-syncs under the renamed identity.
+// Swap the old-slug entry for the renamed mode in a cached modes list.
+// Exported for unit tests. Returns `prev` untouched when nothing is cached
+// yet (`undefined`) or the old slug isn't present, so an optimistic write
+// never fabricates a list.
+export function applyRenameToModeList(
+  prev: OrgModes | undefined,
+  oldName: string,
+  renamed: PromptMode
+): OrgModes | undefined {
+  if (!prev) return prev;
+  return {
+    ...prev,
+    modes: prev.modes.map((m) => (m.name === oldName ? renamed : m)),
+  };
+}
+
+// Reslug a mode in place (#232). Two-part cache update:
+//
+//  1. Synchronously swap the old-slug entry for the returned renamed mode
+//     in the LIST cache. The page selects the new slug immediately after
+//     this mutation resolves (`setSelectedMode(newName)` in modes.tsx);
+//     without this optimistic write the list still holds the old slug in
+//     the render gap before the refetch lands, and the stale-selection
+//     guard there (`modes.tsx`) would see `newName` missing and null the
+//     selection — dropping the user into "no mode" right after a
+//     successful rename.
+//  2. Invalidate the list and BOTH per-mode caches so the optimistic
+//     entry is reconciled with server truth (e.g. fresh `aliases`) and
+//     the old slug's now-stale entry is dropped.
 export function useRenameMode(org?: string | null) {
   const qc = useQueryClient();
   const key = normalize(org);
   return useMutation({
     mutationFn: ({ name, newName }: { name: string; newName: string }) =>
       configApi.renameMode(name, newName, undefined, key),
-    onSuccess: (_data, { name, newName }) => {
+    onSuccess: (data, { name, newName }) => {
+      qc.setQueryData<OrgModes>(keys.modes(key), (prev) =>
+        applyRenameToModeList(prev, name, data)
+      );
       void qc.invalidateQueries({ queryKey: keys.modes(key) });
       void qc.invalidateQueries({ queryKey: keys.mode(name, key) });
       void qc.invalidateQueries({ queryKey: keys.mode(newName, key) });

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -108,6 +108,24 @@ export function useDeleteMode(org?: string | null) {
   });
 }
 
+// Reslug a mode in place (#232). Invalidate the list plus BOTH the old and
+// new per-mode caches: the old slug's entry is now stale (the engine keeps
+// it only as an alias), and the new slug needs a fresh fetch so the editor
+// re-syncs under the renamed identity.
+export function useRenameMode(org?: string | null) {
+  const qc = useQueryClient();
+  const key = normalize(org);
+  return useMutation({
+    mutationFn: ({ name, newName }: { name: string; newName: string }) =>
+      configApi.renameMode(name, newName, undefined, key),
+    onSuccess: (_data, { name, newName }) => {
+      void qc.invalidateQueries({ queryKey: keys.modes(key) });
+      void qc.invalidateQueries({ queryKey: keys.mode(name, key) });
+      void qc.invalidateQueries({ queryKey: keys.mode(newName, key) });
+    },
+  });
+}
+
 export function useSetUserMode(org?: string | null) {
   const key = normalize(org);
   return useMutation({

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -189,6 +189,55 @@ export async function deleteMode(
   }
 }
 
+// Engine mode-op endpoints (`_rename`) reject with a JSON `{ error }` body
+// (validation 400 / not-found 404 / slug-collision 409). Surface that
+// message rather than the raw `{"error":"…"}` blob so the rename dialog can
+// show e.g. "Mode 'x' already exists" inline. Falls back to plain text for
+// non-JSON error bodies.
+async function readModeOpError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => "");
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown };
+    if (typeof parsed.error === "string") return parsed.error;
+  } catch {
+    // Body wasn't JSON — fall through to the raw text.
+  }
+  return text;
+}
+
+// Reslug a mode in place via the engine's `_rename` op (#232). The engine
+// preserves the old slug as an alias so users already assigned to the mode
+// keep resolving — no one is stranded in "no mode". Returns the renamed
+// mode (new canonical `name`). The worker BFF gates this on edit+publish.
+export async function renameMode(
+  name: string,
+  newName: string,
+  signal?: AbortSignal,
+  org?: string | null
+): Promise<PromptMode> {
+  const res = await fetch(
+    buildConfigUrl(
+      `/api/config/modes/${encodeURIComponent(name)}/_rename`,
+      org
+    ),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+      body: JSON.stringify({ newName }),
+      signal,
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to rename mode (${res.status}): ${await readModeOpError(res)}`
+    );
+  }
+
+  // Same `{ org, mode, message }` envelope as putMode/getMode.
+  return unwrapModeResponse((await res.json()) as Record<string, unknown>);
+}
+
 // ---------------------------------------------------------------------------
 // Per-user memory
 // ---------------------------------------------------------------------------

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -10,6 +10,7 @@ import {
   listModes,
   putMode,
   putOrgOverrides,
+  renameMode,
   setUserMode,
 } from "../src/lib/config-api";
 
@@ -316,6 +317,72 @@ describe("deleteMode", () => {
     mockFetchOnce(404, "Mode not found");
     await expect(deleteMode("missing")).rejects.toThrow(
       /Failed to delete mode \(404\): Mode not found/
+    );
+  });
+});
+
+describe("renameMode", () => {
+  it("POSTs `{ newName }` to the _rename endpoint and unwraps the envelope", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          org: "uw",
+          mode: { name: "conversation", document: "## Identity\n" },
+          message: "Mode renamed",
+        }),
+        { status: 200 }
+      )
+    );
+    const result = await renameMode("spoken", "conversation");
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/spoken/_rename");
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      newName: "conversation",
+    });
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json"
+    );
+    // Returns the renamed mode (new canonical name), envelope unwrapped.
+    expect(result.name).toBe("conversation");
+  });
+
+  it("URL-encodes the source mode name in the path", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "new", document: "" } }))
+      );
+    await renameMode("kids mode", "new");
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/kids%20mode/_rename");
+  });
+
+  it("surfaces the engine's JSON `{ error }` message on a slug collision", async () => {
+    // The engine rejects a colliding/invalid new slug with `{ error }` JSON
+    // (409/400). The dialog shows this inline, so the message must be the
+    // engine string — not the raw `{"error":"…"}` blob.
+    mockFetchOnce(409, { error: "Mode 'conversation' already exists" });
+    await expect(renameMode("spoken", "conversation")).rejects.toThrow(
+      /Failed to rename mode \(409\): Mode 'conversation' already exists/
+    );
+  });
+
+  it("falls back to raw text when the error body isn't JSON", async () => {
+    mockFetchOnce(500, "upstream boom");
+    await expect(renameMode("spoken", "conversation")).rejects.toThrow(
+      /Failed to rename mode \(500\): upstream boom/
+    );
+  });
+
+  it("threads org through as ?org=", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "new", document: "" } }))
+      );
+    await renameMode("spoken", "new", undefined, "word-collective");
+    expect(spy.mock.calls[0]![0]).toBe(
+      "/api/config/modes/spoken/_rename?org=word-collective"
     );
   });
 });

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -814,6 +814,132 @@ describe("config authz — #181 verb-perms (modes)", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #232 mode rename — POST /api/config/modes/{name}/_rename
+// ---------------------------------------------------------------------------
+//
+// Rename reslugs a mode's canonical identity in place (the engine keeps the
+// old slug as an alias so assigned users aren't stranded). The BFF gates it
+// on BOTH edit + publish — as destructive as DELETE — and proxies the POST
+// (with its `{ newName }` body) to the engine `_rename` op. The dedicated
+// route must be matched before the generic `modes/{name}` route, which would
+// otherwise swallow `{name}/_rename` and 405 the POST.
+
+function makeRenameRequest(name: string, newName: string): Request {
+  return new Request(
+    `https://portal.example.test/api/config/modes/${name}/_rename`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ newName }),
+    }
+  );
+}
+
+describe("config authz — #232 mode rename (_rename)", () => {
+  it("admin → proxies POST to engine _rename path", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("POST");
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/modes/spoken/_rename"
+    );
+  });
+
+  it("super admin without isAdmin → proxies (super trumps isAdmin)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-admin without any explicit mode rights → 403 (baseline, no proxy)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: false }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-admin with edit only → 403 (publish missing, like DELETE)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ mode_edit_rights: ["spoken"] }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-admin with publish only → 403 (edit missing)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ mode_edit_rights: [], mode_publish_rights: ["spoken"] }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-admin with BOTH edit+publish on the row → proxies POST", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("POST");
+  });
+
+  it("super-admin cross-org via ?org=other → proxies to /orgs/other/.../_rename", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_rename?org=word-collective",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ newName: "conversation" }),
+        }
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/modes/spoken/_rename"
+    );
+  });
+});
+
 describe("config authz — #181 verb diff (pure function)", () => {
   const { computeRequiredVerbsForPut } = __testInternals;
 

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -819,11 +819,13 @@ describe("config authz — #181 verb-perms (modes)", () => {
 // ---------------------------------------------------------------------------
 //
 // Rename reslugs a mode's canonical identity in place (the engine keeps the
-// old slug as an alias so assigned users aren't stranded). The BFF gates it
-// on BOTH edit + publish — as destructive as DELETE — and proxies the POST
-// (with its `{ newName }` body) to the engine `_rename` op. The dedicated
-// route must be matched before the generic `modes/{name}` route, which would
-// otherwise swallow `{name}/_rename` and 405 the POST.
+// old slug as an alias so assigned users aren't stranded). The BFF restricts
+// it to admins + super-admin cross-org and proxies the POST (with its
+// `{ newName }` body) to the engine `_rename` op. Non-admin shepherds are
+// blocked even with full per-row rights: their mode rights are slug-scoped
+// and a rename would lock them out of the renamed slug (#238 review). The
+// dedicated route must be matched before the generic `modes/{name}` route,
+// which would otherwise swallow `{name}/_rename` and 405 the POST.
 
 function makeRenameRequest(name: string, newName: string): Request {
   return new Request(
@@ -877,31 +879,10 @@ describe("config authz — #232 mode rename (_rename)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("non-admin with edit only → 403 (publish missing, like DELETE)", async () => {
-    const fetchSpy = spyFetch();
-    const res = await handleConfig(
-      makeRenameRequest("spoken", "conversation"),
-      env,
-      makeSession({ mode_edit_rights: ["spoken"] }),
-      "/api/config/modes/spoken/_rename"
-    );
-    expect(res.status).toBe(403);
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it("non-admin with publish only → 403 (edit missing)", async () => {
-    const fetchSpy = spyFetch();
-    const res = await handleConfig(
-      makeRenameRequest("spoken", "conversation"),
-      env,
-      makeSession({ mode_edit_rights: [], mode_publish_rights: ["spoken"] }),
-      "/api/config/modes/spoken/_rename"
-    );
-    expect(res.status).toBe(403);
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it("non-admin with BOTH edit+publish on the row → proxies POST", async () => {
+  it("non-admin with BOTH edit+publish on the row → 403 (rename is admin-only)", async () => {
+    // The crux of the #238 review: full per-row rights are NOT enough.
+    // Mode rights are slug-scoped, so letting a shepherd rename would lock
+    // them out of the renamed slug. Only admins/cross-org may rename.
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
@@ -912,9 +893,8 @@ describe("config authz — #232 mode rename (_rename)", () => {
       }),
       "/api/config/modes/spoken/_rename"
     );
-    expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("POST");
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("super-admin cross-org via ?org=other → proxies to /orgs/other/.../_rename", async () => {

--- a/tests/use-prompt-config.test.ts
+++ b/tests/use-prompt-config.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { applyRenameToModeList } from "../src/hooks/use-prompt-config";
+import type { OrgModes, PromptMode } from "../src/types/prompt-override";
+
+// Regression for the #232 review (PR #238): after a successful rename the
+// page selects the new slug immediately. The list cache must already carry
+// that slug or the stale-selection guard in modes.tsx nulls the selection
+// in the render gap before the refetch lands. applyRenameToModeList is the
+// optimistic write that closes that gap.
+
+const renamed: PromptMode = {
+  name: "conversation",
+  label: "Conversation",
+  document: "## Identity\n",
+  published: true,
+};
+
+describe("applyRenameToModeList", () => {
+  it("replaces the old slug with the renamed mode (new slug present, old gone)", () => {
+    const prev: OrgModes = {
+      modes: [
+        { name: "spoken", document: "## Identity\n", published: true },
+        { name: "written", document: "## Identity\n", published: false },
+      ],
+    };
+
+    const next = applyRenameToModeList(prev, "spoken", renamed);
+
+    const names = next!.modes.map((m) => m.name);
+    expect(names).toContain("conversation");
+    expect(names).not.toContain("spoken");
+    // Position is preserved (in-place swap, not append).
+    expect(names).toEqual(["conversation", "written"]);
+  });
+
+  it("leaves other modes untouched", () => {
+    const written: PromptMode = {
+      name: "written",
+      document: "## Identity\n",
+      published: false,
+    };
+    const prev: OrgModes = {
+      modes: [{ name: "spoken", document: "x", published: true }, written],
+    };
+
+    const next = applyRenameToModeList(prev, "spoken", renamed);
+
+    expect(next!.modes[1]).toBe(written);
+  });
+
+  it("returns undefined unchanged when nothing is cached yet", () => {
+    expect(applyRenameToModeList(undefined, "spoken", renamed)).toBeUndefined();
+  });
+
+  it("is a no-op when the old slug isn't in the list (no fabrication)", () => {
+    const prev: OrgModes = {
+      modes: [{ name: "written", document: "x", published: false }],
+    };
+
+    const next = applyRenameToModeList(prev, "spoken", renamed);
+
+    expect(next!.modes.map((m) => m.name)).toEqual(["written"]);
+  });
+});

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -215,8 +215,10 @@ function computeRequiredVerbsForPut(
 //      both verbs, reject before consuming the body. Keeps bodyless
 //      probes (DELETE, GET-with-method-override, malformed PUTs) on
 //      the 403 path rather than a downstream 400.
-//   5. DELETE → requires BOTH edit + publish on the row. Deletion is
-//      strictly more destructive than either alone.
+//   5. DELETE / POST → requires BOTH edit + publish on the row. Deletion
+//      is strictly more destructive than either alone; POST is the
+//      mode `_rename` op (#232), which reslugs a mode's canonical
+//      identity — gated as destructively as deletion.
 //   6. PUT → diff body vs current and require the union of verbs the
 //      diff implies (`edit` if any editorial field changed, `publish`
 //      if the published flag flipped).
@@ -266,7 +268,11 @@ async function gateConfigMutation(
     return { error: errorResponse("Forbidden", 403) };
   }
 
-  if (request.method === "DELETE") {
+  // DELETE and POST (mode `_rename`, #232) both require the full
+  // edit+publish pair. The gate never consumes the body on these paths,
+  // so the downstream proxy reads the `_rename` `{ newName }` payload
+  // intact.
+  if (request.method === "DELETE" || request.method === "POST") {
     if (
       !hasRights(rightsFor(session, kind, "edit"), name) ||
       !hasRights(rightsFor(session, kind, "publish"), name)
@@ -386,6 +392,35 @@ export async function handleConfig(
       env,
       `/api/v1/admin/orgs/${org}/prompt-overrides`,
       ["GET", "PUT", "DELETE"]
+    );
+  }
+
+  // /api/config/modes/{name}/_rename → POST (per-mode verb-perms,
+  // both edit+publish, admin-trump). Matched BEFORE the generic mode
+  // route below — the `(.+)` there would otherwise capture
+  // `{name}/_rename` as the mode name and reject POST as 405. The
+  // engine (#232) reslugs the mode in place and keeps the old slug as
+  // an alias so existing user assignments aren't stranded.
+  const modeRenameMatch = pathname.match(
+    /^\/api\/config\/modes\/(.+)\/_rename$/
+  );
+  if (modeRenameMatch?.[1]) {
+    const modeName = decodeURIComponent(modeRenameMatch[1]);
+    const gate = await gateConfigMutation(
+      request,
+      env,
+      session,
+      resolved.org,
+      "mode",
+      modeName,
+      resolved.crossOrg
+    );
+    if ("error" in gate) return gate.error;
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_rename`,
+      ["POST"]
     );
   }
 

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -215,10 +215,8 @@ function computeRequiredVerbsForPut(
 //      both verbs, reject before consuming the body. Keeps bodyless
 //      probes (DELETE, GET-with-method-override, malformed PUTs) on
 //      the 403 path rather than a downstream 400.
-//   5. DELETE / POST → requires BOTH edit + publish on the row. Deletion
-//      is strictly more destructive than either alone; POST is the
-//      mode `_rename` op (#232), which reslugs a mode's canonical
-//      identity — gated as destructively as deletion.
+//   5. DELETE → requires BOTH edit + publish on the row. Deletion is
+//      strictly more destructive than either alone.
 //   6. PUT → diff body vs current and require the union of verbs the
 //      diff implies (`edit` if any editorial field changed, `publish`
 //      if the published flag flipped).
@@ -268,11 +266,7 @@ async function gateConfigMutation(
     return { error: errorResponse("Forbidden", 403) };
   }
 
-  // DELETE and POST (mode `_rename`, #232) both require the full
-  // edit+publish pair. The gate never consumes the body on these paths,
-  // so the downstream proxy reads the `_rename` `{ newName }` payload
-  // intact.
-  if (request.method === "DELETE" || request.method === "POST") {
+  if (request.method === "DELETE") {
     if (
       !hasRights(rightsFor(session, kind, "edit"), name) ||
       !hasRights(rightsFor(session, kind, "publish"), name)
@@ -395,27 +389,27 @@ export async function handleConfig(
     );
   }
 
-  // /api/config/modes/{name}/_rename → POST (per-mode verb-perms,
-  // both edit+publish, admin-trump). Matched BEFORE the generic mode
-  // route below — the `(.+)` there would otherwise capture
-  // `{name}/_rename` as the mode name and reject POST as 405. The
-  // engine (#232) reslugs the mode in place and keeps the old slug as
-  // an alias so existing user assignments aren't stranded.
+  // /api/config/modes/{name}/_rename → POST. Matched BEFORE the generic
+  // mode route below — the `(.+)` there would otherwise capture
+  // `{name}/_rename` as the mode name and reject POST as 405. The engine
+  // (#232) reslugs the mode in place and keeps the old slug as an alias
+  // so existing user assignments aren't stranded.
+  //
+  // Restricted to admins + super-admin cross-org. Per-user mode rights
+  // are slug-scoped (`mode_edit_rights` / `mode_publish_rights`), so a
+  // non-admin shepherd who renamed a mode would keep rights on the OLD
+  // slug and lose access to the renamed mode — and the worker would 403
+  // their later `/modes/{newName}` calls (#238 review). Until rights
+  // migration exists, only admins (blanket mode access) and cross-org
+  // super-admins (per-row gate bypassed anyway) may rename.
   const modeRenameMatch = pathname.match(
     /^\/api\/config\/modes\/(.+)\/_rename$/
   );
   if (modeRenameMatch?.[1]) {
     const modeName = decodeURIComponent(modeRenameMatch[1]);
-    const gate = await gateConfigMutation(
-      request,
-      env,
-      session,
-      resolved.org,
-      "mode",
-      modeName,
-      resolved.crossOrg
-    );
-    if ("error" in gate) return gate.error;
+    if (!resolved.crossOrg && !hasAdminPowers(session)) {
+      return errorResponse("Forbidden", 403);
+    }
     return proxyToEngine(
       request,
       env,


### PR DESCRIPTION
## Summary

- Add an in-place **Rename** for modes, wiring the engine's existing `_rename` op through the BFF + Modes UI. The engine preserves the old slug as an alias, so existing user assignments keep resolving — no one is stranded in "no mode".
- Worker BFF: `POST /api/config/modes/{name}/_rename` gated on **edit + publish** (as strict as DELETE), matched before the generic mode route; admin-trump and super-admin cross-org bypass preserved.
- Client/UI: `renameMode` + `useRenameMode` (invalidates old + new caches), a slug-input Rename dialog with inline error handling, selection follows the new slug, and rename is disabled while there are unsaved edits.

## Test plan

- [x] `npm run lint` — zero warnings
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npx vitest run` — 366 passing, incl. 8 new worker gate cases + 5 new client cases
- [ ] Manual: select a mode → Rename → confirm selection follows the new slug, list updates, request hits `POST /api/config/modes/{old}/_rename` with `{ newName }`; collision/invalid slug surfaces engine error inline; Rename hidden without edit+publish and disabled with unsaved edits

Closes #232