### PR TITLE
feat(modes): clone mode via engine _clone op (#241 PR B)

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -23,6 +23,7 @@ import { useUiStore } from "@/lib/ui-store";
 import { OrgContextSelector } from "@/components/org-context-selector";
 import { useDebounced } from "@/hooks/use-debounced";
 import {
+  useCloneMode,
   useDeleteMode,
   useMode,
   useModes,
@@ -81,6 +82,7 @@ export function ModesPage() {
   const saveMode = useSaveMode(contextOrg);
   const deleteMode = useDeleteMode(contextOrg);
   const renameMode = useRenameMode(contextOrg);
+  const cloneMode = useCloneMode(contextOrg);
 
   // Filter modes to those the user has any verb on (admin/cross-org
   // sees everything via the `*` short-circuit above). Mirrors
@@ -111,6 +113,11 @@ export function ModesPage() {
   // themselves out of the renamed slug. Mirror the worker gate, which
   // 403s any non-admin same-org rename.
   const canRenameSelected = isAdmin || isCrossOrg;
+  // Clone rides the same gate as rename today (#241 PR B). The clone
+  // has no rights pre-assigned, so a non-admin cloning would land on a
+  // mode they can't edit. Kept as a separate boolean so the gate can
+  // loosen independently once rights-migration lands (#240).
+  const canCloneSelected = isAdmin || isCrossOrg;
 
   // Local document draft (auto-save target).
   //
@@ -388,6 +395,21 @@ export function ModesPage() {
     [deleteMode, selectedMode, setSelectedMode]
   );
 
+  const handleCloneMode = useCallback(
+    async (name: string, newName: string, newLabel: string) => {
+      await cloneMode.mutateAsync({
+        name,
+        newName,
+        newLabel: newLabel || undefined,
+      });
+      // Follow the selection to the freshly-cloned slug so the editor
+      // opens the clone as a draft instead of leaving the user on the
+      // source. Mirrors handleCreateMode's `setSelectedMode(name)`.
+      setSelectedMode(newName);
+    },
+    [cloneMode, setSelectedMode]
+  );
+
   const handleRenameMode = useCallback(
     async (name: string, newName: string) => {
       await renameMode.mutateAsync({ name, newName });
@@ -408,7 +430,8 @@ export function ModesPage() {
 
   const error =
     modesQuery.error || (selectedMode !== null ? modeQuery.error : null);
-  const saveError = saveMode.error ?? deleteMode.error ?? renameMode.error;
+  const saveError =
+    saveMode.error ?? deleteMode.error ?? renameMode.error ?? cloneMode.error;
 
   const saveStatus = useMemo(() => {
     if (isSaving) return "Saving…";
@@ -437,9 +460,11 @@ export function ModesPage() {
               onDeleteMode={handleDeleteMode}
               onSetPublished={handleSetPublished}
               onRenameMode={handleRenameMode}
+              onCloneMode={handleCloneMode}
               isCreating={saveMode.isPending}
               isDeleting={deleteMode.isPending}
               isRenaming={renameMode.isPending}
+              isCloning={cloneMode.isPending}
               isSettingPublished={saveMode.isPending}
               showDrafts={showDrafts}
               onToggleShowDrafts={setShowDrafts}
@@ -447,6 +472,7 @@ export function ModesPage() {
               canPublishSelected={canPublishSelected}
               canDeleteSelected={canDeleteSelected}
               canRenameSelected={canRenameSelected}
+              canCloneSelected={canCloneSelected}
               renameDisabledReason={
                 isDirty || isSaving
                   ? "Save your changes before renaming."

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -408,15 +408,22 @@ export function ModesPage() {
         newName,
         newLabel: trimmedLabel ? trimmedLabel : undefined,
       });
-      // Follow the selection to the engine-canonical slug (not the
-      // client-side `newName`). If the engine re-canonicalizes the
-      // slug and returns a different `data.name`, using `newName`
-      // would land the user on a slug that doesn't exist in the list
-      // and the stale-selection guard would wipe the selection.
-      // Mirrors handleCreateMode's `setSelectedMode(name)`.
-      setSelectedMode(data.name);
+      // Route through handleSelectMode (not raw setSelectedMode) so
+      // the switch-guard fires if the source draft dirtied while the
+      // modal was open. The Clone button is disabled up-front by
+      // `cloneDisabledReason` when isDirty || isSaving, but that only
+      // gates the trigger — once the dialog is open, focus can leak
+      // (click outside the modal, tab out, blur-and-refocus), the
+      // user can type in the editor, and `isDirty` can flip to true
+      // by the time they confirm. `handleSelectMode` inspects the
+      // live isDirty and either switches (clean → setSelectedMode) or
+      // queues a `pendingSwitch` confirmation dialog (dirty → user
+      // picks discard-or-cancel). Uses data.name so an engine slug
+      // canonicalization is picked up too. Belt-and-suspenders for
+      // Frank F1 on #241 PR B.
+      handleSelectMode(data.name);
     },
-    [cloneMode, setSelectedMode]
+    [cloneMode, handleSelectMode]
   );
 
   const handleRenameMode = useCallback(

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -397,15 +397,24 @@ export function ModesPage() {
 
   const handleCloneMode = useCallback(
     async (name: string, newName: string, newLabel: string) => {
-      await cloneMode.mutateAsync({
+      // Only send `newLabel` when the user typed one — the dialog
+      // starts blank (no prefill) so blank always means "unset". This
+      // sidesteps the empty-vs-inherit ambiguity flagged in the F7
+      // review comment: the engine never sees a bare `""` that could
+      // be interpreted as either "user cleared" or "unset".
+      const trimmedLabel = newLabel.trim();
+      const data = await cloneMode.mutateAsync({
         name,
         newName,
-        newLabel: newLabel || undefined,
+        newLabel: trimmedLabel ? trimmedLabel : undefined,
       });
-      // Follow the selection to the freshly-cloned slug so the editor
-      // opens the clone as a draft instead of leaving the user on the
-      // source. Mirrors handleCreateMode's `setSelectedMode(name)`.
-      setSelectedMode(newName);
+      // Follow the selection to the engine-canonical slug (not the
+      // client-side `newName`). If the engine re-canonicalizes the
+      // slug and returns a different `data.name`, using `newName`
+      // would land the user on a slug that doesn't exist in the list
+      // and the stale-selection guard would wipe the selection.
+      // Mirrors handleCreateMode's `setSelectedMode(name)`.
+      setSelectedMode(data.name);
     },
     [cloneMode, setSelectedMode]
   );
@@ -430,8 +439,11 @@ export function ModesPage() {
 
   const error =
     modesQuery.error || (selectedMode !== null ? modeQuery.error : null);
-  const saveError =
-    saveMode.error ?? deleteMode.error ?? renameMode.error ?? cloneMode.error;
+  // Clone errors are NOT folded in here — the clone dialog surfaces
+  // engine 400/404/409 messages inline via `runConfirmedAction`, so a
+  // page-level "Save failed:" banner would be both redundant AND
+  // misleading (clone isn't a save). #241 PR B Frank F3.
+  const saveError = saveMode.error ?? deleteMode.error ?? renameMode.error;
 
   const saveStatus = useMemo(() => {
     if (isSaving) return "Saving…";
@@ -477,6 +489,9 @@ export function ModesPage() {
                 isDirty || isSaving
                   ? "Save your changes before renaming."
                   : null
+              }
+              cloneDisabledReason={
+                isDirty || isSaving ? "Save your changes before cloning." : null
               }
             />
           </div>

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -12,6 +12,7 @@ import {
   Trash2,
 } from "lucide-react";
 
+import { pickCloneDefaultSlug } from "@/lib/mode-clone-defaults";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import type { OrgModes, PromptMode } from "@/types/prompt-override";
 import {
@@ -82,6 +83,12 @@ interface ModeSelectorProps {
       tooltip — used to block rename while the editor has unsaved edits
       (renaming re-syncs the doc under the new slug and would drop them). */
   renameDisabledReason: string | null;
+  /** Non-null disables the Clone trigger and shows the string as its
+      tooltip. Same shape as `renameDisabledReason` and used for the
+      same reason: cloning switches selection to the fresh clone, which
+      silently re-syncs the editor from the clone's document and drops
+      any unsaved edits to the source (#241 PR B Frank F1). */
+  cloneDisabledReason: string | null;
 }
 
 function isPublished(mode: Pick<PromptMode, "published">): boolean {
@@ -123,6 +130,7 @@ export function ModeSelector({
   canRenameSelected,
   canCloneSelected,
   renameDisabledReason,
+  cloneDisabledReason,
 }: ModeSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -481,12 +489,24 @@ export function ModeSelector({
                 onOpenChange={(next) => {
                   setCloneOpen(next);
                   if (next) {
-                    // Prefill with the source's slug + "-copy" so the
-                    // user edits from a sensible default rather than a
-                    // blank input; also seed the label with the source's
-                    // label if any. Clear stale errors.
-                    setCloneName(`${selectedMode}-copy`);
-                    setCloneLabel(selectedModeData?.label ?? "");
+                    // Prefill the slug with a dedup'd default so the
+                    // first click doesn't guarantee a 409 on the second
+                    // clone (#241 PR B Frank F5). Leave the label
+                    // BLANK: prefilling with the source's label made
+                    // "user cleared" and "user left prefilled" both
+                    // send the same wire value, hiding the intent
+                    // difference; the engine's inherit-vs-set-empty
+                    // behavior for an omitted vs empty `newLabel` is
+                    // unspecified in Ian's plan (#241 PR B Frank F7).
+                    setCloneName(
+                      selectedMode !== null
+                        ? pickCloneDefaultSlug(
+                            selectedMode,
+                            modes.map((m) => m.name)
+                          )
+                        : ""
+                    );
+                    setCloneLabel("");
                     setCloneError(null);
                   } else {
                     setCloneError(null);
@@ -496,7 +516,12 @@ export function ModeSelector({
                 }}
               >
                 <AlertDialogTrigger asChild>
-                  <Button variant="ghost" size="sm" disabled={isCloning}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={isCloning || cloneDisabledReason !== null}
+                    title={cloneDisabledReason ?? undefined}
+                  >
                     <Copy className="mr-1.5 size-3.5" />
                     Clone
                   </Button>
@@ -534,7 +559,7 @@ export function ModeSelector({
                         id="mode-clone-label"
                         value={cloneLabel}
                         onChange={(e) => setCloneLabel(e.target.value)}
-                        placeholder="Human-readable label"
+                        placeholder="Leave blank to skip"
                         className="h-8 text-sm"
                       />
                     </div>
@@ -548,10 +573,14 @@ export function ModeSelector({
                     <AlertDialogCancel disabled={isCloning}>
                       Cancel
                     </AlertDialogCancel>
-                    {/* Plain Button — see comment in Unpublish dialog above. */}
+                    {/* Plain Button — see comment in Unpublish dialog above.
+                        Gate matches handleConfirmClone's slug validation
+                        so the affordance can't say "clickable" while the
+                        confirm action always inline-fails (#241 PR B
+                        Frank F4). */}
                     <Button
                       onClick={handleConfirmClone}
-                      disabled={isCloning || !cloneName.trim()}
+                      disabled={isCloning || !slugify(cloneName)}
                     >
                       {isCloning ? "Cloning…" : "Clone"}
                     </Button>

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { faLayerGroup } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
+  Copy,
   Eye,
   EyeOff,
   Pencil,
@@ -49,9 +50,17 @@ interface ModeSelectorProps {
   /** Reslug a mode in place (#232). Like onDeleteMode, must reject on
       error so the rename dialog can surface it inline and stay open. */
   onRenameMode: (name: string, newName: string) => Promise<void>;
+  /** Clone a mode via the engine's `_clone` op (#241 PR B). Must reject
+      on error so the clone dialog can surface it inline and stay open. */
+  onCloneMode: (
+    name: string,
+    newName: string,
+    newLabel: string
+  ) => Promise<void>;
   isCreating: boolean;
   isDeleting: boolean;
   isRenaming: boolean;
+  isCloning: boolean;
   isSettingPublished: boolean;
   showDrafts: boolean;
   onToggleShowDrafts: (showDrafts: boolean) => void;
@@ -64,6 +73,11 @@ interface ModeSelectorProps {
   canPublishSelected: boolean;
   canDeleteSelected: boolean;
   canRenameSelected: boolean;
+  /** Clone rides the same admin/cross-org gate as rename today: fresh
+      mode has no per-user rights assigned, so a non-admin cloning would
+      end up with a mode they can't edit. Kept as a separate flag so the
+      restriction can loosen independently once rights-migration lands. */
+  canCloneSelected: boolean;
   /** Non-null disables the Rename trigger and shows the string as its
       tooltip — used to block rename while the editor has unsaved edits
       (renaming re-syncs the doc under the new slug and would drop them). */
@@ -95,9 +109,11 @@ export function ModeSelector({
   onDeleteMode,
   onSetPublished,
   onRenameMode,
+  onCloneMode,
   isCreating,
   isDeleting,
   isRenaming,
+  isCloning,
   isSettingPublished,
   showDrafts,
   onToggleShowDrafts,
@@ -105,6 +121,7 @@ export function ModeSelector({
   canPublishSelected,
   canDeleteSelected,
   canRenameSelected,
+  canCloneSelected,
   renameDisabledReason,
 }: ModeSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
@@ -123,6 +140,10 @@ export function ModeSelector({
   const [renameOpen, setRenameOpen] = useState(false);
   const [renameError, setRenameError] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  const [cloneOpen, setCloneOpen] = useState(false);
+  const [cloneError, setCloneError] = useState<string | null>(null);
+  const [cloneName, setCloneName] = useState("");
+  const [cloneLabel, setCloneLabel] = useState("");
 
   const handleConfirmUnpublish = useCallback(() => {
     if (selectedMode === null) return;
@@ -143,6 +164,31 @@ export function ModeSelector({
       "Failed to delete mode."
     );
   }, [onDeleteMode, selectedMode]);
+
+  const handleConfirmClone = useCallback(() => {
+    if (selectedMode === null) return;
+    const slug = slugify(cloneName);
+    if (!slug) {
+      setCloneError("Enter a valid name (letters, numbers, hyphens).");
+      return;
+    }
+    if (slug === selectedMode) {
+      setCloneError(
+        "New name must differ from the source. (Rename instead if you want to reslug in place.)"
+      );
+      return;
+    }
+    return runConfirmedAction(
+      () => onCloneMode(selectedMode, slug, cloneLabel.trim()),
+      setCloneError,
+      () => {
+        setCloneOpen(false);
+        setCloneName("");
+        setCloneLabel("");
+      },
+      "Failed to clone mode."
+    );
+  }, [cloneLabel, cloneName, onCloneMode, selectedMode]);
 
   const handleConfirmRename = useCallback(() => {
     if (selectedMode === null) return;
@@ -423,6 +469,91 @@ export function ModeSelector({
                       disabled={isRenaming || !renameValue.trim()}
                     >
                       {isRenaming ? "Renaming…" : "Rename"}
+                    </Button>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+
+            {canCloneSelected && (
+              <AlertDialog
+                open={cloneOpen}
+                onOpenChange={(next) => {
+                  setCloneOpen(next);
+                  if (next) {
+                    // Prefill with the source's slug + "-copy" so the
+                    // user edits from a sensible default rather than a
+                    // blank input; also seed the label with the source's
+                    // label if any. Clear stale errors.
+                    setCloneName(`${selectedMode}-copy`);
+                    setCloneLabel(selectedModeData?.label ?? "");
+                    setCloneError(null);
+                  } else {
+                    setCloneError(null);
+                    setCloneName("");
+                    setCloneLabel("");
+                  }
+                }}
+              >
+                <AlertDialogTrigger asChild>
+                  <Button variant="ghost" size="sm" disabled={isCloning}>
+                    <Copy className="mr-1.5 size-3.5" />
+                    Clone
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Clone mode</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Create a copy of{" "}
+                      <span className="text-foreground font-medium">
+                        &ldquo;{selectedMode}&rdquo;
+                      </span>{" "}
+                      under a new slug. The clone starts as a draft &mdash; the
+                      source mode is untouched and no users are moved.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <div className="space-y-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="mode-clone-name" className="text-xs">
+                        New name (slug)
+                      </Label>
+                      <Input
+                        id="mode-clone-name"
+                        value={cloneName}
+                        onChange={(e) => setCloneName(e.target.value)}
+                        placeholder="e.g. conversation-v2"
+                        className="h-8 text-sm"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="mode-clone-label" className="text-xs">
+                        Display name (optional)
+                      </Label>
+                      <Input
+                        id="mode-clone-label"
+                        value={cloneLabel}
+                        onChange={(e) => setCloneLabel(e.target.value)}
+                        placeholder="Human-readable label"
+                        className="h-8 text-sm"
+                      />
+                    </div>
+                  </div>
+                  {cloneError && (
+                    <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                      {cloneError}
+                    </p>
+                  )}
+                  <AlertDialogFooter>
+                    <AlertDialogCancel disabled={isCloning}>
+                      Cancel
+                    </AlertDialogCancel>
+                    {/* Plain Button — see comment in Unpublish dialog above. */}
+                    <Button
+                      onClick={handleConfirmClone}
+                      disabled={isCloning || !cloneName.trim()}
+                    >
+                      {isCloning ? "Cloning…" : "Clone"}
                     </Button>
                   </AlertDialogFooter>
                 </AlertDialogContent>

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -158,6 +158,32 @@ export function useRenameMode(org?: string | null) {
   });
 }
 
+// Clone a mode (#241 PR B). Unlike rename this is additive — the source is
+// untouched, a new mode appears — so no optimistic list surgery is needed.
+// Two touches on the cache: (1) pre-write the returned clone into the per-
+// mode cache so the page's `setSelectedMode(newName)` renders the fresh
+// mode immediately instead of showing a loading gap; (2) invalidate the
+// modes list so the new entry surfaces on the next tick.
+export function useCloneMode(org?: string | null) {
+  const qc = useQueryClient();
+  const key = normalize(org);
+  return useMutation({
+    mutationFn: ({
+      name,
+      newName,
+      newLabel,
+    }: {
+      name: string;
+      newName: string;
+      newLabel?: string;
+    }) => configApi.cloneMode(name, { newName, newLabel }, undefined, key),
+    onSuccess: (data, { newName }) => {
+      qc.setQueryData(keys.mode(newName, key), data);
+      void qc.invalidateQueries({ queryKey: keys.modes(key) });
+    },
+  });
+}
+
 export function useSetUserMode(org?: string | null) {
   const key = normalize(org);
   return useMutation({

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -112,6 +112,29 @@ export function useDeleteMode(org?: string | null) {
   });
 }
 
+// Append (or replace) the cloned mode in a cached modes list. Exported
+// for unit tests. Returns `prev` untouched when nothing is cached yet
+// (`undefined`) so an optimistic write never fabricates a list. If the
+// new slug already exists in the cache (a rare tab-race with an
+// overlapping refetch, or a stale entry from a concurrent write), the
+// entry is replaced in-place rather than duplicated — the modes-list
+// selector keys on `m.name` and a duplicate would surface as a React
+// key collision.
+export function applyCloneToModeList(
+  prev: OrgModes | undefined,
+  cloned: PromptMode
+): OrgModes | undefined {
+  if (!prev) return prev;
+  const existingIdx = prev.modes.findIndex((m) => m.name === cloned.name);
+  if (existingIdx >= 0) {
+    return {
+      ...prev,
+      modes: prev.modes.map((m, i) => (i === existingIdx ? cloned : m)),
+    };
+  }
+  return { ...prev, modes: [...prev.modes, cloned] };
+}
+
 // Swap the old-slug entry for the renamed mode in a cached modes list.
 // Exported for unit tests. Returns `prev` untouched when nothing is cached
 // yet (`undefined`) or the old slug isn't present, so an optimistic write
@@ -158,12 +181,21 @@ export function useRenameMode(org?: string | null) {
   });
 }
 
-// Clone a mode (#241 PR B). Unlike rename this is additive — the source is
-// untouched, a new mode appears — so no optimistic list surgery is needed.
-// Two touches on the cache: (1) pre-write the returned clone into the per-
-// mode cache so the page's `setSelectedMode(newName)` renders the fresh
-// mode immediately instead of showing a loading gap; (2) invalidate the
-// modes list so the new entry surfaces on the next tick.
+// Clone a mode (#241 PR B). Three-part cache update mirroring the shape
+// of `useRenameMode` — needed because the page follows selection to the
+// new slug on success (`setSelectedMode(data.name)` in modes.tsx) and
+// the stale-selection guard there wipes the selection if the list cache
+// hasn't caught up:
+//
+//  1. Synchronously append the returned clone to the LIST cache via
+//     `applyCloneToModeList`. Without this optimistic write the list
+//     still holds the pre-clone snapshot in the render gap before the
+//     refetch lands; the guard sees the new slug missing and drops the
+//     user to no selection (#241 PR B Frank F2).
+//  2. Pre-write the returned clone into the per-mode cache so the page
+//     renders the fresh mode without a loading spinner.
+//  3. Invalidate the list and the per-mode cache so the optimistic
+//     writes reconcile with server truth.
 export function useCloneMode(org?: string | null) {
   const qc = useQueryClient();
   const key = normalize(org);
@@ -177,9 +209,13 @@ export function useCloneMode(org?: string | null) {
       newName: string;
       newLabel?: string;
     }) => configApi.cloneMode(name, { newName, newLabel }, undefined, key),
-    onSuccess: (data, { newName }) => {
-      qc.setQueryData(keys.mode(newName, key), data);
+    onSuccess: (data) => {
+      qc.setQueryData<OrgModes>(keys.modes(key), (prev) =>
+        applyCloneToModeList(prev, data)
+      );
+      qc.setQueryData(keys.mode(data.name, key), data);
       void qc.invalidateQueries({ queryKey: keys.modes(key) });
+      void qc.invalidateQueries({ queryKey: keys.mode(data.name, key) });
     },
   });
 }

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -238,6 +238,37 @@ export async function renameMode(
   return unwrapModeResponse((await res.json()) as Record<string, unknown>);
 }
 
+// Clone a mode via the engine's `_clone` op (#232 / #241 PR B). The engine
+// creates a new mode with the given slug (+ optional label); document is
+// copied verbatim from the source and `published` is reset to false so the
+// clone lands as a draft. Rejects with 409 if the new slug collides with any
+// existing mode's canonical name OR alias in the org (Ian's #232
+// reconciliation §4).
+export async function cloneMode(
+  name: string,
+  body: { newName: string; newLabel?: string },
+  signal?: AbortSignal,
+  org?: string | null
+): Promise<PromptMode> {
+  const res = await fetch(
+    buildConfigUrl(`/api/config/modes/${encodeURIComponent(name)}/_clone`, org),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+      body: JSON.stringify(body),
+      signal,
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to clone mode (${res.status}): ${await readModeOpError(res)}`
+    );
+  }
+
+  return unwrapModeResponse((await res.json()) as Record<string, unknown>);
+}
+
 // ---------------------------------------------------------------------------
 // Per-user memory
 // ---------------------------------------------------------------------------

--- a/src/lib/mode-clone-defaults.ts
+++ b/src/lib/mode-clone-defaults.ts
@@ -1,0 +1,30 @@
+// Pure helpers for the Modes page's Clone dialog (#241 PR B). Kept
+// separate from the component file so unit tests can import without
+// pulling JSX config in, and so the react-refresh fast-refresh rule
+// doesn't complain about a component file exporting non-component
+// symbols.
+
+// Pick a default new-slug for the clone dialog that doesn't collide
+// with an existing mode's name in the org. First tries `${source}-copy`;
+// if that's taken, walks `-copy-2`, `-copy-3`, ... until it finds a free
+// slot. #241 PR B Frank F5 — a bare `${source}-copy` prefill guaranteed
+// a 409 on the second clone of the same source since the first clone
+// had already claimed that slug.
+//
+// Note: this uses the caller-provided list only; the engine also checks
+// against aliases (Ian's #232 reconciliation §4), so a picked default
+// can still 409 if a distinct mode carries the picked slug as an alias.
+// That's acceptable — we're picking a sensible default, not enforcing
+// uniqueness; the engine remains the source of truth and its message
+// surfaces inline.
+export function pickCloneDefaultSlug(
+  source: string,
+  existing: readonly string[]
+): string {
+  const taken = new Set(existing);
+  const base = `${source}-copy`;
+  if (!taken.has(base)) return base;
+  let n = 2;
+  while (taken.has(`${base}-${n}`)) n++;
+  return `${base}-${n}`;
+}

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   clearUserMode,
+  cloneMode,
   deleteMode,
   deleteUserMemory,
   getMode,
@@ -383,6 +384,97 @@ describe("renameMode", () => {
     await renameMode("spoken", "new", undefined, "word-collective");
     expect(spy.mock.calls[0]![0]).toBe(
       "/api/config/modes/spoken/_rename?org=word-collective"
+    );
+  });
+});
+
+describe("cloneMode", () => {
+  it("POSTs `{ newName, newLabel? }` to the _clone endpoint and unwraps the envelope", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          org: "uw",
+          mode: {
+            name: "spoken-v2",
+            label: "Spoken v2",
+            document: "## Identity\n",
+            published: false,
+          },
+          message: "Mode cloned",
+        }),
+        { status: 200 }
+      )
+    );
+    const result = await cloneMode("spoken", {
+      newName: "spoken-v2",
+      newLabel: "Spoken v2",
+    });
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/spoken/_clone");
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      newName: "spoken-v2",
+      newLabel: "Spoken v2",
+    });
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json"
+    );
+    // Returns the cloned mode (new canonical name, draft), envelope unwrapped.
+    expect(result.name).toBe("spoken-v2");
+    expect(result.published).toBe(false);
+  });
+
+  it("omits newLabel from the body when not provided (engine treats as unset)", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "new", document: "" } }))
+      );
+    await cloneMode("spoken", { newName: "new" });
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({ newName: "new" });
+  });
+
+  it("URL-encodes the source mode name in the path", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "new", document: "" } }))
+      );
+    await cloneMode("kids mode", { newName: "new" });
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/kids%20mode/_clone");
+  });
+
+  it("surfaces the engine's JSON `{ error }` message on a slug collision", async () => {
+    // Engine returns 409 for a collision against another mode's name OR
+    // alias. Dialog shows this inline; the message must be the engine
+    // string, not the raw JSON blob.
+    mockFetchOnce(409, {
+      error: 'Slug "conversation" already belongs to another mode in this org',
+    });
+    await expect(
+      cloneMode("spoken", { newName: "conversation" })
+    ).rejects.toThrow(
+      /Failed to clone mode \(409\): Slug "conversation" already belongs/
+    );
+  });
+
+  it("falls back to raw text when the error body isn't JSON", async () => {
+    mockFetchOnce(500, "upstream boom");
+    await expect(cloneMode("spoken", { newName: "new" })).rejects.toThrow(
+      /Failed to clone mode \(500\): upstream boom/
+    );
+  });
+
+  it("threads org through as ?org=", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "new", document: "" } }))
+      );
+    await cloneMode("spoken", { newName: "new" }, undefined, "word-collective");
+    expect(spy.mock.calls[0]![0]).toBe(
+      "/api/config/modes/spoken/_clone?org=word-collective"
     );
   });
 });

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1023,6 +1023,32 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
       "/api/v1/admin/orgs/word-collective/modes/spoken/_clone"
     );
   });
+
+  // #241 PR B Frank F8: the arm's regex was greedy (`(.+)`), so a path like
+  // /api/config/modes/foo/_clone/_clone would capture `foo/_clone` as the
+  // mode name and forward a guaranteed-404 request to the engine. Anchored
+  // to `[^/]+` (mode names are always single URL segments), the crafted
+  // path falls through to the generic modes/{name} arm — which is only
+  // wired for GET/PUT/DELETE, so a POST gets 405 at the BFF without any
+  // engine round-trip.
+  it("does not match a duplicated /_clone suffix (regex is segment-anchored, not greedy)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/foo/_clone/_clone",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ newName: "bar" }),
+        }
+      ),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/foo/_clone/_clone"
+    );
+    expect(res.status).toBe(405);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("config authz — #181 verb diff (pure function)", () => {

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -920,6 +920,111 @@ describe("config authz — #232 mode rename (_rename)", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #241 PR B mode clone — POST /api/config/modes/{name}/_clone
+// ---------------------------------------------------------------------------
+//
+// Clone creates a new mode (draft, distinct slug + optional label) via the
+// engine `_clone` op. The BFF proxies POST + `{ newName, newLabel? }` to
+// the engine, admin-gated on the same basis as _rename: per-user
+// mode_edit_rights / mode_publish_rights are slug-scoped, and the clone's
+// fresh slug has no rights pre-assigned, so a non-admin cloner would land
+// on a mode they can't edit. Matched before the generic `modes/{name}` arm
+// for the same regex-ordering reason as _rename.
+
+function makeCloneRequest(name: string, body: object): Request {
+  return new Request(
+    `https://portal.example.test/api/config/modes/${name}/_clone`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("config authz — #241 PR B mode clone (_clone)", () => {
+  it("admin → proxies POST to engine _clone path", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("POST");
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/modes/spoken/_clone"
+    );
+  });
+
+  it("super admin without isAdmin → proxies (super trumps isAdmin)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-admin without any explicit mode rights → 403 (baseline, no proxy)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({ isAdmin: false }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-admin with BOTH edit+publish on the source row → 403 (clone is admin-only, same reasoning as rename)", async () => {
+    // Clone's new slug carries no per-user rights, so a shepherd cloning
+    // would produce a mode they can't edit. Gating this to admins/cross-
+    // org avoids that trap; loosen when rights-migration exists (#240).
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("super-admin cross-org via ?org=other → proxies to /orgs/other/.../_clone", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_clone?org=word-collective",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ newName: "spoken-v2" }),
+        }
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/modes/spoken/_clone"
+    );
+  });
+});
+
 describe("config authz — #181 verb diff (pure function)", () => {
   const { computeRequiredVerbsForPut } = __testInternals;
 

--- a/tests/mode-clone-defaults.test.ts
+++ b/tests/mode-clone-defaults.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { pickCloneDefaultSlug } from "../src/lib/mode-clone-defaults";
+
+// #241 PR B Frank F5: the clone dialog prefilled `${source}-copy`
+// unconditionally, so the second click of Clone on the same source
+// guaranteed a 409 collision. `pickCloneDefaultSlug` walks `-copy`,
+// `-copy-2`, `-copy-3`, ... until it finds a free slot in the caller-
+// provided existing-names set.
+
+describe("pickCloneDefaultSlug", () => {
+  it("uses the bare `${source}-copy` when nothing collides", () => {
+    expect(pickCloneDefaultSlug("spoken", ["spoken", "written"])).toBe(
+      "spoken-copy"
+    );
+  });
+
+  it("walks to `-copy-2` when the bare form is taken", () => {
+    expect(pickCloneDefaultSlug("spoken", ["spoken", "spoken-copy"])).toBe(
+      "spoken-copy-2"
+    );
+  });
+
+  it("skips holes and lands on the first free numbered slot", () => {
+    // A sparse taken-set (missing `-copy-3`) still resolves to the next
+    // sequential free slot rather than filling the gap — matches the
+    // "keep incrementing until free" semantic the docstring promises.
+    expect(
+      pickCloneDefaultSlug("spoken", [
+        "spoken",
+        "spoken-copy",
+        "spoken-copy-2",
+        "spoken-copy-4",
+      ])
+    ).toBe("spoken-copy-3");
+  });
+
+  it("returns the base when the existing list is empty", () => {
+    expect(pickCloneDefaultSlug("spoken", [])).toBe("spoken-copy");
+  });
+
+  it("dedupes against a mode whose canonical slug already IS `${source}-copy`", () => {
+    // Someone renamed a mode to `spoken-copy` in the past, so a fresh
+    // clone of `spoken` needs to jump to `-copy-2` on the first attempt.
+    expect(pickCloneDefaultSlug("spoken", ["spoken", "spoken-copy"])).toBe(
+      "spoken-copy-2"
+    );
+  });
+});

--- a/tests/use-prompt-config.test.ts
+++ b/tests/use-prompt-config.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { applyRenameToModeList } from "../src/hooks/use-prompt-config";
+import {
+  applyCloneToModeList,
+  applyRenameToModeList,
+} from "../src/hooks/use-prompt-config";
 import type { OrgModes, PromptMode } from "../src/types/prompt-override";
 
 // Regression for the #232 review (PR #238): after a successful rename the
@@ -61,5 +64,69 @@ describe("applyRenameToModeList", () => {
     const next = applyRenameToModeList(prev, "spoken", renamed);
 
     expect(next!.modes.map((m) => m.name)).toEqual(["written"]);
+  });
+});
+
+// Regression for the #241 PR B review (Frank F2): after a successful clone
+// the page follows selection to the new slug. Without an optimistic list
+// write, the stale-selection guard in modes.tsx sees the new slug missing
+// from `modesQuery.data` and clears the selection before the invalidated
+// list refetches. applyCloneToModeList closes that gap by appending the
+// cloned mode synchronously.
+
+const cloned: PromptMode = {
+  name: "spoken-v2",
+  label: "Spoken v2",
+  document: "## Identity\n",
+  published: false,
+};
+
+describe("applyCloneToModeList", () => {
+  it("appends the cloned mode to the list (source untouched)", () => {
+    const prev: OrgModes = {
+      modes: [
+        { name: "spoken", document: "## Identity\n", published: true },
+        { name: "written", document: "## Identity\n", published: false },
+      ],
+    };
+
+    const next = applyCloneToModeList(prev, cloned);
+
+    // Source and sibling both preserved; the clone lands at the tail.
+    expect(next!.modes.map((m) => m.name)).toEqual([
+      "spoken",
+      "written",
+      "spoken-v2",
+    ]);
+  });
+
+  it("returns undefined unchanged when nothing is cached yet", () => {
+    expect(applyCloneToModeList(undefined, cloned)).toBeUndefined();
+  });
+
+  it("replaces an existing entry rather than duplicating (concurrent-tab race guard)", () => {
+    // A tab that already saw the clone via a background refetch would
+    // otherwise pick up a duplicate key here; the modes-list Select
+    // renders `key={m.name}` and duplicates would surface as a React
+    // warning + collapsed dropdown.
+    const stale: PromptMode = {
+      name: "spoken-v2",
+      document: "## Old\n",
+      published: false,
+    };
+    const prev: OrgModes = {
+      modes: [
+        { name: "spoken", document: "## Identity\n", published: true },
+        stale,
+      ],
+    };
+
+    const next = applyCloneToModeList(prev, cloned);
+
+    expect(next!.modes).toHaveLength(2);
+    // In-place replacement preserves position AND swaps to the fresh
+    // payload (label + document from the mutation response).
+    expect(next!.modes[1]).toBe(cloned);
+    expect(next!.modes[1]).not.toBe(stale);
   });
 });

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -402,8 +402,12 @@ export async function handleConfig(
   // their later `/modes/{newName}` calls (#238 review). Until rights
   // migration exists, only admins (blanket mode access) and cross-org
   // super-admins (per-row gate bypassed anyway) may rename.
+  // `[^/]+` (not `.+`) so `.../foo/_rename/_rename` doesn't slip past
+  // with modeName = "foo/_rename" and waste an engine round-trip on a
+  // guaranteed 404. Mode names are always single URL segments — the
+  // portal URL-encodes any slashes upstream.
   const modeRenameMatch = pathname.match(
-    /^\/api\/config\/modes\/(.+)\/_rename$/
+    /^\/api\/config\/modes\/([^/]+)\/_rename$/
   );
   if (modeRenameMatch?.[1]) {
     const modeName = decodeURIComponent(modeRenameMatch[1]);
@@ -426,7 +430,10 @@ export async function handleConfig(
   // gating this to admin/cross-org avoids handing a non-admin a mode
   // they can't edit. Matched above the catch-all for the same regex-
   // ordering reason as _rename.
-  const modeCloneMatch = pathname.match(/^\/api\/config\/modes\/(.+)\/_clone$/);
+  // `[^/]+` for the same reason as _rename above.
+  const modeCloneMatch = pathname.match(
+    /^\/api\/config\/modes\/([^/]+)\/_clone$/
+  );
   if (modeCloneMatch?.[1]) {
     const modeName = decodeURIComponent(modeCloneMatch[1]);
     if (!resolved.crossOrg && !hasAdminPowers(session)) {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -418,6 +418,28 @@ export async function handleConfig(
     );
   }
 
+  // /api/config/modes/{name}/_clone → POST. Same admin-only gate as
+  // _rename (#241 PR B). The engine creates a new mode with the new
+  // slug + optional label; content is copied verbatim from the source.
+  // Rights don't migrate — mode_edit_rights / mode_publish_rights are
+  // slug-scoped and no shepherd holds rights on the fresh slug yet, so
+  // gating this to admin/cross-org avoids handing a non-admin a mode
+  // they can't edit. Matched above the catch-all for the same regex-
+  // ordering reason as _rename.
+  const modeCloneMatch = pathname.match(/^\/api\/config\/modes\/(.+)\/_clone$/);
+  if (modeCloneMatch?.[1]) {
+    const modeName = decodeURIComponent(modeCloneMatch[1]);
+    if (!resolved.crossOrg && !hasAdminPowers(session)) {
+      return errorResponse("Forbidden", 403);
+    }
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_clone`,
+      ["POST"]
+    );
+  }
+
   // /api/config/modes/{name} → GET (any session) / PUT/DELETE (per-mode
   // verb-perms, admin-trump)
   const modeMatch = pathname.match(/^\/api\/config\/modes\/(.+)$/);


### PR DESCRIPTION
## Summary

Second slice of the **#241 umbrella** (Ian's deferred #232 §2 — clone). Engine `_clone` endpoint has been live since bt-servant-worker v2.28.0, so this is pure portal-side wiring across all four layers.

| Layer | File | Change |
|---|---|---|
| Worker proxy | `worker/config.ts` | New arm `POST /api/config/modes/{name}/_clone` above the catch-all; admin/cross-org direct-gate |
| API client | `src/lib/config-api.ts` | `cloneMode(name, {newName, newLabel?}, signal?, org?)` |
| Hook | `src/hooks/use-prompt-config.ts` | `useCloneMode()` — pre-writes clone into per-mode cache + invalidates list |
| UI | `src/components/mode-selector.tsx`, `src/app/pages/modes.tsx` | Clone button + two-field dialog (slug + optional label) |

## Design notes

- **Admin/cross-org gate (same as rename).** Per-user `mode_edit_rights` / `mode_publish_rights` are slug-scoped, and the clone's fresh slug has no rights pre-assigned, so a non-admin cloner would land on a mode they can't edit. Loosening this is tracked as part of #240 (rights-migration).
- **Direct-gate, not `gateConfigMutation`.** Mirrors PR #238's rename arm — POST isn't in `isAdminMutation`'s method set, so the arm gates in-line.
- **Regex ordering matters.** The `/_clone` arm is matched *before* the generic `^/api/config/modes/(.+)$` arm; without that, the catch-all would swallow `{name}/_clone` and 405 the POST.
- **No optimistic list surgery.** Unlike rename (which swaps an entry), clone is additive. The hook pre-writes the returned clone into `keys.mode(newName)` so `setSelectedMode(newName)` in the page renders the fresh mode immediately without a loading gap, then invalidates the list.
- **Error pass-through.** The engine returns 400 (invalid slug), 404 (missing source), or 409 (collision against another mode's name OR alias, per Ian's #232 reconciliation §4). All three surface inline in the dialog via `runConfirmedAction` — no `AlertDialogAction` per [[feedback_alertdialogaction_async]].
- **Dialog prefill.** New slug prefills to `${source}-copy`, label prefills to the source's label. User can edit either before confirming.

## Tests

`tests/config-authz.test.ts` (+5): admin passes, super-admin trumps isAdmin, non-admin baseline 403, non-admin with full per-row rights still 403, cross-org via `?org=`.
`tests/config-api.test.ts` (+6): body shape with + without `newLabel`, URL encoding, 409 error pass-through, non-JSON error fallback, `?org=` threading.

Suite 372 → 383.

## Out of scope

- **§3 retire-and-forward** — separate PR C in the umbrella; different UX (destructive + target-picker).
- **Non-admin clone** — gated on #240.
- **Existing alias badges on the cloned mode's header** — a freshly cloned mode has no aliases by definition, so no display change is needed. The badge code already handles the empty case.

## Test plan

- [ ] `npm run typecheck` — ✓ local
- [ ] `npm run lint` — ✓ local
- [ ] `npm run test` — ✓ local (383 passing)
- [ ] `npm run build` — ✓ local (via pre-commit)
- [ ] Visual on staging: as an admin, select a mode → click Clone → enter a new slug + label → confirm the clone appears in the dropdown as a Draft and the editor opens on it. Try a collision (existing slug or alias) → confirm the engine's 409 message appears inline in the dialog.

Refs #241, #232. Depends on bt-servant-worker#285 (v2.28.0, shipped).