### PR TITLE
feat(modes): aliases type + display + export round-trip (#241 PR A)

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -229,11 +229,18 @@ export function ModesPage() {
     // Single `Date` instance so the frontmatter `exported_at` and the
     // filename timestamp can never drift by a second across the call.
     const ctx = { org: effectiveOrg, exportedAt: new Date() };
+    // Spread `modeQuery.data` so every PromptMode field (label,
+    // description, aliases, and anything added later) flows through
+    // without a per-field update here. The three overrides below are
+    // intentional: `name` follows the user's selection, `document`
+    // captures unsaved edits, `published` uses the locally-tracked
+    // toggle (not cache, which can be stale during a Publish race).
+    // Original inline construction dropped `aliases` silently — #241 PR A
+    // Frank review.
     const content = buildModeExportContent(
       {
+        ...modeQuery.data,
         name: selectedMode,
-        label: serverLabel,
-        description: serverDescription,
         document: draft,
         published: lastSyncedPublished,
       },
@@ -252,15 +259,7 @@ export function ModesPage() {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, [
-    draft,
-    effectiveOrg,
-    lastSyncedPublished,
-    modeQuery.data,
-    selectedMode,
-    serverDescription,
-    serverLabel,
-  ]);
+  }, [draft, effectiveOrg, lastSyncedPublished, modeQuery.data, selectedMode]);
 
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -254,13 +254,39 @@ export function ModeSelector({
         )}
 
         {selectedMode !== null && selectedModeData && (
-          <div className="border-border flex items-center gap-2 sm:border-l sm:pl-3">
+          <div className="border-border flex flex-wrap items-center gap-2 sm:border-l sm:pl-3">
             <Badge
               variant={selectedIsPublished ? "default" : "outline"}
               className="shrink-0"
             >
               {selectedIsPublished ? "Published" : "Draft"}
             </Badge>
+
+            {/* Alias badges (#232 / #241). A mode answers to its previous
+                slug(s) after rename, or to its merged-in slug(s) after a
+                retire-and-forward. Showing them is essential for trust —
+                otherwise the rerouting is invisible. Engine omits the
+                field when empty, so `aliases?.length` covers both cases. */}
+            {selectedModeData.aliases?.length ? (
+              <div
+                className="flex flex-wrap items-center gap-1"
+                role="list"
+                aria-label={`Also resolves to ${selectedModeData.aliases.length} previous ${selectedModeData.aliases.length === 1 ? "slug" : "slugs"}`}
+              >
+                <span className="text-muted-foreground text-xs">also:</span>
+                {selectedModeData.aliases.map((alias) => (
+                  <Badge
+                    key={alias}
+                    variant="outline"
+                    role="listitem"
+                    title={`Users referencing "${alias}" still resolve to this mode (alias from rename or retire-and-forward).`}
+                    className="text-muted-foreground font-mono text-[10px] font-normal"
+                  >
+                    {alias}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
 
             {canPublishSelected &&
               (selectedIsPublished ? (

--- a/src/lib/mode-export.ts
+++ b/src/lib/mode-export.ts
@@ -27,6 +27,14 @@ export function buildModeExportContent(
     lines.push(`description: ${yamlScalar(mode.description)}`);
   }
   lines.push(`published: ${mode.published === true ? "true" : "false"}`);
+  // Engine omits `aliases` when empty (#232 reconciliation §2); mirror
+  // that on export so round-tripped files don't sprout an empty key.
+  if (mode.aliases?.length) {
+    lines.push("aliases:");
+    for (const alias of mode.aliases) {
+      lines.push(`  - ${yamlScalar(alias)}`);
+    }
+  }
   lines.push(`org: ${yamlScalar(ctx.org)}`);
   lines.push(`exported_at: ${ctx.exportedAt.toISOString()}`);
   lines.push(`export_version: ${MODE_EXPORT_VERSION}`);

--- a/src/types/prompt-override.ts
+++ b/src/types/prompt-override.ts
@@ -55,6 +55,11 @@ export interface PromptMode {
   description?: string;
   document: string;
   published?: boolean;
+  // Previous slugs this mode also answers to (#232 alias mechanism).
+  // Engine omits the field when empty rather than returning []; mirror
+  // that on the wire by only sending the key when there are entries, and
+  // guard reads with `aliases?.length`.
+  aliases?: string[];
 }
 
 export interface OrgModes {

--- a/tests/mode-export.test.ts
+++ b/tests/mode-export.test.ts
@@ -68,6 +68,40 @@ describe("buildModeExportContent — frontmatter", () => {
     expect(withEmpty).not.toContain("aliases");
   });
 
+  it("preserves cached metadata when constructed via spread + draft/published overrides", () => {
+    // Pins the pattern used in src/app/pages/modes.tsx handleExport
+    // (`{ ...modeQuery.data, name, document, published }`). The
+    // original inline construction listed fields by hand and dropped
+    // `aliases` silently when the field was added to PromptMode — Frank
+    // P1 on #241 PR A. This test guards the spread shape so any
+    // future PromptMode field is captured on export by default.
+    const cachedMode: PromptMode = {
+      name: "spoken",
+      label: "Spoken Mode",
+      description: "Cached description",
+      document: "old-doc-from-cache",
+      published: true,
+      aliases: ["spoken-old", "spoken-legacy"],
+    };
+    const out = buildModeExportContent(
+      {
+        ...cachedMode,
+        name: "spoken",
+        document: "current-draft-with-edits",
+        published: false,
+      },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    // Cached metadata (especially aliases — the regression) survives.
+    expect(out).toContain('label: "Spoken Mode"');
+    expect(out).toContain('description: "Cached description"');
+    expect(out).toContain('aliases:\n  - "spoken-old"\n  - "spoken-legacy"');
+    // Overrides win for the three locally-tracked fields.
+    expect(out).toContain("current-draft-with-edits");
+    expect(out).not.toContain("old-doc-from-cache");
+    expect(out).toContain("published: false");
+  });
+
   it("escapes alias slugs through the same YAML scalar emitter as other strings", () => {
     const out = buildModeExportContent(
       { ...baseMode, aliases: ['weird "quoted"', "back\\slash"] },

--- a/tests/mode-export.test.ts
+++ b/tests/mode-export.test.ts
@@ -45,6 +45,38 @@ describe("buildModeExportContent — frontmatter", () => {
     expect(out).toContain("published: false");
   });
 
+  it("emits an aliases block when the mode carries aliases", () => {
+    const out = buildModeExportContent(
+      { ...baseMode, aliases: ["spoken-old", "spoken-legacy"] },
+      { org: "unfoldingWord", exportedAt: FIXED_DATE }
+    );
+    expect(out).toContain('aliases:\n  - "spoken-old"\n  - "spoken-legacy"');
+  });
+
+  it("omits the aliases key entirely when the mode has no aliases", () => {
+    const withoutKey = buildModeExportContent(baseMode, {
+      org: "uW",
+      exportedAt: FIXED_DATE,
+    });
+    const withEmpty = buildModeExportContent(
+      { ...baseMode, aliases: [] },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    // Engine omits `aliases` when empty; mirror that so round-tripped
+    // files don't sprout an empty key on subsequent exports.
+    expect(withoutKey).not.toContain("aliases");
+    expect(withEmpty).not.toContain("aliases");
+  });
+
+  it("escapes alias slugs through the same YAML scalar emitter as other strings", () => {
+    const out = buildModeExportContent(
+      { ...baseMode, aliases: ['weird "quoted"', "back\\slash"] },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(out).toContain('  - "weird \\"quoted\\""');
+    expect(out).toContain('  - "back\\\\slash"');
+  });
+
   it("emits published as the literal boolean — false when undefined or false", () => {
     const undef = buildModeExportContent(
       { name: "x", document: "" },


### PR DESCRIPTION
## Summary

First read-side slice of the **#241 umbrella** (the deferred §0/§3a/§4 capabilities from Ian's [original #232 plan](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/232#issuecomment-4791833638); the engine half is already live in `bt-servant-worker` v2.28.0). Three additive changes; zero behavior change for modes without aliases.

- **`PromptMode.aliases?: string[]`** added in `src/types/prompt-override.ts`. Engine omits the field when empty (per Ian's [reconciliation #2](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/232#issuecomment-4803957569)) so the type stays optional, reads are guarded with `aliases?.length`, and the wire round-trip preserves the omitted-vs-empty parity rather than sprouting `aliases: []` on subsequent PUTs.
- **Alias badges next to the Published/Draft badge** in `mode-selector.tsx`. Outline badges, muted/monospaced styling, tooltip explains the rerouting. Essential for trust per Ian's plan — without it the rename/retire mechanism is invisible. Handles 1–N aliases (a retire-and-forward target inherits the source's own aliases too, per Ian's reconciliation #3).
- **`aliases:` YAML block in `buildModeExportContent`** only when the mode has entries. Reuses the existing `yamlScalar` emitter so escaping is consistent.

This unblocks **#241 PR B (clone)** and **#241 PR C (retire-and-forward)**, both of which need the type field. Shipped on its own because it is read-side only and lets the alias-badge UX be reviewed before any new mutations land.

## Why split this way

Ian's plan called out four capabilities (§2 clone, §3a alias display, §3b retire-and-forward, §4 export). §0 (the `aliases?` type field) is a prerequisite for all of them. Bundling §0 + §3a + §4 here gives a small read-side PR; PR B + PR C are then independent and pickable in either order.

## Tests

`tests/mode-export.test.ts` +3 cases: aliases present block, aliases absent (both `aliases: []` and field-missing), and escaping of slugs through `yamlScalar`. Suite 368 → 371.

## Visual verification note

The badges only render when a mode has been the source of a rename or the target of a retire. Staging modes likely already carry aliases from Ian's #232 testing battery; otherwise verify locally by renaming any mode and selecting the renamed mode.

## Test plan

- [ ] `npm run typecheck` — ✓ local
- [ ] `npm run lint` — ✓ local
- [ ] `npm run test` — ✓ local (371 passing)
- [ ] `npm run build` — ✓ local
- [ ] Visual: on staging, select a mode that carries an alias from rename testing; confirm the badge row renders with the alias slug and the tooltip describes the rerouting.

Refs #241, #232.