### PR TITLE
feat(modes): retire-and-forward via engine _retire op (#241 PR C)

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -28,6 +28,7 @@ import {
   useMode,
   useModes,
   useRenameMode,
+  useRetireMode,
   useSaveMode,
 } from "@/hooks/use-prompt-config";
 import type { MarkdownHeading } from "@/types/markdown";
@@ -83,6 +84,7 @@ export function ModesPage() {
   const deleteMode = useDeleteMode(contextOrg);
   const renameMode = useRenameMode(contextOrg);
   const cloneMode = useCloneMode(contextOrg);
+  const retireMode = useRetireMode(contextOrg);
 
   // Filter modes to those the user has any verb on (admin/cross-org
   // sees everything via the `*` short-circuit above). Mirrors
@@ -118,6 +120,11 @@ export function ModesPage() {
   // mode they can't edit. Kept as a separate boolean so the gate can
   // loosen independently once rights-migration lands (#240).
   const canCloneSelected = isAdmin || isCrossOrg;
+  // Retire rides the same gate (#241 PR C). Deleting a mode + widening
+  // the target's alias set are org-wide config changes at the same
+  // trust bar as rename. Loosen independently when rights-migration
+  // (#240) exists.
+  const canRetireSelected = isAdmin || isCrossOrg;
 
   // Local document draft (auto-save target).
   //
@@ -426,6 +433,19 @@ export function ModesPage() {
     [cloneMode, handleSelectMode]
   );
 
+  const handleRetireMode = useCallback(
+    async (name: string, forwardTo: string) => {
+      const data = await retireMode.mutateAsync({ name, forwardTo });
+      // Route through handleSelectMode so the switch-guard fires if
+      // the source draft dirtied while the modal was open (same
+      // reasoning as handleCloneMode — leaky focus race). Selection
+      // moves to the TARGET because the source is gone; `data.name`
+      // is the engine-canonical target slug.
+      handleSelectMode(data.name);
+    },
+    [handleSelectMode, retireMode]
+  );
+
   const handleRenameMode = useCallback(
     async (name: string, newName: string) => {
       await renameMode.mutateAsync({ name, newName });
@@ -446,10 +466,11 @@ export function ModesPage() {
 
   const error =
     modesQuery.error || (selectedMode !== null ? modeQuery.error : null);
-  // Clone errors are NOT folded in here — the clone dialog surfaces
-  // engine 400/404/409 messages inline via `runConfirmedAction`, so a
-  // page-level "Save failed:" banner would be both redundant AND
-  // misleading (clone isn't a save). #241 PR B Frank F3.
+  // Clone AND retire errors are NOT folded in here — both dialogs
+  // surface engine 400/404/409 messages inline via `runConfirmedAction`,
+  // so a page-level "Save failed:" banner would be both redundant AND
+  // misleading (neither is a save). #241 PR B Frank F3; retire matches
+  // the same policy on introduction (#241 PR C).
   const saveError = saveMode.error ?? deleteMode.error ?? renameMode.error;
 
   const saveStatus = useMemo(() => {
@@ -480,10 +501,12 @@ export function ModesPage() {
               onSetPublished={handleSetPublished}
               onRenameMode={handleRenameMode}
               onCloneMode={handleCloneMode}
+              onRetireMode={handleRetireMode}
               isCreating={saveMode.isPending}
               isDeleting={deleteMode.isPending}
               isRenaming={renameMode.isPending}
               isCloning={cloneMode.isPending}
+              isRetiring={retireMode.isPending}
               isSettingPublished={saveMode.isPending}
               showDrafts={showDrafts}
               onToggleShowDrafts={setShowDrafts}
@@ -492,6 +515,7 @@ export function ModesPage() {
               canDeleteSelected={canDeleteSelected}
               canRenameSelected={canRenameSelected}
               canCloneSelected={canCloneSelected}
+              canRetireSelected={canRetireSelected}
               renameDisabledReason={
                 isDirty || isSaving
                   ? "Save your changes before renaming."
@@ -499,6 +523,11 @@ export function ModesPage() {
               }
               cloneDisabledReason={
                 isDirty || isSaving ? "Save your changes before cloning." : null
+              }
+              retireDisabledReason={
+                isDirty || isSaving
+                  ? "Save your changes before retiring."
+                  : null
               }
             />
           </div>

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { faLayerGroup } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
+  ArrowRightLeft,
   Copy,
   Eye,
   EyeOff,
@@ -58,10 +59,15 @@ interface ModeSelectorProps {
     newName: string,
     newLabel: string
   ) => Promise<void>;
+  /** Retire a mode and forward its users to `forwardTo` via the engine's
+      `_retire` op (#241 PR C). Same reject-on-error contract as delete
+      and clone. */
+  onRetireMode: (name: string, forwardTo: string) => Promise<void>;
   isCreating: boolean;
   isDeleting: boolean;
   isRenaming: boolean;
   isCloning: boolean;
+  isRetiring: boolean;
   isSettingPublished: boolean;
   showDrafts: boolean;
   onToggleShowDrafts: (showDrafts: boolean) => void;
@@ -79,6 +85,11 @@ interface ModeSelectorProps {
       end up with a mode they can't edit. Kept as a separate flag so the
       restriction can loosen independently once rights-migration lands. */
   canCloneSelected: boolean;
+  /** Retire rides the same admin/cross-org gate — deleting a mode +
+      widening the target's alias set is an org-wide config change
+      identical in trust bar to rename. Kept as its own flag so the
+      restriction can loosen independently. */
+  canRetireSelected: boolean;
   /** Non-null disables the Rename trigger and shows the string as its
       tooltip — used to block rename while the editor has unsaved edits
       (renaming re-syncs the doc under the new slug and would drop them). */
@@ -89,6 +100,13 @@ interface ModeSelectorProps {
       silently re-syncs the editor from the clone's document and drops
       any unsaved edits to the source (#241 PR B Frank F1). */
   cloneDisabledReason: string | null;
+  /** Non-null disables the Retire trigger and shows the string as its
+      tooltip. Same shape as `renameDisabledReason` / `cloneDisabledReason`
+      — retire deletes the source and shifts selection to the target,
+      which would silently drop any unsaved edits. Belt-and-suspenders
+      route through `handleSelectMode` in modes.tsx defends the race
+      window when focus escapes the modal. */
+  retireDisabledReason: string | null;
 }
 
 function isPublished(mode: Pick<PromptMode, "published">): boolean {
@@ -117,10 +135,12 @@ export function ModeSelector({
   onSetPublished,
   onRenameMode,
   onCloneMode,
+  onRetireMode,
   isCreating,
   isDeleting,
   isRenaming,
   isCloning,
+  isRetiring,
   isSettingPublished,
   showDrafts,
   onToggleShowDrafts,
@@ -129,8 +149,10 @@ export function ModeSelector({
   canDeleteSelected,
   canRenameSelected,
   canCloneSelected,
+  canRetireSelected,
   renameDisabledReason,
   cloneDisabledReason,
+  retireDisabledReason,
 }: ModeSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -152,6 +174,9 @@ export function ModeSelector({
   const [cloneError, setCloneError] = useState<string | null>(null);
   const [cloneName, setCloneName] = useState("");
   const [cloneLabel, setCloneLabel] = useState("");
+  const [retireOpen, setRetireOpen] = useState(false);
+  const [retireError, setRetireError] = useState<string | null>(null);
+  const [retireTarget, setRetireTarget] = useState<string>("");
 
   const handleConfirmUnpublish = useCallback(() => {
     if (selectedMode === null) return;
@@ -172,6 +197,30 @@ export function ModeSelector({
       "Failed to delete mode."
     );
   }, [onDeleteMode, selectedMode]);
+
+  const handleConfirmRetire = useCallback(() => {
+    if (selectedMode === null) return;
+    if (!retireTarget) {
+      setRetireError("Pick a mode to forward users to.");
+      return;
+    }
+    if (retireTarget === selectedMode) {
+      // Belt-and-suspenders — the Select excludes self, but the engine
+      // also 400s a retire-to-self and this catches any wire-shape
+      // slip. Keeps the affordance ↔ action gate consistent.
+      setRetireError("Forward target must differ from the source.");
+      return;
+    }
+    return runConfirmedAction(
+      () => onRetireMode(selectedMode, retireTarget),
+      setRetireError,
+      () => {
+        setRetireOpen(false);
+        setRetireTarget("");
+      },
+      "Failed to retire mode."
+    );
+  }, [onRetireMode, retireTarget, selectedMode]);
 
   const handleConfirmClone = useCallback(() => {
     if (selectedMode === null) return;
@@ -583,6 +632,113 @@ export function ModeSelector({
                       disabled={isCloning || !slugify(cloneName)}
                     >
                       {isCloning ? "Cloning…" : "Clone"}
+                    </Button>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+
+            {canRetireSelected && (
+              <AlertDialog
+                open={retireOpen}
+                onOpenChange={(next) => {
+                  setRetireOpen(next);
+                  if (next) {
+                    setRetireTarget("");
+                    setRetireError(null);
+                  } else {
+                    setRetireError(null);
+                    setRetireTarget("");
+                  }
+                }}
+              >
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={isRetiring || retireDisabledReason !== null}
+                    title={retireDisabledReason ?? undefined}
+                    className="text-amber-600 hover:text-amber-600 dark:text-amber-500 dark:hover:text-amber-500"
+                  >
+                    <ArrowRightLeft className="mr-1.5 size-3.5" />
+                    Retire
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Retire and forward</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Delete{" "}
+                      <span className="text-foreground font-medium">
+                        &ldquo;{selectedMode}&rdquo;
+                      </span>{" "}
+                      and forward every user assigned to it (plus anyone still
+                      resolving via one of its previous aliases) onto the target
+                      mode below. The target inherits the source&rsquo;s slug as
+                      a new alias, so nobody is left without a mode &mdash; but
+                      the source itself is permanently removed.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="mode-retire-target" className="text-xs">
+                      Forward to
+                    </Label>
+                    <Select
+                      value={retireTarget}
+                      onValueChange={setRetireTarget}
+                    >
+                      <SelectTrigger id="mode-retire-target" className="h-8">
+                        <SelectValue placeholder="Pick a target mode" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {modes
+                          .filter((m) => m.name !== selectedMode)
+                          .map((m) => (
+                            <SelectItem key={m.name} value={m.name}>
+                              <span className="flex items-center gap-2">
+                                <span className="truncate">
+                                  {m.label || m.name}
+                                </span>
+                                {!isPublished(m) && (
+                                  <Badge
+                                    variant="outline"
+                                    className="px-1.5 py-0 text-[10px]"
+                                  >
+                                    Draft
+                                  </Badge>
+                                )}
+                              </span>
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                    {modes.filter((m) => m.name !== selectedMode).length ===
+                      0 && (
+                      <p className="text-muted-foreground text-xs">
+                        No other modes exist to forward to. Create one first.
+                      </p>
+                    )}
+                  </div>
+                  {retireError && (
+                    <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                      {retireError}
+                    </p>
+                  )}
+                  <AlertDialogFooter>
+                    <AlertDialogCancel disabled={isRetiring}>
+                      Cancel
+                    </AlertDialogCancel>
+                    {/* Plain Button — see comment in Unpublish dialog above.
+                        Retire is destructive-styled to signal the source
+                        goes away, but amber-not-red because users
+                        aren't stranded (the alias route keeps them
+                        resolving on the target). */}
+                    <Button
+                      variant="destructive"
+                      onClick={handleConfirmRetire}
+                      disabled={isRetiring || !retireTarget}
+                    >
+                      {isRetiring ? "Retiring…" : "Retire & forward"}
                     </Button>
                   </AlertDialogFooter>
                 </AlertDialogContent>

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -220,6 +220,60 @@ export function useCloneMode(org?: string | null) {
   });
 }
 
+// Apply a retire-and-forward to the cached modes list. Exported for
+// unit tests. Removes the SOURCE (`sourceName`) entry and replaces the
+// TARGET entry with the response's `target` (which now carries the
+// source's slug + the source's own aliases in its own `aliases`
+// array). Returns `prev` untouched when nothing is cached yet so an
+// optimistic write never fabricates a list. If either the source or
+// target isn't present, that individual step is a no-op — the source
+// removal is idempotent, the target replace matches on name.
+export function applyRetireToModeList(
+  prev: OrgModes | undefined,
+  sourceName: string,
+  target: PromptMode
+): OrgModes | undefined {
+  if (!prev) return prev;
+  return {
+    ...prev,
+    modes: prev.modes
+      .filter((m) => m.name !== sourceName)
+      .map((m) => (m.name === target.name ? target : m)),
+  };
+}
+
+// Retire a mode and forward its users to another mode via the engine's
+// `_retire` op (#241 PR C). Three-part cache update:
+//
+//  1. Synchronously rewrite the LIST cache via `applyRetireToModeList`
+//     — the source is removed, the target's entry is replaced with the
+//     response (now widened aliases). Without the optimistic write the
+//     page's stale-selection guard would fire on the source's slug in
+//     the render gap after the page's `handleSelectMode(target.name)`.
+//  2. Overwrite the target's per-mode cache with the response so the
+//     editor renders the updated alias set without a loading gap. Drop
+//     the source's per-mode cache entry so a subsequent stale read
+//     doesn't resurrect it.
+//  3. Invalidate the list + both per-mode caches so the optimistic
+//     writes reconcile with server truth.
+export function useRetireMode(org?: string | null) {
+  const qc = useQueryClient();
+  const key = normalize(org);
+  return useMutation({
+    mutationFn: ({ name, forwardTo }: { name: string; forwardTo: string }) =>
+      configApi.retireMode(name, forwardTo, undefined, key),
+    onSuccess: (data, { name }) => {
+      qc.setQueryData<OrgModes>(keys.modes(key), (prev) =>
+        applyRetireToModeList(prev, name, data)
+      );
+      qc.setQueryData(keys.mode(data.name, key), data);
+      qc.removeQueries({ queryKey: keys.mode(name, key) });
+      void qc.invalidateQueries({ queryKey: keys.modes(key) });
+      void qc.invalidateQueries({ queryKey: keys.mode(data.name, key) });
+    },
+  });
+}
+
 export function useSetUserMode(org?: string | null) {
   const key = normalize(org);
   return useMutation({

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -269,6 +269,41 @@ export async function cloneMode(
   return unwrapModeResponse((await res.json()) as Record<string, unknown>);
 }
 
+// Retire the source mode and forward users onto `forwardTo` via the
+// engine's `_retire` op (#232 / #241 PR C). The engine moves the
+// source's canonical slug AND its own existing aliases onto the
+// target's aliases array (Ian's #232 reconciliation §3), then deletes
+// the source. Returns the TARGET mode (widened aliases). Rejects with
+// 400 (retire-to-self, missing body), 404 (missing source or missing
+// `forwardTo` target).
+export async function retireMode(
+  name: string,
+  forwardTo: string,
+  signal?: AbortSignal,
+  org?: string | null
+): Promise<PromptMode> {
+  const res = await fetch(
+    buildConfigUrl(
+      `/api/config/modes/${encodeURIComponent(name)}/_retire`,
+      org
+    ),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+      body: JSON.stringify({ forwardTo }),
+      signal,
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to retire mode (${res.status}): ${await readModeOpError(res)}`
+    );
+  }
+
+  return unwrapModeResponse((await res.json()) as Record<string, unknown>);
+}
+
 // ---------------------------------------------------------------------------
 // Per-user memory
 // ---------------------------------------------------------------------------

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -12,6 +12,7 @@ import {
   putMode,
   putOrgOverrides,
   renameMode,
+  retireMode,
   setUserMode,
 } from "../src/lib/config-api";
 
@@ -475,6 +476,90 @@ describe("cloneMode", () => {
     await cloneMode("spoken", { newName: "new" }, undefined, "word-collective");
     expect(spy.mock.calls[0]![0]).toBe(
       "/api/config/modes/spoken/_clone?org=word-collective"
+    );
+  });
+});
+
+describe("retireMode", () => {
+  it("POSTs `{ forwardTo }` to the _retire endpoint and unwraps the TARGET envelope", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          org: "uw",
+          // Engine returns the TARGET (with widened aliases), not the
+          // source. Client passes it through so the page can pre-write
+          // the target's per-mode cache and re-point selection.
+          mode: {
+            name: "conversation",
+            label: "Conversation",
+            document: "## Identity\n",
+            published: true,
+            aliases: ["spoken", "spoken-old"],
+          },
+          message: "Mode retired",
+        }),
+        { status: 200 }
+      )
+    );
+    const result = await retireMode("spoken", "conversation");
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/spoken/_retire");
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      forwardTo: "conversation",
+    });
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json"
+    );
+    expect(result.name).toBe("conversation");
+    expect(result.aliases).toEqual(["spoken", "spoken-old"]);
+  });
+
+  it("URL-encodes the source mode name in the path", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "target", document: "" } }))
+      );
+    await retireMode("kids mode", "target");
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/kids%20mode/_retire");
+  });
+
+  it("surfaces the engine's JSON `{ error }` message on retire-to-self / missing target", async () => {
+    // Engine returns 400 for retire-to-self, 404 for missing forwardTo
+    // target. Both should surface inline; strip the outer JSON blob so
+    // the dialog shows the engine's message, not the raw wire body.
+    mockFetchOnce(400, { error: "Cannot retire a mode to itself" });
+    await expect(retireMode("spoken", "spoken")).rejects.toThrow(
+      /Failed to retire mode \(400\): Cannot retire a mode to itself/
+    );
+  });
+
+  it("surfaces the engine's 404 message when the forward target is missing", async () => {
+    mockFetchOnce(404, {
+      error: 'Target mode "does-not-exist" not found in org',
+    });
+    await expect(retireMode("spoken", "does-not-exist")).rejects.toThrow(
+      /Failed to retire mode \(404\): Target mode "does-not-exist" not found/
+    );
+  });
+
+  it("falls back to raw text when the error body isn't JSON", async () => {
+    mockFetchOnce(500, "upstream boom");
+    await expect(retireMode("spoken", "target")).rejects.toThrow(
+      /Failed to retire mode \(500\): upstream boom/
+    );
+  });
+
+  it("threads org through as ?org=", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ mode: { name: "target", document: "" } }))
+      );
+    await retireMode("spoken", "target", undefined, "word-collective");
+    expect(spy.mock.calls[0]![0]).toBe(
+      "/api/config/modes/spoken/_retire?org=word-collective"
     );
   });
 });

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1051,6 +1051,131 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #241 PR C mode retire — POST /api/config/modes/{name}/_retire
+// ---------------------------------------------------------------------------
+//
+// Retire moves the source mode's canonical slug (+ its own aliases) onto the
+// target mode's aliases array, then deletes the source. Users assigned to
+// the source (or resolving via one of its previous aliases) silently
+// resolve to the target. Same admin/cross-org gate as _rename and _clone —
+// deleting a mode is an org-wide config change at the same trust bar as
+// today's PUT/DELETE modes. Regex is segment-anchored so a duplicated
+// suffix falls through to the generic arm and 405s at the BFF.
+
+function makeRetireRequest(name: string, body: object): Request {
+  return new Request(
+    `https://portal.example.test/api/config/modes/${name}/_retire`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("config authz — #241 PR C mode retire (_retire)", () => {
+  it("admin → proxies POST to engine _retire path", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("POST");
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/modes/spoken/_retire"
+    );
+  });
+
+  it("super admin without isAdmin → proxies (super trumps isAdmin)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-admin without any explicit mode rights → 403 (baseline, no proxy)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({ isAdmin: false }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-admin with BOTH edit+publish on the source row → 403 (retire is admin-only)", async () => {
+    // Same reasoning as rename/clone: retire deletes a mode + widens the
+    // target's alias set (org-wide change), and the target's rights
+    // aren't necessarily aligned with the source's — a shepherd who
+    // could edit the source might have no rights on the target.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken", "conversation"],
+        mode_publish_rights: ["spoken", "conversation"],
+      }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("super-admin cross-org via ?org=other → proxies to /orgs/other/.../_retire", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_retire?org=word-collective",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ forwardTo: "conversation" }),
+        }
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/modes/spoken/_retire"
+    );
+  });
+
+  it("does not match a duplicated /_retire suffix (regex is segment-anchored, not greedy)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/foo/_retire/_retire",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ forwardTo: "bar" }),
+        }
+      ),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/foo/_retire/_retire"
+    );
+    expect(res.status).toBe(405);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("config authz — #181 verb diff (pure function)", () => {
   const { computeRequiredVerbsForPut } = __testInternals;
 

--- a/tests/use-prompt-config.test.ts
+++ b/tests/use-prompt-config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyCloneToModeList,
   applyRenameToModeList,
+  applyRetireToModeList,
 } from "../src/hooks/use-prompt-config";
 import type { OrgModes, PromptMode } from "../src/types/prompt-override";
 
@@ -128,5 +129,85 @@ describe("applyCloneToModeList", () => {
     // payload (label + document from the mutation response).
     expect(next!.modes[1]).toBe(cloned);
     expect(next!.modes[1]).not.toBe(stale);
+  });
+});
+
+// Regression + spec for the #241 PR C retire-and-forward cache
+// surgery. The engine returns the TARGET mode (widened aliases) and the
+// source is deleted. The list cache must drop the source AND replace
+// the target with the response payload — the page's post-retire
+// `handleSelectMode(target.name)` reads from `modesQuery.data` and the
+// stale-selection guard would fire on either half being out of sync.
+
+const retireTarget: PromptMode = {
+  name: "conversation",
+  label: "Conversation",
+  document: "## Identity\n",
+  published: true,
+  aliases: ["spoken", "spoken-old"],
+};
+
+describe("applyRetireToModeList", () => {
+  it("drops the source and replaces the target with the response payload", () => {
+    const prev: OrgModes = {
+      modes: [
+        { name: "spoken", document: "## src\n", published: true },
+        {
+          name: "conversation",
+          document: "## tgt-old\n",
+          published: true,
+          aliases: ["conv-old"],
+        },
+        { name: "written", document: "## other\n", published: false },
+      ],
+    };
+
+    const next = applyRetireToModeList(prev, "spoken", retireTarget);
+
+    expect(next!.modes.map((m) => m.name)).toEqual(["conversation", "written"]);
+    // Target's entry is the response payload verbatim (aliases now
+    // include the source's slug + its own prior aliases).
+    const target = next!.modes.find((m) => m.name === "conversation");
+    expect(target).toBe(retireTarget);
+    expect(target?.aliases).toEqual(["spoken", "spoken-old"]);
+  });
+
+  it("returns undefined unchanged when nothing is cached yet", () => {
+    expect(
+      applyRetireToModeList(undefined, "spoken", retireTarget)
+    ).toBeUndefined();
+  });
+
+  it("is a no-op on source removal when the source isn't in the list (no fabrication)", () => {
+    // Concurrent tab already saw the retire and refetched, or the
+    // source was never in this cache. The target still gets its
+    // replace; nothing is fabricated on the source side.
+    const prev: OrgModes = {
+      modes: [
+        {
+          name: "conversation",
+          document: "## tgt-old\n",
+          published: true,
+        },
+      ],
+    };
+
+    const next = applyRetireToModeList(prev, "spoken", retireTarget);
+
+    expect(next!.modes.map((m) => m.name)).toEqual(["conversation"]);
+    expect(next!.modes[0]).toBe(retireTarget);
+  });
+
+  it("leaves target replace as a no-op when the target isn't in the list yet either", () => {
+    // Edge case: neither source nor target in the cache. The source
+    // filter is a no-op (source not there), the target map is a no-op
+    // (target not there). Cache stays effectively unchanged.
+    const prev: OrgModes = {
+      modes: [{ name: "written", document: "x", published: false }],
+    };
+
+    const next = applyRetireToModeList(prev, "spoken", retireTarget);
+
+    expect(next!.modes.map((m) => m.name)).toEqual(["written"]);
   });
 });

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -447,6 +447,34 @@ export async function handleConfig(
     );
   }
 
+  // /api/config/modes/{name}/_retire → POST. Retires the source mode
+  // by moving its canonical slug (+ its own existing aliases) onto the
+  // target mode's aliases array, then deleting the source. Users
+  // assigned to the source slug (or any of its previous aliases)
+  // silently resolve to the target — the "bring FIA Coach users over
+  // silently" flow from Ian's #232 plan §3.
+  //
+  // Same admin/cross-org gate as _rename and _clone. Retire deletes a
+  // mode + widens the target's alias set, both of which are org-wide
+  // config changes; per-user mode rights are slug-scoped, so gating
+  // to admin/cross-org matches the trust bar of PUT/DELETE-modes
+  // today. `[^/]+` for the same reason as _rename and _clone above.
+  const modeRetireMatch = pathname.match(
+    /^\/api\/config\/modes\/([^/]+)\/_retire$/
+  );
+  if (modeRetireMatch?.[1]) {
+    const modeName = decodeURIComponent(modeRetireMatch[1]);
+    if (!resolved.crossOrg && !hasAdminPowers(session)) {
+      return errorResponse("Forbidden", 403);
+    }
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_retire`,
+      ["POST"]
+    );
+  }
+
   // /api/config/modes/{name} → GET (any session) / PUT/DELETE (per-mode
   // verb-perms, admin-trump)
   const modeMatch = pathname.match(/^\/api\/config\/modes\/(.+)$/);


### PR DESCRIPTION
## Summary

**Final slice of the #241 umbrella.** Closes Ian's deferred §3 (retire-and-forward) from the [#232 plan](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/232#issuecomment-4791833638). Engine `_retire` endpoint has been live since bt-servant-worker v2.28.0; this PR wires the portal through all four layers.

## What retire does

Retire moves the source mode's canonical slug **AND** its own existing aliases onto the target mode's aliases array (Ian's [#232 reconciliation §3](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/232#issuecomment-4803957569)), then deletes the source. Users assigned to the source (or resolving via one of its previous aliases) silently resolve to the target — nobody stranded. The "bring FIA Coach users over silently" flow.

| Layer | File | Change |
|---|---|---|
| Worker proxy | `worker/config.ts` | `POST /api/config/modes/{name}/_retire` arm; admin/cross-org direct-gate; `[^/]+` segment-anchored regex |
| API client | `src/lib/config-api.ts` | `retireMode(name, forwardTo, signal?, org?)` |
| Hook | `src/hooks/use-prompt-config.ts` | `useRetireMode()` + new `applyRetireToModeList` helper |
| UI | `src/components/mode-selector.tsx`, `src/app/pages/modes.tsx` | Retire button (amber) + confirm dialog with target `<Select>` |

## Design notes

- **Same admin/cross-org gate as rename + clone.** Retire deletes a mode + widens the target's alias set — both org-wide config changes at the same trust bar as PUT/DELETE modes. Loosens independently when #240 (rights-migration) lands.
- **Cache surgery is three-part.** Source filtered out of list; target's entry replaced with the response payload (widened aliases); source's per-mode cache removed; then invalidations reconcile. Mirrors the shape Frank locked in via `applyRenameToModeList` / `applyCloneToModeList`.
- **Belt-and-suspenders selection routing.** `handleRetireMode` routes through `handleSelectMode(data.name)` (not raw `setSelectedMode`) so if the source draft dirtied while the modal was open, the switch-guard fires. Selection naturally lands on the target since the source is gone.
- **`retireDisabledReason` mirrors clone + rename.** Blocked on `isDirty || isSaving`; renders as tooltip on the disabled Retire button.
- **Retire errors surface inline only.** Not folded into `saveError` — same policy Frank F3 established on PR B, generalized in a shared comment covering both clone and retire.
- **Target `<Select>` excludes self** at the UI level; the confirm handler also rejects `retireTarget === selectedMode` before the runConfirmedAction call. Belt-and-suspenders because the engine also 400s a retire-to-self.
- **Empty-state message** ("No other modes exist to forward to. Create one first.") when the org has only one mode. Retire is disabled implicitly via the empty target — the Confirm button gates on `!retireTarget`.

## F9 evaluation (from PR B code review)

The three slug-op confirm handlers (rename/clone/retire) share the `runConfirmedAction` shape but differ substantively: rename + clone take slug inputs with `slugify` validation; retire takes a target `<Select>` with existence validation. Extracting a shared hook would need to accommodate both shapes and the resulting abstraction would obscure the per-op validation more than it saves. **Deferred** — the rule of three doesn't trigger cleanly.

## Tests

`tests/config-authz.test.ts` (+6): retire admin passes, super trumps isAdmin, non-admin baseline 403, non-admin with full per-row rights 403, cross-org via `?org=`, segment-anchored regex 405 on duplicated suffix.
`tests/config-api.test.ts` (+6): request-body shape, URL encoding, 400 retire-to-self message, 404 missing-target message, non-JSON error fallback, `?org=` threading.
`tests/use-prompt-config.test.ts` (+4): `applyRetireToModeList` — drop-source + replace-target, undefined cache, no-op on missing source, no-op on missing both.

Suite 392 → 408.

## Test plan

- [ ] `npm run typecheck` — ✓ local
- [ ] `npm run lint` — ✓ local
- [ ] `npm run test` — ✓ local (408 passing)
- [ ] `npm run build` — ✓ local (via pre-commit)
- [ ] Visual on staging: admin selects a mode → clicks Retire → picks a target from the Select → confirms → target is now selected and shows the source's slug in its alias badges. Try retire-to-self via a wire tweak → engine 400 surfaces inline. Try retire while dirty → button is disabled with the tooltip.

Refs #241, #232. Depends on bt-servant-worker#285 (v2.28.0, shipped).