### PR TITLE
feat(modes): migrate per-user mode rights on rename; open rename to shepherds (#240)

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Download, Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
-import { fetchMe } from "@/lib/auth-api";
 import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import {
@@ -481,28 +480,23 @@ export function ModesPage() {
           ),
         });
       }
-      // Follow the selection to the new slug so the editor re-syncs the
-      // doc under the renamed identity instead of orphaning on the old
-      // (now alias-only) name. Route through handleSelectMode (not raw
-      // setSelectedMode) so the dirty-editor switch-guard applies —
-      // same belt-and-suspenders as clone (#241 PR B) and retire.
-      if (name === selectedMode) handleSelectMode(newName);
-      // Background true-up from the server, shepherds only: admin and
-      // cross-org gates resolve to "*" without reading stored arrays,
-      // so the round-trip would be a pure no-op for them. Fire-and-
-      // forget — the optimistic patch above already made the UI
-      // consistent; this just reconciles any drift.
-      if (!isAdmin && !isCrossOrg) {
-        void fetchMe()
-          .then((freshUser) => {
-            if (freshUser) setUser(freshUser);
-          })
-          .catch(() => {
-            // keep the optimistic patch; next full load reconciles
-          });
-      }
+      // Follow the selection to the new slug DIRECTLY — deliberately
+      // NOT via handleSelectMode, unlike clone/retire (rd-4 review).
+      // Their switch-guard protects a still-existing source row; after
+      // a rename the old slug is gone from the list cache and the
+      // stale-selection guard nulls it regardless, so deferring to a
+      // "Switch mode?" dialog offers a "Stay" that cannot be honored.
+      // The rename dialog is dirty-gated upstream (renameDisabledReason)
+      // — a draft dirtied through the focus-leak window re-syncs under
+      // the renamed identity, same as main's pre-#240 behavior.
+      if (name === selectedMode) setSelectedMode(newName);
+      // No server true-up here: /me re-reads KV, which is eventually
+      // consistent — a racing read could return the PRE-migration
+      // snapshot and clobber the exact patch above (rd-4 review). The
+      // local patch mirrors the worker's migration; the next full page
+      // load reconciles any residual drift.
     },
-    [renameMode, selectedMode, handleSelectMode, setUser, isAdmin, isCrossOrg]
+    [renameMode, selectedMode, setSelectedMode, setUser]
   );
 
   const handleJumpToLine = useCallback((line: number) => {

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Download, Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
+import { fetchMe } from "@/lib/auth-api";
 import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import {
@@ -55,6 +56,7 @@ const AUTO_SAVE_DEBOUNCE_MS = 800;
 
 export function ModesPage() {
   const user = useAuthStore((s) => s.user);
+  const setUser = useAuthStore((s) => s.setUser);
   const isAdmin = hasAdminPowers(user);
   const homeOrg = useAuthStore((s) => s.user?.org);
   const selectedMode = useUiStore((s) => s.selectedMode);
@@ -452,12 +454,26 @@ export function ModesPage() {
   const handleRenameMode = useCallback(
     async (name: string, newName: string) => {
       await renameMode.mutateAsync({ name, newName });
+      // #240: the worker migrated this user's stored mode_*_rights to
+      // the new slug, but the Zustand auth store still holds the login-
+      // time snapshot with the OLD slug — the per-row rights guard and
+      // the dropdown filter below would hide the just-renamed mode
+      // until a full reload. Refresh from /me BEFORE moving the
+      // selection so the guard sees the migrated rights. Best-effort:
+      // on failure keep the stale user (admins are unaffected either
+      // way; a shepherd falls back to reload — the pre-#240 behavior).
+      try {
+        const freshUser = await fetchMe();
+        if (freshUser) setUser(freshUser);
+      } catch {
+        // keep the stale snapshot; selection below still moves
+      }
       // Follow the selection to the new slug so the editor re-syncs the
       // doc under the renamed identity instead of orphaning on the old
       // (now alias-only) name.
       if (name === selectedMode) setSelectedMode(newName);
     },
-    [renameMode, selectedMode, setSelectedMode]
+    [renameMode, selectedMode, setSelectedMode, setUser]
   );
 
   const handleJumpToLine = useCallback((line: number) => {

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -14,6 +14,7 @@ import {
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
 import {
   effectiveModeEditRights,
+  renameSlugInRights,
   effectiveModePublishRights,
   filterByAnyRights,
   hasAdminPowers,
@@ -457,23 +458,51 @@ export function ModesPage() {
       // #240: the worker migrated this user's stored mode_*_rights to
       // the new slug, but the Zustand auth store still holds the login-
       // time snapshot with the OLD slug — the per-row rights guard and
-      // the dropdown filter below would hide the just-renamed mode
-      // until a full reload. Refresh from /me BEFORE moving the
-      // selection so the guard sees the migrated rights. Best-effort:
-      // on failure keep the stale user (admins are unaffected either
-      // way; a shepherd falls back to reload — the pre-#240 behavior).
-      try {
-        const freshUser = await fetchMe();
-        if (freshUser) setUser(freshUser);
-      } catch {
-        // keep the stale snapshot; selection below still moves
+      // the dropdown filter would hide the just-renamed mode. Patch the
+      // store SYNCHRONOUSLY (a local mirror of the worker's migration)
+      // so no render ever sees the fresh list paired with stale rights.
+      // An awaited /me here would reopen exactly that window: the list
+      // cache already swapped slugs in useRenameMode.onSuccess, and the
+      // stale-selection guard would null the selection mid-round-trip,
+      // blanking the editor (rd-3 review).
+      const current = useAuthStore.getState().user;
+      if (current) {
+        setUser({
+          ...current,
+          mode_edit_rights: renameSlugInRights(
+            current.mode_edit_rights,
+            name,
+            newName
+          ),
+          mode_publish_rights: renameSlugInRights(
+            current.mode_publish_rights,
+            name,
+            newName
+          ),
+        });
       }
       // Follow the selection to the new slug so the editor re-syncs the
       // doc under the renamed identity instead of orphaning on the old
-      // (now alias-only) name.
-      if (name === selectedMode) setSelectedMode(newName);
+      // (now alias-only) name. Route through handleSelectMode (not raw
+      // setSelectedMode) so the dirty-editor switch-guard applies —
+      // same belt-and-suspenders as clone (#241 PR B) and retire.
+      if (name === selectedMode) handleSelectMode(newName);
+      // Background true-up from the server, shepherds only: admin and
+      // cross-org gates resolve to "*" without reading stored arrays,
+      // so the round-trip would be a pure no-op for them. Fire-and-
+      // forget — the optimistic patch above already made the UI
+      // consistent; this just reconciles any drift.
+      if (!isAdmin && !isCrossOrg) {
+        void fetchMe()
+          .then((freshUser) => {
+            if (freshUser) setUser(freshUser);
+          })
+          .catch(() => {
+            // keep the optimistic patch; next full load reconciles
+          });
+      }
     },
-    [renameMode, selectedMode, setSelectedMode, setUser]
+    [renameMode, selectedMode, handleSelectMode, setUser, isAdmin, isCrossOrg]
   );
 
   const handleJumpToLine = useCallback((line: number) => {

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -110,11 +110,14 @@ export function ModesPage() {
   const canPublishSelected =
     selectedMode !== null && hasRights(modePublishRights, selectedMode);
   const canDeleteSelected = canEditSelected && canPublishSelected;
-  // Rename is admin/cross-org only (#238 review). Per-user mode rights are
-  // slug-scoped, so a non-admin shepherd renaming a mode would lock
-  // themselves out of the renamed slug. Mirror the worker gate, which
-  // 403s any non-admin same-org rename.
-  const canRenameSelected = isAdmin || isCrossOrg;
+  // Rename opens to shepherds with EDIT rights on the row (#240): the
+  // worker now migrates per-user `mode_*_rights` old-slug→new-slug
+  // around the engine rename, so a shepherd renaming their own mode
+  // keeps access to the renamed slug. Mirrors the worker gate (admin /
+  // cross-org / edit-on-source). isAdmin/isCrossOrg are implied by
+  // canEditSelected here (both resolve modeEditRights to "*") but stay
+  // explicit to keep the gate's intent readable.
+  const canRenameSelected = isAdmin || isCrossOrg || canEditSelected;
   // Clone rides the same gate as rename today (#241 PR B). The clone
   // has no rights pre-assigned, so a non-admin cloning would land on a
   // mode they can't edit. Kept as a separate boolean so the gate can

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -205,8 +205,11 @@ export function filterAuthorizedLanguages<T extends { name: string }>(
 // mode_*_rights (old slug → new slug) — but the client auth store still
 // holds the login-time snapshot, and the per-row guard + dropdown
 // filter would hide the just-renamed mode until a reload. The caller
-// applies this synchronously post-rename (with a background /me
-// true-up), so the UI never renders an inconsistent rights/list pair.
+// applies this synchronously post-rename so the UI never renders an
+// inconsistent rights/list pair. Deliberately NO server true-up after
+// the patch: /me re-reads eventually-consistent KV, and a racing read
+// could return the PRE-migration snapshot and clobber this exact patch
+// (rd-4/rd-5 review) — the next full page load reconciles any drift.
 // `undefined` and `"*"` pass through — wildcard callers don't key on
 // stored arrays.
 export function renameSlugInRights(

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -199,3 +199,23 @@ export function filterAuthorizedLanguages<T extends { name: string }>(
   const allowed = new Set(rights);
   return languages.filter((l) => allowed.has(l.name));
 }
+
+// #240: local mirror of the worker's rename rights-migration. After a
+// shepherd renames a mode, the worker rewrites their stored
+// mode_*_rights (old slug → new slug) — but the client auth store still
+// holds the login-time snapshot, and the per-row guard + dropdown
+// filter would hide the just-renamed mode until a reload. The caller
+// applies this synchronously post-rename (with a background /me
+// true-up), so the UI never renders an inconsistent rights/list pair.
+// `undefined` and `"*"` pass through — wildcard callers don't key on
+// stored arrays.
+export function renameSlugInRights(
+  rights: LanguageRights | undefined,
+  from: string,
+  to: string
+): LanguageRights | undefined {
+  if (rights === undefined || rights === "*") return rights;
+  if (!rights.includes(from)) return rights;
+  const withoutFrom = rights.filter((slug) => slug !== from);
+  return withoutFrom.includes(to) ? withoutFrom : [...withoutFrom, to];
+}

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -2,7 +2,7 @@ import { env } from "cloudflare:test";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { __testInternals, handleConfig } from "../worker/config";
-import type { SessionData } from "../worker/types";
+import type { SessionData, StoredUser } from "../worker/types";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -819,13 +819,19 @@ describe("config authz — #181 verb-perms (modes)", () => {
 // ---------------------------------------------------------------------------
 //
 // Rename reslugs a mode's canonical identity in place (the engine keeps the
-// old slug as an alias so assigned users aren't stranded). The BFF restricts
-// it to admins + super-admin cross-org and proxies the POST (with its
-// `{ newName }` body) to the engine `_rename` op. Non-admin shepherds are
-// blocked even with full per-row rights: their mode rights are slug-scoped
-// and a rename would lock them out of the renamed slug (#238 review). The
-// dedicated route must be matched before the generic `modes/{name}` route,
-// which would otherwise swallow `{name}/_rename` and 405 the POST.
+// old slug as an alias so assigned users aren't stranded). The BFF proxies
+// the POST (with its `{ newName }` body) to the engine `_rename` op.
+//
+// #240 opened rename to non-admin shepherds with EDIT rights on the source
+// mode: the arm now migrates per-user `mode_*_rights` (old slug → new slug)
+// around the engine call, so a shepherd renaming their own mode keeps
+// access to the renamed slug (previously the #238-review reason to gate
+// admin-only). Publish-only shepherds stay denied — rename is an edit-side
+// action. The dedicated route must be matched before the generic
+// `modes/{name}` route, which would otherwise swallow `{name}/_rename` and
+// 405 the POST. Migration side-effect coverage lives in the "#240 rename
+// rights migration" describe below; pure-helper coverage in
+// tests/rights-migration.test.ts.
 
 function makeRenameRequest(name: string, newName: string): Request {
   return new Request(
@@ -879,10 +885,9 @@ describe("config authz — #232 mode rename (_rename)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("non-admin with BOTH edit+publish on the row → 403 (rename is admin-only)", async () => {
-    // The crux of the #238 review: full per-row rights are NOT enough.
-    // Mode rights are slug-scoped, so letting a shepherd rename would lock
-    // them out of the renamed slug. Only admins/cross-org may rename.
+  it("non-admin shepherd with EDIT rights on the row → proxies (#240)", async () => {
+    // Inversion of the #238-review case: with rights migration in place,
+    // full per-row rights ARE enough. This was 403 pre-#240.
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
@@ -893,7 +898,96 @@ describe("config authz — #232 mode rename (_rename)", () => {
       }),
       "/api/config/modes/spoken/_rename"
     );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/modes/spoken/_rename"
+    );
+  });
+
+  it("non-admin shepherd with edit-only rights → proxies (#240 acceptance)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ mode_edit_rights: ["spoken"] }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-admin with publish-only rights → 403 (rename is edit-side)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ mode_publish_rights: ["spoken"] }),
+      "/api/config/modes/spoken/_rename"
+    );
     expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-admin with edit rights on a DIFFERENT mode → 403", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ mode_edit_rights: ["other-mode"] }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("malformed JSON body → 400 without engine call", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_rename",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{not json",
+        }
+      ),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("missing newName → 400 without engine call", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_rename",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        }
+      ),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("GET on the rename route → 405 (method gate precedes body read)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("GET", "/api/config/modes/spoken/_rename"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(405);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -917,6 +1011,227 @@ describe("config authz — #232 mode rename (_rename)", () => {
     expect(String(fetchSpy.mock.calls[0]![0])).toContain(
       "/api/v1/admin/orgs/word-collective/modes/spoken/_rename"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #240 rename rights migration — per-user mode_*_rights old slug → new slug
+// ---------------------------------------------------------------------------
+//
+// End-to-end through handleConfig with real AUTH_KV records: the rename arm
+// expands affected users (old + new slug) before the engine call, then
+// contracts (drops old) on engine success or compensates (drops the never-
+// live new slug) on engine failure. Assertions inspect the stored user
+// records directly — the first KV-side-effect coverage in this file.
+
+interface SeedRightsUser {
+  email: string;
+  org: string;
+  mode_edit_rights?: StoredUser["mode_edit_rights"];
+  mode_publish_rights?: StoredUser["mode_publish_rights"];
+}
+
+async function seedRightsUser(input: SeedRightsUser): Promise<void> {
+  const stored: StoredUser = {
+    id: crypto.randomUUID(),
+    email: input.email,
+    name: input.email,
+    org: input.org,
+    // Auth fields are never consulted by the config gate — dummies keep
+    // the seed cheap (no PBKDF2 per test).
+    passwordHash: "x",
+    salt: "x",
+    isAdmin: false,
+    mode_edit_rights: input.mode_edit_rights,
+    mode_publish_rights: input.mode_publish_rights,
+  };
+  await env.AUTH_KV.put(`user:${input.email}`, JSON.stringify(stored));
+}
+
+async function readRightsUser(email: string): Promise<StoredUser> {
+  const user = await env.AUTH_KV.get<StoredUser>(`user:${email}`, {
+    type: "json",
+  });
+  if (!user) throw new Error(`seed user missing: ${email}`);
+  return user;
+}
+
+function spyFetchEngineFailure(status: number) {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(() =>
+      Promise.resolve(new Response('{"error":"engine says no"}', { status }))
+    );
+}
+
+describe("#240 rename rights migration", () => {
+  it("engine success → affected users' arrays hold the new slug, old removed", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["other", "spoken"],
+      mode_publish_rights: ["spoken"],
+    });
+    spyFetch();
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+
+    const after = await readRightsUser("shepherd@acme.com");
+    expect(after.mode_edit_rights).toEqual(["conversation", "other"]);
+    expect(after.mode_publish_rights).toEqual(["conversation"]);
+  });
+
+  it("renaming shepherd keeps access to the renamed mode (#240 acceptance)", async () => {
+    // The shepherd's own stored record migrates like everyone else's;
+    // validateSession re-reads the record per request, so their next
+    // call sees the new slug without re-login.
+    await seedRightsUser({
+      email: "self@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+    });
+    spyFetch();
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ email: "self@acme.com", mode_edit_rights: ["spoken"] }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+
+    const after = await readRightsUser("self@acme.com");
+    expect(after.mode_edit_rights).toEqual(["conversation"]);
+  });
+
+  it("wildcard and unrelated users untouched; other-org same-slug untouched", async () => {
+    await seedRightsUser({
+      email: "wildcard@acme.com",
+      org: "acme",
+      mode_edit_rights: "*",
+    });
+    await seedRightsUser({
+      email: "unrelated@acme.com",
+      org: "acme",
+      mode_edit_rights: ["other"],
+    });
+    await seedRightsUser({
+      email: "elsewhere@word-collective.com",
+      org: "word-collective",
+      mode_edit_rights: ["spoken"],
+    });
+    spyFetch();
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+
+    expect((await readRightsUser("wildcard@acme.com")).mode_edit_rights).toBe(
+      "*"
+    );
+    expect(
+      (await readRightsUser("unrelated@acme.com")).mode_edit_rights
+    ).toEqual(["other"]);
+    expect(
+      (await readRightsUser("elsewhere@word-collective.com")).mode_edit_rights
+    ).toEqual(["spoken"]);
+  });
+
+  it("engine failure → migration compensated, arrays unchanged, engine status passes through", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: ["spoken", "zulu"],
+    });
+    spyFetchEngineFailure(409);
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(409);
+
+    const after = await readRightsUser("shepherd@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken"]);
+    expect(after.mode_publish_rights).toEqual(["spoken", "zulu"]);
+  });
+
+  it("user already holding BOTH slugs is untouched by contract (pinned)", async () => {
+    // Expand skips them (new slug already present), so they're outside
+    // the recorded set that contract/compensate operate on. After the
+    // rename their old-slug entry goes stale-but-inert (it survives as
+    // an alias, and nothing in authz reads aliases). Deliberately NOT
+    // cleaned up: we can't distinguish a stale entry from an intentional
+    // grant made moments before the rename, and the conservative rule is
+    // to never remove entries the migration didn't add.
+    await seedRightsUser({
+      email: "both@acme.com",
+      org: "acme",
+      mode_edit_rights: ["conversation", "spoken"],
+    });
+    spyFetch();
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+
+    expect((await readRightsUser("both@acme.com")).mode_edit_rights).toEqual([
+      "conversation",
+      "spoken",
+    ]);
+  });
+
+  it("cross-org rename migrates TARGET-org users, not the caller's home org", async () => {
+    await seedRightsUser({
+      email: "target@word-collective.com",
+      org: "word-collective",
+      mode_edit_rights: ["spoken"],
+    });
+    await seedRightsUser({
+      email: "home@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+    });
+    spyFetch();
+
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_rename?org=word-collective",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ newName: "conversation" }),
+        }
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+
+    expect(
+      (await readRightsUser("target@word-collective.com")).mode_edit_rights
+    ).toEqual(["conversation"]);
+    expect((await readRightsUser("home@acme.com")).mode_edit_rights).toEqual([
+      "spoken",
+    ]);
   });
 });
 

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1198,6 +1198,66 @@ describe("#240 rename rights migration", () => {
     ]);
   });
 
+  it("org slug that URL-encodes differently still matches stored users (Frank rd-1 P1)", async () => {
+    // Stored `user.org` values are raw strings; the engine path uses
+    // encodeURIComponent(org). The migration must compare against the
+    // RAW org — an org with a space would otherwise migrate nobody and
+    // silently strand every shepherd.
+    await seedRightsUser({
+      email: "shepherd@spacey.com",
+      org: "word collective",
+      mode_edit_rights: ["spoken"],
+    });
+    spyFetch();
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ org: "word collective", isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+
+    expect(
+      (await readRightsUser("shepherd@spacey.com")).mode_edit_rights
+    ).toEqual(["conversation"]);
+  });
+
+  it("padded newName is trimmed for BOTH the migration and the engine body (Frank rd-1 P2)", async () => {
+    // The BFF is the API boundary: a direct call with `" conversation "`
+    // must not migrate rights to `conversation` while the engine
+    // receives the padded original.
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+    });
+    const fetchSpy = spyFetch();
+
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_rename",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ newName: "  conversation  " }),
+        }
+      ),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+
+    const sentBody = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string
+    ) as { newName: string };
+    expect(sentBody.newName).toBe("conversation");
+    expect(
+      (await readRightsUser("shepherd@acme.com")).mode_edit_rights
+    ).toEqual(["conversation"]);
+  });
+
   it("cross-org rename migrates TARGET-org users, not the caller's home org", async () => {
     await seedRightsUser({
       email: "target@word-collective.com",

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -855,9 +855,9 @@ function makeRenameRequest(name: string, newName: string): Request {
 function spyFetchRenameEngine(opts: {
   sourceSlug: string;
   targetSlug: string;
-  source?: { name: string } | null;
-  target?: { name: string } | null;
-  probe?: { name: string } | null;
+  source?: Record<string, unknown> | null;
+  target?: Record<string, unknown> | null;
+  probe?: Record<string, unknown> | null;
   engineStatus?: number;
   engineThrows?: boolean;
   // Simulate a transient engine failure (500) on the preflight GETs —
@@ -866,7 +866,7 @@ function spyFetchRenameEngine(opts: {
   targetGetFails?: boolean;
 }) {
   let sourceGets = 0;
-  const wrap = (mode: { name: string } | null | undefined) =>
+  const wrap = (mode: Record<string, unknown> | null | undefined) =>
     mode
       ? new Response(JSON.stringify({ org: "x", mode }), { status: 200 })
       : new Response('{"error":"not found"}', { status: 404 });
@@ -1212,6 +1212,25 @@ describe("config authz — #232 mode rename (_rename)", () => {
       sourceSlug: "spoken",
       targetSlug: "conversation",
       sourceGetFails: true,
+    });
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(502);
+    expect(findEnginePost(fetchSpy)).toBeUndefined();
+  });
+
+  it("found mode WITHOUT a string name → 502 fail-closed, not a skipped guard (rd-4)", async () => {
+    // The canonical-name comparisons ARE the security checks; a
+    // response-shape drift that drops `name` must disable the rename,
+    // not silently disable the guards.
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+      source: { slug: "spoken" }, // no `name` field
     });
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1242,6 +1242,39 @@ describe("config authz — #232 mode rename (_rename)", () => {
     expect(findEnginePost(fetchSpy)).toBeUndefined();
   });
 
+  it("source MISSING beats target-side engine error → 404, not 502 (rd-5)", async () => {
+    // A flaky target GET must not mask "the mode you're renaming
+    // doesn't exist" behind a retry prompt the user can never satisfy.
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "ghost",
+      targetSlug: "anything",
+      source: null,
+      targetGetFails: true,
+    });
+    const res = await handleConfig(
+      makeRenameRequest("ghost", "anything"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/ghost/_rename"
+    );
+    expect(res.status).toBe(404);
+    expect(findEnginePost(fetchSpy)).toBeUndefined();
+  });
+
+  it("thrown fetch during preflight → 502, not an uncaught exception (rd-5)", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("connect failure"));
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(502);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
   it("engine error on TARGET preflight → 502 fail-closed, no expand (rd-3 F1)", async () => {
     // The collision guard must not evaporate on a transient GET error —
     // that would reopen the escalation window it exists to close.
@@ -1266,6 +1299,35 @@ describe("config authz — #232 mode rename (_rename)", () => {
     expect(
       (await readRightsUser("shepherd@acme.com")).mode_edit_rights
     ).toEqual(["spoken"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT-gate parity — fetchResourceState extraction must not soften the gate
+// ---------------------------------------------------------------------------
+
+describe("PUT gate — thrown engine GET propagates (rd-5 parity)", () => {
+  it("edit-only shepherd PUT while the gate's current-state GET throws → request fails, no proxy", async () => {
+    // On main, a thrown fetch in fetchCurrentResource propagated and
+    // the mutation was blocked. The rd-4 extraction briefly swallowed
+    // it into null → creation semantics, which would have let an
+    // edit-only shepherd unpublish a live mode (creation semantics
+    // only demand publish on published:true). Pin the propagation.
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("connect failure")
+    );
+    await expect(
+      handleConfig(
+        new Request("https://portal.example.test/api/config/modes/spoken", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ document: "# doc", published: false }),
+        }),
+        env,
+        makeSession({ mode_edit_rights: ["spoken"] }),
+        "/api/config/modes/spoken"
+      )
+    ).rejects.toThrow("connect failure");
   });
 });
 

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -860,6 +860,10 @@ function spyFetchRenameEngine(opts: {
   probe?: { name: string } | null;
   engineStatus?: number;
   engineThrows?: boolean;
+  // Simulate a transient engine failure (500) on the preflight GETs —
+  // the fail-closed paths.
+  sourceGetFails?: boolean;
+  targetGetFails?: boolean;
 }) {
   let sourceGets = 0;
   const wrap = (mode: { name: string } | null | undefined) =>
@@ -888,6 +892,11 @@ function spyFetchRenameEngine(opts: {
         opts.source === undefined ? { name: opts.sourceSlug } : opts.source;
       if (url.endsWith(`/modes/${encodeURIComponent(opts.sourceSlug)}`)) {
         sourceGets += 1;
+        if (sourceGets === 1 && opts.sourceGetFails) {
+          return Promise.resolve(
+            new Response('{"error":"transient"}', { status: 500 })
+          );
+        }
         if (sourceGets > 1) {
           return Promise.resolve(
             wrap(opts.probe === undefined ? defaultSource : opts.probe)
@@ -896,6 +905,11 @@ function spyFetchRenameEngine(opts: {
         return Promise.resolve(wrap(defaultSource));
       }
       if (url.endsWith(`/modes/${encodeURIComponent(opts.targetSlug)}`)) {
+        if (opts.targetGetFails) {
+          return Promise.resolve(
+            new Response('{"error":"transient"}', { status: 500 })
+          );
+        }
         return Promise.resolve(
           wrap(opts.target === undefined ? null : opts.target)
         );
@@ -1192,6 +1206,48 @@ describe("config authz — #232 mode rename (_rename)", () => {
     expect(res.status).toBe(200);
     expect(findEnginePost(fetchSpy)).toBeDefined();
   });
+
+  it("engine error on SOURCE preflight → 502 fail-closed, not a false 404 (rd-3)", async () => {
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+      sourceGetFails: true,
+    });
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(502);
+    expect(findEnginePost(fetchSpy)).toBeUndefined();
+  });
+
+  it("engine error on TARGET preflight → 502 fail-closed, no expand (rd-3 F1)", async () => {
+    // The collision guard must not evaporate on a transient GET error —
+    // that would reopen the escalation window it exists to close.
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+    });
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+      targetGetFails: true,
+    });
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ mode_edit_rights: ["spoken"] }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(502);
+    expect(findEnginePost(fetchSpy)).toBeUndefined();
+    expect(
+      (await readRightsUser("shepherd@acme.com")).mode_edit_rights
+    ).toEqual(["spoken"]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1258,7 +1314,7 @@ describe("#240 rename rights migration", () => {
     expect(res.status).toBe(200);
 
     const after = await readRightsUser("shepherd@acme.com");
-    expect(after.mode_edit_rights).toEqual(["conversation", "other"]);
+    expect(after.mode_edit_rights).toEqual(["other", "conversation"]);
     expect(after.mode_publish_rights).toEqual(["conversation"]);
   });
 
@@ -1383,7 +1439,7 @@ describe("#240 rename rights migration", () => {
 
     expect(
       (await readRightsUser("shepherd@acme.com")).mode_edit_rights
-    ).toEqual(["conversation", "spoken"]);
+    ).toEqual(["spoken", "conversation"]);
   });
 
   it("engine 5xx + probe shows rename LANDED → contracts to the new slug (rd-2 F7)", async () => {
@@ -1416,7 +1472,12 @@ describe("#240 rename rights migration", () => {
     ).toEqual(["conversation"]);
   });
 
-  it("engine 5xx + probe shows rename did NOT land → compensates to the old slug", async () => {
+  it("engine 5xx + probe still shows the OLD name → keeps the superset (rd-3 F3)", async () => {
+    // Probe-says-old is NOT definitive: a gateway 5xx can be emitted
+    // while the engine is still processing, and the rename may commit
+    // moments after the probe. Compensating here would strand every
+    // shepherd on a dead slug. Only probe-says-NEW is proof (of
+    // success); everything else keeps both slugs.
     await seedRightsUser({
       email: "shepherd@acme.com",
       org: "acme",
@@ -1439,7 +1500,7 @@ describe("#240 rename rights migration", () => {
 
     expect(
       (await readRightsUser("shepherd@acme.com")).mode_edit_rights
-    ).toEqual(["spoken"]);
+    ).toEqual(["spoken", "conversation"]);
   });
 
   it("user already holding BOTH slugs is untouched by contract (pinned)", async () => {

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -844,9 +844,82 @@ function makeRenameRequest(name: string, newName: string): Request {
   );
 }
 
+// The #240 rename arm makes up to four engine calls: preflight GET of
+// the source slug (canonical check), preflight GET of the target slug
+// (collision check), the POST itself, and — on an ambiguous 5xx — a
+// disambiguating re-GET of the source slug. This route-aware mock lets
+// each test script those independently. GETs of the source slug return
+// `source` on the first call and `probe` (default: same as source) on
+// subsequent calls; GETs of the target slug return `target` (default:
+// 404 — the normal "new slug is free" case).
+function spyFetchRenameEngine(opts: {
+  sourceSlug: string;
+  targetSlug: string;
+  source?: { name: string } | null;
+  target?: { name: string } | null;
+  probe?: { name: string } | null;
+  engineStatus?: number;
+  engineThrows?: boolean;
+}) {
+  let sourceGets = 0;
+  const wrap = (mode: { name: string } | null | undefined) =>
+    mode
+      ? new Response(JSON.stringify({ org: "x", mode }), { status: 200 })
+      : new Response('{"error":"not found"}', { status: 404 });
+
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === "POST") {
+        if (opts.engineThrows) {
+          return Promise.reject(new Error("simulated network failure"));
+        }
+        return Promise.resolve(
+          new Response('{"error":"engine says no"}', {
+            status: opts.engineStatus ?? 200,
+          })
+        );
+      }
+      // GET — decide by which slug the path ends in. `undefined` means
+      // "use the default"; an explicit `null` means 404 — hence the
+      // === undefined checks rather than ??.
+      const defaultSource =
+        opts.source === undefined ? { name: opts.sourceSlug } : opts.source;
+      if (url.endsWith(`/modes/${encodeURIComponent(opts.sourceSlug)}`)) {
+        sourceGets += 1;
+        if (sourceGets > 1) {
+          return Promise.resolve(
+            wrap(opts.probe === undefined ? defaultSource : opts.probe)
+          );
+        }
+        return Promise.resolve(wrap(defaultSource));
+      }
+      if (url.endsWith(`/modes/${encodeURIComponent(opts.targetSlug)}`)) {
+        return Promise.resolve(
+          wrap(opts.target === undefined ? null : opts.target)
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+}
+
+// The engine POST within a route-aware mock's call list.
+function findEnginePost(
+  spy: ReturnType<typeof spyFetchRenameEngine>
+): [string, RequestInit] | undefined {
+  const call = spy.mock.calls.find(
+    (c) => (c[1] as RequestInit | undefined)?.method === "POST"
+  );
+  return call ? [String(call[0]), call[1] as RequestInit] : undefined;
+}
+
 describe("config authz — #232 mode rename (_rename)", () => {
   it("admin → proxies POST to engine _rename path", async () => {
-    const fetchSpy = spyFetch();
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
       env,
@@ -854,15 +927,16 @@ describe("config authz — #232 mode rename (_rename)", () => {
       "/api/config/modes/spoken/_rename"
     );
     expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("POST");
-    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
-      "/api/v1/admin/orgs/acme/modes/spoken/_rename"
-    );
+    const post = findEnginePost(fetchSpy);
+    expect(post).toBeDefined();
+    expect(post![0]).toContain("/api/v1/admin/orgs/acme/modes/spoken/_rename");
   });
 
   it("super admin without isAdmin → proxies (super trumps isAdmin)", async () => {
-    const fetchSpy = spyFetch();
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
       env,
@@ -870,7 +944,7 @@ describe("config authz — #232 mode rename (_rename)", () => {
       "/api/config/modes/spoken/_rename"
     );
     expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(findEnginePost(fetchSpy)).toBeDefined();
   });
 
   it("non-admin without any explicit mode rights → 403 (baseline, no proxy)", async () => {
@@ -888,7 +962,10 @@ describe("config authz — #232 mode rename (_rename)", () => {
   it("non-admin shepherd with EDIT rights on the row → proxies (#240)", async () => {
     // Inversion of the #238-review case: with rights migration in place,
     // full per-row rights ARE enough. This was 403 pre-#240.
-    const fetchSpy = spyFetch();
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
       env,
@@ -899,14 +976,16 @@ describe("config authz — #232 mode rename (_rename)", () => {
       "/api/config/modes/spoken/_rename"
     );
     expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
-      "/api/v1/admin/orgs/acme/modes/spoken/_rename"
-    );
+    const post = findEnginePost(fetchSpy);
+    expect(post).toBeDefined();
+    expect(post![0]).toContain("/api/v1/admin/orgs/acme/modes/spoken/_rename");
   });
 
   it("non-admin shepherd with edit-only rights → proxies (#240 acceptance)", async () => {
-    const fetchSpy = spyFetch();
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
       env,
@@ -914,7 +993,7 @@ describe("config authz — #232 mode rename (_rename)", () => {
       "/api/config/modes/spoken/_rename"
     );
     expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(findEnginePost(fetchSpy)).toBeDefined();
   });
 
   it("non-admin with publish-only rights → 403 (rename is edit-side)", async () => {
@@ -992,7 +1071,10 @@ describe("config authz — #232 mode rename (_rename)", () => {
   });
 
   it("super-admin cross-org via ?org=other → proxies to /orgs/other/.../_rename", async () => {
-    const fetchSpy = spyFetch();
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
     const res = await handleConfig(
       new Request(
         "https://portal.example.test/api/config/modes/spoken/_rename?org=word-collective",
@@ -1007,10 +1089,108 @@ describe("config authz — #232 mode rename (_rename)", () => {
       "/api/config/modes/spoken/_rename"
     );
     expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+    const post = findEnginePost(fetchSpy);
+    expect(post).toBeDefined();
+    expect(post![0]).toContain(
       "/api/v1/admin/orgs/word-collective/modes/spoken/_rename"
     );
+  });
+
+  it("JSON `null` body → 400, not a thrown 500 (rd-2 F9)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_rename",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "null",
+        }
+      ),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("source slug that is an ALIAS of another mode → 409, no engine POST (rd-2 F1)", async () => {
+    // The engine resolves the rename source through aliases, so a
+    // shepherd holding rights only on a stale alias (e.g. left by a
+    // retire-and-forward) could otherwise rename — and capture — the
+    // aliased-to mode. The canonical-slug preflight closes it.
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "quiz",
+      targetSlug: "quiz-two",
+      source: { name: "chat" }, // GET quiz resolves to mode "chat"
+    });
+    const res = await handleConfig(
+      makeRenameRequest("quiz", "quiz-two"),
+      env,
+      makeSession({ mode_edit_rights: ["quiz"] }),
+      "/api/config/modes/quiz/_rename"
+    );
+    expect(res.status).toBe(409);
+    expect(findEnginePost(fetchSpy)).toBeUndefined();
+  });
+
+  it("source mode not found → 404, no engine POST", async () => {
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "ghost",
+      targetSlug: "anything",
+      source: null,
+    });
+    const res = await handleConfig(
+      makeRenameRequest("ghost", "anything"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/ghost/_rename"
+    );
+    expect(res.status).toBe(404);
+    expect(findEnginePost(fetchSpy)).toBeUndefined();
+  });
+
+  it("newName colliding with ANOTHER mode → 409 BEFORE any rights expand (rd-2 F2)", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+    });
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+      target: { name: "conversation" }, // an existing, different mode
+    });
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ mode_edit_rights: ["spoken"] }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(409);
+    expect(findEnginePost(fetchSpy)).toBeUndefined();
+    // The escalation window never opened: no expand happened.
+    expect(
+      (await readRightsUser("shepherd@acme.com")).mode_edit_rights
+    ).toEqual(["spoken"]);
+  });
+
+  it("newName that is the mode's OWN alias → proceeds (promote-own-alias)", async () => {
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "speak",
+      // GET "speak" resolves (alias-aware) to the SAME mode.
+      target: { name: "spoken" },
+    });
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "speak"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(200);
+    expect(findEnginePost(fetchSpy)).toBeDefined();
   });
 });
 
@@ -1056,14 +1236,6 @@ async function readRightsUser(email: string): Promise<StoredUser> {
   return user;
 }
 
-function spyFetchEngineFailure(status: number) {
-  return vi
-    .spyOn(globalThis, "fetch")
-    .mockImplementation(() =>
-      Promise.resolve(new Response('{"error":"engine says no"}', { status }))
-    );
-}
-
 describe("#240 rename rights migration", () => {
   it("engine success → affected users' arrays hold the new slug, old removed", async () => {
     await seedRightsUser({
@@ -1072,7 +1244,10 @@ describe("#240 rename rights migration", () => {
       mode_edit_rights: ["other", "spoken"],
       mode_publish_rights: ["spoken"],
     });
-    spyFetch();
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
 
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
@@ -1096,7 +1271,10 @@ describe("#240 rename rights migration", () => {
       org: "acme",
       mode_edit_rights: ["spoken"],
     });
-    spyFetch();
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
 
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
@@ -1126,7 +1304,10 @@ describe("#240 rename rights migration", () => {
       org: "word-collective",
       mode_edit_rights: ["spoken"],
     });
-    spyFetch();
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
 
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
@@ -1147,14 +1328,22 @@ describe("#240 rename rights migration", () => {
     ).toEqual(["spoken"]);
   });
 
-  it("engine failure → migration compensated, arrays unchanged, engine status passes through", async () => {
+  it("engine 4xx → migration compensated, arrays unchanged, engine status passes through", async () => {
+    // Preflights make the common collision a pre-expand 409, but the
+    // engine can still definitively reject on races (mode created
+    // between preflight and POST) or slug validation — those 4xx paths
+    // must compensate.
     await seedRightsUser({
       email: "shepherd@acme.com",
       org: "acme",
       mode_edit_rights: ["spoken"],
       mode_publish_rights: ["spoken", "zulu"],
     });
-    spyFetchEngineFailure(409);
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+      engineStatus: 409,
+    });
 
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
@@ -1167,6 +1356,90 @@ describe("#240 rename rights migration", () => {
     const after = await readRightsUser("shepherd@acme.com");
     expect(after.mode_edit_rights).toEqual(["spoken"]);
     expect(after.mode_publish_rights).toEqual(["spoken", "zulu"]);
+  });
+
+  it("engine fetch THROWS after expand → 502 and the rights superset is retained (rd-2 F5)", async () => {
+    // Ambiguous outcome: the rename may or may not have applied.
+    // Compensating a rename that landed would strand shepherds, so the
+    // arm keeps both slugs — access is covered either way.
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+    });
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+      engineThrows: true,
+    });
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(502);
+
+    expect(
+      (await readRightsUser("shepherd@acme.com")).mode_edit_rights
+    ).toEqual(["conversation", "spoken"]);
+  });
+
+  it("engine 5xx + probe shows rename LANDED → contracts to the new slug (rd-2 F7)", async () => {
+    // A gateway can emit a 5xx after the engine persisted the rename.
+    // The disambiguating re-GET (alias-aware) reports the new canonical
+    // name, so the arm contracts instead of wrongly compensating —
+    // which would have stranded every shepherd.
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+    });
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+      engineStatus: 502,
+      probe: { name: "conversation" },
+    });
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(502);
+
+    expect(
+      (await readRightsUser("shepherd@acme.com")).mode_edit_rights
+    ).toEqual(["conversation"]);
+  });
+
+  it("engine 5xx + probe shows rename did NOT land → compensates to the old slug", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+    });
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+      engineStatus: 500,
+      probe: { name: "spoken" },
+    });
+
+    const res = await handleConfig(
+      makeRenameRequest("spoken", "conversation"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_rename"
+    );
+    expect(res.status).toBe(500);
+
+    expect(
+      (await readRightsUser("shepherd@acme.com")).mode_edit_rights
+    ).toEqual(["spoken"]);
   });
 
   it("user already holding BOTH slugs is untouched by contract (pinned)", async () => {
@@ -1182,7 +1455,10 @@ describe("#240 rename rights migration", () => {
       org: "acme",
       mode_edit_rights: ["conversation", "spoken"],
     });
-    spyFetch();
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
 
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
@@ -1208,7 +1484,10 @@ describe("#240 rename rights migration", () => {
       org: "word collective",
       mode_edit_rights: ["spoken"],
     });
-    spyFetch();
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
 
     const res = await handleConfig(
       makeRenameRequest("spoken", "conversation"),
@@ -1232,7 +1511,10 @@ describe("#240 rename rights migration", () => {
       org: "acme",
       mode_edit_rights: ["spoken"],
     });
-    const fetchSpy = spyFetch();
+    const fetchSpy = spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
 
     const res = await handleConfig(
       new Request(
@@ -1249,9 +1531,10 @@ describe("#240 rename rights migration", () => {
     );
     expect(res.status).toBe(200);
 
-    const sentBody = JSON.parse(
-      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string
-    ) as { newName: string };
+    const post = findEnginePost(fetchSpy);
+    const sentBody = JSON.parse(post![1].body as string) as {
+      newName: string;
+    };
     expect(sentBody.newName).toBe("conversation");
     expect(
       (await readRightsUser("shepherd@acme.com")).mode_edit_rights
@@ -1269,7 +1552,10 @@ describe("#240 rename rights migration", () => {
       org: "acme",
       mode_edit_rights: ["spoken"],
     });
-    spyFetch();
+    spyFetchRenameEngine({
+      sourceSlug: "spoken",
+      targetSlug: "conversation",
+    });
 
     const res = await handleConfig(
       new Request(

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -12,6 +12,7 @@ import {
   hasAnyLanguageRights,
   hasAnyModeAccess,
   hasLanguageRights,
+  renameSlugInRights,
 } from "../src/lib/permissions";
 
 // Trinary back-compat is load-bearing for this file:
@@ -366,5 +367,31 @@ describe("filterByAnyRights", () => {
 
   it("both empty arrays → empty", () => {
     expect(filterByAnyRights(all, [], [])).toEqual([]);
+  });
+});
+
+describe("renameSlugInRights (#240 client mirror)", () => {
+  it("replaces the old slug with the new, preserving order", () => {
+    expect(renameSlugInRights(["a", "spoken", "b"], "spoken", "conv")).toEqual([
+      "a",
+      "b",
+      "conv",
+    ]);
+  });
+
+  it("no duplicate when the new slug is already held", () => {
+    expect(renameSlugInRights(["spoken", "conv"], "spoken", "conv")).toEqual([
+      "conv",
+    ]);
+  });
+
+  it("unchanged when the old slug isn't held", () => {
+    const rights = ["other"];
+    expect(renameSlugInRights(rights, "spoken", "conv")).toBe(rights);
+  });
+
+  it("wildcard and undefined pass through", () => {
+    expect(renameSlugInRights("*", "spoken", "conv")).toBe("*");
+    expect(renameSlugInRights(undefined, "spoken", "conv")).toBeUndefined();
   });
 });

--- a/tests/rights-migration.test.ts
+++ b/tests/rights-migration.test.ts
@@ -1,0 +1,202 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import {
+  contractOrgModeRights,
+  expandOrgModeRights,
+  expandRights,
+  removeSlugIfPartnerPresent,
+} from "../worker/rights-migration";
+import type { StoredUser } from "../worker/types";
+
+// #240 — the invariant these helpers enforce end-to-end: at every
+// intermediate point of expand → engine op → contract/compensate, a
+// user's rights cover whichever slug is live. The pure functions below
+// are the whole guarantee; the orchestration tests pin the recorded-set
+// semantics (cleanup only ever touches users the expand actually
+// modified).
+
+describe("expandRights", () => {
+  it("adds the new slug alongside the old, sorted", () => {
+    expect(expandRights(["spoken"], "spoken", "conversation")).toEqual([
+      "conversation",
+      "spoken",
+    ]);
+    expect(expandRights(["b", "spoken", "a"], "spoken", "z")).toEqual([
+      "a",
+      "b",
+      "spoken",
+      "z",
+    ]);
+  });
+
+  it("null (no change) when the old slug isn't held", () => {
+    expect(expandRights(["other"], "spoken", "conversation")).toBeNull();
+    expect(expandRights([], "spoken", "conversation")).toBeNull();
+  });
+
+  it("null when the new slug is already held (idempotent)", () => {
+    expect(
+      expandRights(["conversation", "spoken"], "spoken", "conversation")
+    ).toBeNull();
+  });
+
+  it("wildcard and undefined pass through untouched", () => {
+    expect(expandRights("*", "spoken", "conversation")).toBeNull();
+    expect(expandRights(undefined, "spoken", "conversation")).toBeNull();
+  });
+});
+
+describe("removeSlugIfPartnerPresent", () => {
+  it("removes only when the partner is present", () => {
+    expect(
+      removeSlugIfPartnerPresent(
+        ["conversation", "spoken"],
+        "spoken",
+        "conversation"
+      )
+    ).toEqual(["conversation"]);
+  });
+
+  it("null when the partner is absent — never shrinks below the live slug", () => {
+    // The load-bearing guard: contract/compensate can run against any
+    // intermediate state without ever removing a user's only live slug.
+    expect(
+      removeSlugIfPartnerPresent(["spoken"], "spoken", "conversation")
+    ).toBeNull();
+  });
+
+  it("null when the removal target isn't held (idempotent)", () => {
+    expect(
+      removeSlugIfPartnerPresent(["conversation"], "spoken", "conversation")
+    ).toBeNull();
+  });
+
+  it("wildcard and undefined pass through untouched", () => {
+    expect(removeSlugIfPartnerPresent("*", "spoken", "x")).toBeNull();
+    expect(removeSlugIfPartnerPresent(undefined, "spoken", "x")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orchestration over AUTH_KV
+// ---------------------------------------------------------------------------
+
+async function seed(
+  email: string,
+  org: string,
+  fields: Partial<
+    Pick<StoredUser, "mode_edit_rights" | "mode_publish_rights">
+  > = {}
+): Promise<string> {
+  const key = `user:${email}`;
+  const stored: StoredUser = {
+    id: crypto.randomUUID(),
+    email,
+    name: email,
+    org,
+    passwordHash: "x",
+    salt: "x",
+    isAdmin: false,
+    ...fields,
+  };
+  await env.AUTH_KV.put(key, JSON.stringify(stored));
+  return key;
+}
+
+async function read(email: string): Promise<StoredUser> {
+  const user = await env.AUTH_KV.get<StoredUser>(`user:${email}`, {
+    type: "json",
+  });
+  if (!user) throw new Error(`missing seed: ${email}`);
+  return user;
+}
+
+describe("expandOrgModeRights", () => {
+  it("expands both verb fields for affected org users, returns their keys", async () => {
+    const key = await seed("a@acme.com", "acme", {
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: ["spoken", "zulu"],
+    });
+    await seed("b@acme.com", "acme", { mode_edit_rights: ["other"] });
+
+    const written = await expandOrgModeRights(
+      env,
+      "acme",
+      "spoken",
+      "conversation"
+    );
+    expect(written).toEqual([key]);
+
+    const after = await read("a@acme.com");
+    expect(after.mode_edit_rights).toEqual(["conversation", "spoken"]);
+    expect(after.mode_publish_rights).toEqual([
+      "conversation",
+      "spoken",
+      "zulu",
+    ]);
+    expect((await read("b@acme.com")).mode_edit_rights).toEqual(["other"]);
+  });
+
+  it("skips users outside the org and users already holding the new slug", async () => {
+    await seed("other-org@wc.com", "word-collective", {
+      mode_edit_rights: ["spoken"],
+    });
+    await seed("both@acme.com", "acme", {
+      mode_edit_rights: ["conversation", "spoken"],
+    });
+
+    const written = await expandOrgModeRights(
+      env,
+      "acme",
+      "spoken",
+      "conversation"
+    );
+    expect(written).toEqual([]);
+    expect((await read("other-org@wc.com")).mode_edit_rights).toEqual([
+      "spoken",
+    ]);
+    expect((await read("both@acme.com")).mode_edit_rights).toEqual([
+      "conversation",
+      "spoken",
+    ]);
+  });
+});
+
+describe("contractOrgModeRights", () => {
+  it("removes the slug only from the given keys, partner-guarded", async () => {
+    const migrated = await seed("m@acme.com", "acme", {
+      mode_edit_rights: ["conversation", "spoken"],
+    });
+    // Same shape, but NOT in the recorded set — must be untouched.
+    await seed("outside@acme.com", "acme", {
+      mode_edit_rights: ["conversation", "spoken"],
+    });
+
+    await contractOrgModeRights(env, [migrated], "spoken", "conversation");
+
+    expect((await read("m@acme.com")).mode_edit_rights).toEqual([
+      "conversation",
+    ]);
+    expect((await read("outside@acme.com")).mode_edit_rights).toEqual([
+      "conversation",
+      "spoken",
+    ]);
+  });
+
+  it("leaves a user alone when the partner slug is missing", async () => {
+    // Defensive: if state drifted between phases (concurrent admin
+    // edit removed the new slug), contract must not strip the old one.
+    const key = await seed("drift@acme.com", "acme", {
+      mode_edit_rights: ["spoken"],
+    });
+    await contractOrgModeRights(env, [key], "spoken", "conversation");
+    expect((await read("drift@acme.com")).mode_edit_rights).toEqual(["spoken"]);
+  });
+
+  it("tolerates keys whose records vanished", async () => {
+    await expect(
+      contractOrgModeRights(env, ["user:gone@acme.com"], "a", "b")
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/rights-migration.test.ts
+++ b/tests/rights-migration.test.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   contractOrgModeRights,
@@ -113,20 +113,22 @@ async function read(email: string): Promise<StoredUser> {
 }
 
 describe("expandOrgModeRights", () => {
-  it("expands both verb fields for affected org users, returns their keys", async () => {
+  it("expands both verb fields for affected org users, returns per-field records", async () => {
     const key = await seed("a@acme.com", "acme", {
       mode_edit_rights: ["spoken"],
       mode_publish_rights: ["spoken", "zulu"],
     });
     await seed("b@acme.com", "acme", { mode_edit_rights: ["other"] });
 
-    const written = await expandOrgModeRights(
+    const records = await expandOrgModeRights(
       env,
       "acme",
       "spoken",
       "conversation"
     );
-    expect(written).toEqual([key]);
+    expect(records).toEqual([
+      { key, fields: ["mode_edit_rights", "mode_publish_rights"] },
+    ]);
 
     const after = await read("a@acme.com");
     expect(after.mode_edit_rights).toEqual(["conversation", "spoken"]);
@@ -138,6 +140,24 @@ describe("expandOrgModeRights", () => {
     expect((await read("b@acme.com")).mode_edit_rights).toEqual(["other"]);
   });
 
+  it("records ONLY the fields it modified (per-field, not per-user)", async () => {
+    // The F4-review scenario setup: the publish field already legit-
+    // imately holds the new slug, so expand must touch (and record)
+    // only the edit field.
+    const key = await seed("mixed@acme.com", "acme", {
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: ["conversation", "spoken"],
+    });
+
+    const records = await expandOrgModeRights(
+      env,
+      "acme",
+      "spoken",
+      "conversation"
+    );
+    expect(records).toEqual([{ key, fields: ["mode_edit_rights"] }]);
+  });
+
   it("skips users outside the org and users already holding the new slug", async () => {
     await seed("other-org@wc.com", "word-collective", {
       mode_edit_rights: ["spoken"],
@@ -146,13 +166,13 @@ describe("expandOrgModeRights", () => {
       mode_edit_rights: ["conversation", "spoken"],
     });
 
-    const written = await expandOrgModeRights(
+    const records = await expandOrgModeRights(
       env,
       "acme",
       "spoken",
       "conversation"
     );
-    expect(written).toEqual([]);
+    expect(records).toEqual([]);
     expect((await read("other-org@wc.com")).mode_edit_rights).toEqual([
       "spoken",
     ]);
@@ -161,10 +181,35 @@ describe("expandOrgModeRights", () => {
       "spoken",
     ]);
   });
+
+  it("partial write failure → rolls back landed writes and throws (rd-2 F11)", async () => {
+    await seed("ok@acme.com", "acme", { mode_edit_rights: ["spoken"] });
+    await seed("fails@acme.com", "acme", { mode_edit_rights: ["spoken"] });
+
+    const realPut = env.AUTH_KV.put.bind(env.AUTH_KV);
+    const putSpy = vi
+      .spyOn(env.AUTH_KV, "put")
+      .mockImplementation((key, value, options) => {
+        if (key === "user:fails@acme.com") {
+          return Promise.reject(new Error("simulated KV outage"));
+        }
+        return realPut(key, value, options);
+      });
+
+    await expect(
+      expandOrgModeRights(env, "acme", "spoken", "conversation")
+    ).rejects.toThrow("rights migration failed");
+    putSpy.mockRestore();
+
+    // The user whose write landed must be rolled back to pre-expand
+    // state; the failed one never persisted.
+    expect((await read("ok@acme.com")).mode_edit_rights).toEqual(["spoken"]);
+    expect((await read("fails@acme.com")).mode_edit_rights).toEqual(["spoken"]);
+  });
 });
 
 describe("contractOrgModeRights", () => {
-  it("removes the slug only from the given keys, partner-guarded", async () => {
+  it("removes the slug only from recorded keys, partner-guarded", async () => {
     const migrated = await seed("m@acme.com", "acme", {
       mode_edit_rights: ["conversation", "spoken"],
     });
@@ -173,7 +218,12 @@ describe("contractOrgModeRights", () => {
       mode_edit_rights: ["conversation", "spoken"],
     });
 
-    await contractOrgModeRights(env, [migrated], "spoken", "conversation");
+    await contractOrgModeRights(
+      env,
+      [{ key: migrated, fields: ["mode_edit_rights"] }],
+      "spoken",
+      "conversation"
+    );
 
     expect((await read("m@acme.com")).mode_edit_rights).toEqual([
       "conversation",
@@ -184,19 +234,52 @@ describe("contractOrgModeRights", () => {
     ]);
   });
 
+  it("touches ONLY recorded fields — pre-existing grant in the other field survives compensation (rd-2 F4)", async () => {
+    // The confirmed F4 scenario: expand modified only the edit field;
+    // the publish field's "conversation" entry is a pre-existing grant.
+    // Compensation (remove "conversation", keep "spoken") must strip it
+    // from the recorded edit field ONLY — a per-user sweep would pass
+    // the partner-guard on publish too and delete the legitimate grant.
+    const key = await seed("mixed@acme.com", "acme", {
+      mode_edit_rights: ["conversation", "spoken"],
+      mode_publish_rights: ["conversation", "spoken"],
+    });
+
+    await contractOrgModeRights(
+      env,
+      [{ key, fields: ["mode_edit_rights"] }],
+      "conversation",
+      "spoken"
+    );
+
+    const after = await read("mixed@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken"]);
+    expect(after.mode_publish_rights).toEqual(["conversation", "spoken"]);
+  });
+
   it("leaves a user alone when the partner slug is missing", async () => {
     // Defensive: if state drifted between phases (concurrent admin
     // edit removed the new slug), contract must not strip the old one.
     const key = await seed("drift@acme.com", "acme", {
       mode_edit_rights: ["spoken"],
     });
-    await contractOrgModeRights(env, [key], "spoken", "conversation");
+    await contractOrgModeRights(
+      env,
+      [{ key, fields: ["mode_edit_rights"] }],
+      "spoken",
+      "conversation"
+    );
     expect((await read("drift@acme.com")).mode_edit_rights).toEqual(["spoken"]);
   });
 
   it("tolerates keys whose records vanished", async () => {
     await expect(
-      contractOrgModeRights(env, ["user:gone@acme.com"], "a", "b")
+      contractOrgModeRights(
+        env,
+        [{ key: "user:gone@acme.com", fields: ["mode_edit_rights"] }],
+        "a",
+        "b"
+      )
     ).resolves.toBeUndefined();
   });
 });

--- a/tests/rights-migration.test.ts
+++ b/tests/rights-migration.test.ts
@@ -1,5 +1,12 @@
 import { env } from "cloudflare:test";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  // Belt-and-suspenders for the KV put spy below: if its expected
+  // rejection ever stops occurring, an inline mockRestore would be
+  // skipped and the rejecting mock would leak into every later test.
+  vi.restoreAllMocks();
+});
 
 import {
   contractOrgModeRights,
@@ -17,15 +24,18 @@ import type { StoredUser } from "../worker/types";
 // modified).
 
 describe("expandRights", () => {
-  it("adds the new slug alongside the old, sorted", () => {
+  it("appends the new slug alongside the old WITHOUT reordering", () => {
+    // Order preservation is load-bearing: a failed rename must be
+    // write-neutral (expand + compensate restores the exact original
+    // array), so expand can't sort as a side effect.
     expect(expandRights(["spoken"], "spoken", "conversation")).toEqual([
-      "conversation",
       "spoken",
+      "conversation",
     ]);
     expect(expandRights(["b", "spoken", "a"], "spoken", "z")).toEqual([
-      "a",
       "b",
       "spoken",
+      "a",
       "z",
     ]);
   });
@@ -131,11 +141,11 @@ describe("expandOrgModeRights", () => {
     ]);
 
     const after = await read("a@acme.com");
-    expect(after.mode_edit_rights).toEqual(["conversation", "spoken"]);
+    expect(after.mode_edit_rights).toEqual(["spoken", "conversation"]);
     expect(after.mode_publish_rights).toEqual([
-      "conversation",
       "spoken",
       "zulu",
+      "conversation",
     ]);
     expect((await read("b@acme.com")).mode_edit_rights).toEqual(["other"]);
   });

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -1,7 +1,7 @@
 import { getSessionId, invalidateUserSessions, validateSession } from "./auth";
 import { generateSalt, hashPassword, timingSafeEqual } from "./crypto";
 import type { Env } from "./helpers";
-import { errorResponse, jsonResponse } from "./helpers";
+import { errorResponse, jsonResponse, listKvKeys } from "./helpers";
 import type { LanguageRights, StoredUser } from "./types";
 
 // Accepts `"*"` or an array of non-empty trimmed strings. Returns `undefined`
@@ -299,17 +299,11 @@ async function listUsers(
     return errorResponse("Method not allowed", 405);
   }
 
-  const keys: KVNamespaceListKey<unknown>[] = [];
-  let cursor: string | undefined;
-  do {
-    const list = await env.AUTH_KV.list({ prefix: "user:", cursor });
-    keys.push(...list.keys);
-    cursor = list.list_complete ? undefined : list.cursor;
-  } while (cursor);
+  const keys = await listKvKeys(env.AUTH_KV, "user:");
 
   const users = await Promise.all(
     keys.map(async (key) => {
-      const user = await env.AUTH_KV.get<StoredUser>(key.name, {
+      const user = await env.AUTH_KV.get<StoredUser>(key, {
         type: "json",
       });
       if (!user) return null;

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -1,6 +1,6 @@
 import { generateSalt, hashPassword, timingSafeEqual } from "./crypto";
 import type { Env } from "./helpers";
-import { errorResponse, jsonResponse } from "./helpers";
+import { errorResponse, jsonResponse, listKvKeys } from "./helpers";
 import type { LanguageRights, SessionData, StoredUser } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -53,25 +53,20 @@ export async function invalidateUserSessions(
   targetEmail: string,
   exceptSessionId?: string | null
 ): Promise<void> {
-  let cursor: string | undefined;
+  const keys = await listKvKeys(env.AUTH_KV, "session:");
   const deletePromises: Promise<void>[] = [];
-  do {
-    const page = await env.AUTH_KV.list({ prefix: "session:", cursor });
-    const reads = page.keys
-      .filter(
-        (key) => !exceptSessionId || key.name !== `session:${exceptSessionId}`
-      )
+  await Promise.all(
+    keys
+      .filter((key) => !exceptSessionId || key !== `session:${exceptSessionId}`)
       .map(async (key) => {
-        const sess = await env.AUTH_KV.get<SessionData>(key.name, {
+        const sess = await env.AUTH_KV.get<SessionData>(key, {
           type: "json",
         });
         if (sess?.email === targetEmail) {
-          deletePromises.push(env.AUTH_KV.delete(key.name));
+          deletePromises.push(env.AUTH_KV.delete(key));
         }
-      });
-    await Promise.all(reads);
-    cursor = page.list_complete ? undefined : page.cursor;
-  } while (cursor);
+      })
+  );
   await Promise.all(deletePromises);
 }
 

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -455,9 +455,19 @@ export async function handleConfig(
     // Phase 1 — expand: affected users hold BOTH slugs. Aborts (500)
     // without calling the engine if the user store can't be fully
     // updated, so a half-migrated store never coexists with a rename.
+    //
+    // `resolved.org` (raw), NOT the URL-encoded `org` used for engine
+    // paths: stored `user.org` values are raw strings, so an org slug
+    // that encodes differently (space, non-ASCII) would otherwise match
+    // nobody and silently strand every shepherd (Frank rd-1 P1).
     let expandedUserKeys: string[];
     try {
-      expandedUserKeys = await expandOrgModeRights(env, org, modeName, newName);
+      expandedUserKeys = await expandOrgModeRights(
+        env,
+        resolved.org,
+        modeName,
+        newName
+      );
     } catch {
       return errorResponse("Rights migration failed; rename aborted", 500);
     }
@@ -467,7 +477,12 @@ export async function handleConfig(
       env,
       `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_rename`,
       ["POST"],
-      renameBody
+      // Forward the TRIMMED newName — the same value the migration used.
+      // The browser slugifies before sending, but the BFF is the API
+      // boundary: a direct call with `" conversation "` must not migrate
+      // rights to `conversation` while the engine receives the padded
+      // original (Frank rd-1 P2).
+      { ...renameBody, newName }
     );
 
     // Phase 3 — contract on success (drop the old slug), compensate on

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -1,5 +1,6 @@
 import type { Env } from "./helpers";
 import { errorResponse } from "./helpers";
+import { contractOrgModeRights, expandOrgModeRights } from "./rights-migration";
 import type { LanguageRights, SessionData } from "./types";
 
 // `undefined` is the back-compat default for users predating the rights
@@ -393,15 +394,24 @@ export async function handleConfig(
   // mode route below — the `(.+)` there would otherwise capture
   // `{name}/_rename` as the mode name and reject POST as 405. The engine
   // (#232) reslugs the mode in place and keeps the old slug as an alias
-  // so existing user assignments aren't stranded.
+  // so existing END-USER assignments aren't stranded.
   //
-  // Restricted to admins + super-admin cross-org. Per-user mode rights
-  // are slug-scoped (`mode_edit_rights` / `mode_publish_rights`), so a
-  // non-admin shepherd who renamed a mode would keep rights on the OLD
-  // slug and lose access to the renamed mode — and the worker would 403
-  // their later `/modes/{newName}` calls (#238 review). Until rights
-  // migration exists, only admins (blanket mode access) and cross-org
-  // super-admins (per-row gate bypassed anyway) may rename.
+  // Authorization (#240): admins and cross-org super-admins pass as
+  // before; non-admin shepherds pass with EDIT rights on the source
+  // mode. `rightsFor` returns `[]` for modes when the verb field is
+  // unset, so the pre-#181 admin-only baseline (both mode fields
+  // undefined → deny) holds without a separate check. Publish-only
+  // shepherds are denied — rename changes the mode's identity, which is
+  // an edit-side action.
+  //
+  // Rights migration (#240): per-user `mode_edit_rights` /
+  // `mode_publish_rights` are slug-scoped and nothing in the authz path
+  // reads aliases, so renaming would strand every shepherd holding the
+  // old slug. Around the engine call we run an expand→contract
+  // migration over the target org's users (see worker/rights-migration
+  // .ts for the atomicity model — at every intermediate point a user's
+  // rights cover whichever slug is live).
+  //
   // `[^/]+` (not `.+`) so `.../foo/_rename/_rename` doesn't slip past
   // with modeName = "foo/_rename" and waste an engine round-trip on a
   // guaranteed 404. Mode names are always single URL segments — the
@@ -411,15 +421,66 @@ export async function handleConfig(
   );
   if (modeRenameMatch?.[1]) {
     const modeName = decodeURIComponent(modeRenameMatch[1]);
-    if (!resolved.crossOrg && !hasAdminPowers(session)) {
+    if (
+      !resolved.crossOrg &&
+      !hasAdminPowers(session) &&
+      !hasRights(rightsFor(session, "mode", "edit"), modeName)
+    ) {
       return errorResponse("Forbidden", 403);
     }
-    return proxyToEngine(
+    // Method check before the body read so a non-POST still gets 405
+    // (proxyToEngine would normally handle this, but we consume the
+    // body first and a failed json() on a bodyless GET would misreport
+    // as 400).
+    if (request.method !== "POST") {
+      return errorResponse("Method not allowed", 405);
+    }
+    // The migration needs `newName` before the engine call, so the arm
+    // reads the body (one-shot stream) and passes the parsed copy back
+    // through proxyToEngine. Only presence is validated here — slug
+    // format, self-rename, and collisions (409) are the engine's calls,
+    // and its status + message pass through faithfully.
+    let renameBody: { newName?: unknown };
+    try {
+      renameBody = (await request.json()) as { newName?: unknown };
+    } catch {
+      return errorResponse("Invalid JSON", 400);
+    }
+    const newName =
+      typeof renameBody.newName === "string" ? renameBody.newName.trim() : "";
+    if (!newName) {
+      return errorResponse("Missing newName", 400);
+    }
+
+    // Phase 1 — expand: affected users hold BOTH slugs. Aborts (500)
+    // without calling the engine if the user store can't be fully
+    // updated, so a half-migrated store never coexists with a rename.
+    let expandedUserKeys: string[];
+    try {
+      expandedUserKeys = await expandOrgModeRights(env, org, modeName, newName);
+    } catch {
+      return errorResponse("Rights migration failed; rename aborted", 500);
+    }
+
+    const engineRes = await proxyToEngine(
       request,
       env,
       `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_rename`,
-      ["POST"]
+      ["POST"],
+      renameBody
     );
+
+    // Phase 3 — contract on success (drop the old slug), compensate on
+    // engine failure (drop the never-live new slug). Both are best-
+    // effort: affected users already hold the live slug either way, so
+    // a failed cleanup leaves a harmless stale entry (logged inside the
+    // helper), and the engine's response passes through regardless.
+    if (engineRes.ok) {
+      await contractOrgModeRights(env, expandedUserKeys, modeName, newName);
+    } else {
+      await contractOrgModeRights(env, expandedUserKeys, newName, modeName);
+    }
+    return engineRes;
   }
 
   // /api/config/modes/{name}/_clone → POST. Same admin-only gate as

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -154,6 +154,13 @@ async function fetchCurrentResource(
 // envelope unwrap (rd-4 review: preflightMode and fetchCurrentResource
 // had drifted into near-duplicates of it). Callers layer their own
 // error semantics on top.
+//
+// Deliberately does NOT catch: a thrown fetch (network) or a malformed
+// 2xx body (json parse) PROPAGATES. The PUT gate has always let those
+// surface as a request failure — swallowing them here would widen its
+// creation-semantics fallback and let an edit-only shepherd unpublish a
+// live mode during an engine blip (rd-5 review). preflightMode adds its
+// own catch to map throws to fail-closed "error".
 type ResourceState =
   | { status: "found"; mode: ResourceShape }
   | { status: "missing" }
@@ -165,28 +172,24 @@ async function fetchResourceState(
   org: string,
   name: string
 ): Promise<ResourceState> {
-  try {
-    const enginePath =
-      kind === "language"
-        ? `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(name)}`
-        : `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(name)}`;
-    const res = await fetch(`${env.ENGINE_BASE_URL}${enginePath}`, {
-      headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` },
-    });
-    if (res.status === 404) return { status: "missing" };
-    if (!res.ok) return { status: "error" };
-    const data = (await res.json()) as Record<string, unknown>;
-    // Engine wraps in { org, language|mode: {...} } — mirror of the
-    // unwrap logic in src/lib/languages-api.ts + src/lib/config-api.ts.
-    const wrapped = kind === "language" ? data.language : data.mode;
-    const mode =
-      wrapped && typeof wrapped === "object"
-        ? (wrapped as ResourceShape)
-        : (data as ResourceShape);
-    return { status: "found", mode };
-  } catch {
-    return { status: "error" };
-  }
+  const enginePath =
+    kind === "language"
+      ? `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(name)}`
+      : `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(name)}`;
+  const res = await fetch(`${env.ENGINE_BASE_URL}${enginePath}`, {
+    headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` },
+  });
+  if (res.status === 404) return { status: "missing" };
+  if (!res.ok) return { status: "error" };
+  const data = (await res.json()) as Record<string, unknown>;
+  // Engine wraps in { org, language|mode: {...} } — mirror of the
+  // unwrap logic in src/lib/languages-api.ts + src/lib/config-api.ts.
+  const wrapped = kind === "language" ? data.language : data.mode;
+  const mode =
+    wrapped && typeof wrapped === "object"
+      ? (wrapped as ResourceShape)
+      : (data as ResourceShape);
+  return { status: "found", mode };
 }
 
 // Preflight lookup for the rename arm. Unlike fetchCurrentResource
@@ -210,7 +213,12 @@ async function preflightMode(
   org: string,
   name: string
 ): Promise<ModePreflight> {
-  const state = await fetchResourceState(env, "mode", org, name);
+  let state: ResourceState;
+  try {
+    state = await fetchResourceState(env, "mode", org, name);
+  } catch {
+    return { status: "error" };
+  }
   if (state.status !== "found") return state;
   if (typeof state.mode.name !== "string") return { status: "error" };
   return {
@@ -542,7 +550,12 @@ export async function handleConfig(
       preflightMode(env, org, modeName),
       preflightMode(env, org, newName),
     ]);
-    if (source.status === "error" || target.status === "error") {
+    // Source-first evaluation, FULLY: the source's definitive answers
+    // (missing → 404, alias-addressed → 409) take precedence over a
+    // target-side engine error — a flaky target GET must not mask
+    // "the mode you're renaming doesn't exist" behind a generic
+    // 502 retry prompt the user can never satisfy (rd-5 review).
+    if (source.status === "error") {
       return errorResponse(
         "Engine unreachable; rename not attempted. Retry the rename.",
         502
@@ -556,6 +569,12 @@ export async function handleConfig(
       return errorResponse(
         `"${modeName}" is an alias of "${canonicalName}" — rename the mode via its canonical slug`,
         409
+      );
+    }
+    if (target.status === "error") {
+      return errorResponse(
+        "Engine unreachable; rename not attempted. Retry the rename.",
+        502
       );
     }
     if (target.status === "found" && target.mode.name !== canonicalName) {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -136,63 +136,49 @@ async function fetchCurrentResource(
   org: string,
   name: string
 ): Promise<ResourceShape | null> {
-  const enginePath =
-    kind === "language"
-      ? `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(name)}`
-      : `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(name)}`;
-  const res = await fetch(`${env.ENGINE_BASE_URL}${enginePath}`, {
-    headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` },
-  });
-  if (!res.ok) {
-    // 404 → resource doesn't exist yet (creation). Any other non-2xx
-    // (auth, 5xx, network blip): treat as null too so the gate falls
-    // through to creation semantics. The downstream proxy PUT will
-    // fail naturally if engine is genuinely down — duplicating the
-    // failure mode at the gate makes verb-restricted shepherds the
-    // first to lose autosave during transient engine flakiness for no
-    // security benefit. Creation semantics demand at minimum edit on
-    // any editorial field and publish on `published: true`, so the
-    // fall-through is conservative (stricter, not laxer) than the
-    // diff path would have produced.
-    return null;
-  }
-  const data = (await res.json()) as Record<string, unknown>;
-  // Engine wraps in { org, language|mode: {...} } — mirror of the
-  // unwrap logic in src/lib/languages-api.ts + src/lib/config-api.ts.
-  const wrapped = kind === "language" ? data.language : data.mode;
-  if (wrapped && typeof wrapped === "object") {
-    return wrapped as ResourceShape;
-  }
-  return data as ResourceShape;
+  // Any non-found state → null. 404 means the resource doesn't exist
+  // yet (creation); any other failure (auth, 5xx, network blip) is
+  // DELIBERATELY collapsed to null too, so the PUT gate falls through
+  // to creation semantics. The downstream proxy PUT will fail naturally
+  // if the engine is genuinely down — duplicating the failure mode at
+  // the gate makes verb-restricted shepherds the first to lose autosave
+  // during transient engine flakiness for no security benefit. Creation
+  // semantics demand at minimum edit on any editorial field and publish
+  // on `published: true`, so the fall-through is conservative
+  // (stricter, not laxer) than the diff path would have produced.
+  const state = await fetchResourceState(env, kind, org, name);
+  return state.status === "found" ? state.mode : null;
 }
 
-// Tri-state mode lookup for the rename arm's preflights. Unlike
-// fetchCurrentResource (whose null-on-any-error is deliberately lax —
-// the PUT gate falls through to stricter creation semantics), the
-// preflights are SECURITY checks and must fail CLOSED: a transient
-// engine 5xx during the collision check must abort the rename, not
-// read as "slug is free" and reopen the escalation window it guards
-// (rd-3 review). Distinguishing 404 from other failures also keeps the
-// error contract honest — "missing" is the only case reported as 404.
-type ModePreflight =
+// Tri-state resource lookup — the single copy of the engine GET +
+// envelope unwrap (rd-4 review: preflightMode and fetchCurrentResource
+// had drifted into near-duplicates of it). Callers layer their own
+// error semantics on top.
+type ResourceState =
   | { status: "found"; mode: ResourceShape }
   | { status: "missing" }
   | { status: "error" };
 
-async function preflightMode(
+async function fetchResourceState(
   env: Env,
+  kind: ResourceKind,
   org: string,
   name: string
-): Promise<ModePreflight> {
+): Promise<ResourceState> {
   try {
-    const res = await fetch(
-      `${env.ENGINE_BASE_URL}/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(name)}`,
-      { headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` } }
-    );
+    const enginePath =
+      kind === "language"
+        ? `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(name)}`
+        : `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(name)}`;
+    const res = await fetch(`${env.ENGINE_BASE_URL}${enginePath}`, {
+      headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` },
+    });
     if (res.status === 404) return { status: "missing" };
     if (!res.ok) return { status: "error" };
     const data = (await res.json()) as Record<string, unknown>;
-    const wrapped = data.mode;
+    // Engine wraps in { org, language|mode: {...} } — mirror of the
+    // unwrap logic in src/lib/languages-api.ts + src/lib/config-api.ts.
+    const wrapped = kind === "language" ? data.language : data.mode;
     const mode =
       wrapped && typeof wrapped === "object"
         ? (wrapped as ResourceShape)
@@ -201,6 +187,36 @@ async function preflightMode(
   } catch {
     return { status: "error" };
   }
+}
+
+// Preflight lookup for the rename arm. Unlike fetchCurrentResource
+// (whose null-on-any-error is deliberately lax — the PUT gate falls
+// through to stricter creation semantics), the preflights are SECURITY
+// checks and must fail CLOSED: a transient engine 5xx during the
+// collision check must abort the rename, not read as "slug is free"
+// and reopen the escalation window it guards (rd-3 review). A found
+// mode whose payload lacks a string `name` is treated as an error for
+// the same reason — the canonical-name comparisons are the checks, and
+// a response-shape drift must disable the rename, not the guards
+// (rd-4 review). Distinguishing 404 from other failures also keeps the
+// error contract honest — "missing" is the only case reported as 404.
+type ModePreflight =
+  | { status: "found"; mode: ResourceShape & { name: string } }
+  | { status: "missing" }
+  | { status: "error" };
+
+async function preflightMode(
+  env: Env,
+  org: string,
+  name: string
+): Promise<ModePreflight> {
+  const state = await fetchResourceState(env, "mode", org, name);
+  if (state.status !== "found") return state;
+  if (typeof state.mode.name !== "string") return { status: "error" };
+  return {
+    status: "found",
+    mode: state.mode as ResourceShape & { name: string },
+  };
 }
 
 // Diff a PUT body against current engine state to determine which verb
@@ -498,6 +514,12 @@ export async function handleConfig(
       return errorResponse("Missing newName", 400);
     }
 
+    // Preflights — both fail CLOSED (engine error or a payload missing
+    // its canonical name → 502 retry, before any rights mutation), and
+    // both engine GETs run in parallel (independent lookups; rd-4
+    // latency note) with results evaluated source-first so the response
+    // precedence is unchanged.
+    //
     // Preflight 1 — the addressed slug must be the mode's CANONICAL
     // name. The engine resolves the rename source through aliases
     // (findModeBySlug honors aliases, engine #284), while this arm's
@@ -506,10 +528,21 @@ export async function handleConfig(
     // by a retire-and-forward) could rename — and thereby capture — the
     // aliased-to mode, stranding its real shepherds. Runs AFTER authz,
     // so a no-rights caller can't probe mode existence through it.
-    // preflightMode fails CLOSED: engine errors abort with 502 (retry),
-    // and only a true engine 404 reports "not found" (rd-3 review).
-    const source = await preflightMode(env, org, modeName);
-    if (source.status === "error") {
+    //
+    // Preflight 2 — collision check BEFORE expanding rights. Without
+    // it, renaming TO an existing mode's slug would grant every
+    // old-slug holder rights on that live mode for the window between
+    // expand and the engine's 409 (and permanently, if compensation's
+    // best-effort write fails). The engine GET resolves aliases, so a
+    // newName matching another mode's name OR alias surfaces here; a
+    // newName that is THIS mode's own alias returns the same mode and
+    // falls through — that's the engine's valid promote-own-alias
+    // un-rename.
+    const [source, target] = await Promise.all([
+      preflightMode(env, org, modeName),
+      preflightMode(env, org, newName),
+    ]);
+    if (source.status === "error" || target.status === "error") {
       return errorResponse(
         "Engine unreachable; rename not attempted. Retry the rename.",
         502
@@ -518,38 +551,14 @@ export async function handleConfig(
     if (source.status === "missing") {
       return errorResponse("Mode not found", 404);
     }
-    const canonicalName =
-      typeof source.mode.name === "string" ? source.mode.name : modeName;
+    const canonicalName = source.mode.name;
     if (canonicalName !== modeName) {
       return errorResponse(
         `"${modeName}" is an alias of "${canonicalName}" — rename the mode via its canonical slug`,
         409
       );
     }
-
-    // Preflight 2 — collision check BEFORE expanding rights. Without
-    // it, renaming TO an existing mode's slug would grant every
-    // old-slug holder rights on that live mode for the window between
-    // expand and the engine's 409 (and permanently, if compensation's
-    // best-effort write fails). Fails CLOSED for the same reason: a
-    // transient engine error must not read as "slug is free" and reopen
-    // the window this check exists to close. The engine GET resolves
-    // aliases, so a newName matching another mode's name OR alias
-    // surfaces here; a newName that is THIS mode's own alias returns
-    // the same mode and falls through — that's the engine's valid
-    // promote-own-alias un-rename.
-    const target = await preflightMode(env, org, newName);
-    if (target.status === "error") {
-      return errorResponse(
-        "Engine unreachable; rename not attempted. Retry the rename.",
-        502
-      );
-    }
-    if (
-      target.status === "found" &&
-      typeof target.mode.name === "string" &&
-      target.mode.name !== canonicalName
-    ) {
+    if (target.status === "found" && target.mode.name !== canonicalName) {
       return errorResponse(
         `Slug "${newName}" already belongs to another mode (as a name or alias) in this org`,
         409

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -166,6 +166,43 @@ async function fetchCurrentResource(
   return data as ResourceShape;
 }
 
+// Tri-state mode lookup for the rename arm's preflights. Unlike
+// fetchCurrentResource (whose null-on-any-error is deliberately lax —
+// the PUT gate falls through to stricter creation semantics), the
+// preflights are SECURITY checks and must fail CLOSED: a transient
+// engine 5xx during the collision check must abort the rename, not
+// read as "slug is free" and reopen the escalation window it guards
+// (rd-3 review). Distinguishing 404 from other failures also keeps the
+// error contract honest — "missing" is the only case reported as 404.
+type ModePreflight =
+  | { status: "found"; mode: ResourceShape }
+  | { status: "missing" }
+  | { status: "error" };
+
+async function preflightMode(
+  env: Env,
+  org: string,
+  name: string
+): Promise<ModePreflight> {
+  try {
+    const res = await fetch(
+      `${env.ENGINE_BASE_URL}/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(name)}`,
+      { headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` } }
+    );
+    if (res.status === 404) return { status: "missing" };
+    if (!res.ok) return { status: "error" };
+    const data = (await res.json()) as Record<string, unknown>;
+    const wrapped = data.mode;
+    const mode =
+      wrapped && typeof wrapped === "object"
+        ? (wrapped as ResourceShape)
+        : (data as ResourceShape);
+    return { status: "found", mode };
+  } catch {
+    return { status: "error" };
+  }
+}
+
 // Diff a PUT body against current engine state to determine which verb
 // rights the caller needs. The portal sends the full resource on every
 // PUT — document and published both present even for an autosave that
@@ -469,12 +506,20 @@ export async function handleConfig(
     // by a retire-and-forward) could rename — and thereby capture — the
     // aliased-to mode, stranding its real shepherds. Runs AFTER authz,
     // so a no-rights caller can't probe mode existence through it.
-    const sourceMode = await fetchCurrentResource(env, "mode", org, modeName);
-    if (!sourceMode) {
+    // preflightMode fails CLOSED: engine errors abort with 502 (retry),
+    // and only a true engine 404 reports "not found" (rd-3 review).
+    const source = await preflightMode(env, org, modeName);
+    if (source.status === "error") {
+      return errorResponse(
+        "Engine unreachable; rename not attempted. Retry the rename.",
+        502
+      );
+    }
+    if (source.status === "missing") {
       return errorResponse("Mode not found", 404);
     }
     const canonicalName =
-      typeof sourceMode.name === "string" ? sourceMode.name : modeName;
+      typeof source.mode.name === "string" ? source.mode.name : modeName;
     if (canonicalName !== modeName) {
       return errorResponse(
         `"${modeName}" is an alias of "${canonicalName}" — rename the mode via its canonical slug`,
@@ -486,16 +531,24 @@ export async function handleConfig(
     // it, renaming TO an existing mode's slug would grant every
     // old-slug holder rights on that live mode for the window between
     // expand and the engine's 409 (and permanently, if compensation's
-    // best-effort write fails). The engine GET resolves aliases, so a
-    // newName matching another mode's name OR alias surfaces here; a
-    // newName that is THIS mode's own alias returns the same mode and
-    // falls through — that's the engine's valid promote-own-alias
-    // un-rename.
-    const targetMode = await fetchCurrentResource(env, "mode", org, newName);
+    // best-effort write fails). Fails CLOSED for the same reason: a
+    // transient engine error must not read as "slug is free" and reopen
+    // the window this check exists to close. The engine GET resolves
+    // aliases, so a newName matching another mode's name OR alias
+    // surfaces here; a newName that is THIS mode's own alias returns
+    // the same mode and falls through — that's the engine's valid
+    // promote-own-alias un-rename.
+    const target = await preflightMode(env, org, newName);
+    if (target.status === "error") {
+      return errorResponse(
+        "Engine unreachable; rename not attempted. Retry the rename.",
+        502
+      );
+    }
     if (
-      targetMode &&
-      typeof targetMode.name === "string" &&
-      targetMode.name !== canonicalName
+      target.status === "found" &&
+      typeof target.mode.name === "string" &&
+      target.mode.name !== canonicalName
     ) {
       return errorResponse(
         `Slug "${newName}" already belongs to another mode (as a name or alias) in this org`,
@@ -551,37 +604,37 @@ export async function handleConfig(
     }
 
     // Phase 3 — classify the outcome:
-    //   2xx  → rename applied → contract (drop the old slug).
-    //   4xx  → engine definitively rejected (validation/collision/404)
-    //          → compensate (drop the never-live new slug).
-    //   5xx  → AMBIGUOUS (the engine may have persisted the rename and
-    //          failed afterwards, or a gateway may have emitted the 5xx
-    //          after commit). Disambiguate with a re-GET of the old
-    //          slug — alias-aware resolution means it returns the mode
-    //          either way, and its canonical name tells us whether the
-    //          rename landed. If the probe itself fails, keep the
-    //          superset: never compensate on uncertainty.
+    //   2xx        → rename applied → contract (drop the old slug).
+    //   400–499    → engine definitively rejected (validation, races on
+    //                collision/404) → compensate (drop the never-live
+    //                new slug).
+    //   everything → AMBIGUOUS. A 5xx can be emitted by a gateway after
+    //   else         the engine committed — or WHILE the engine is
+    //                still processing, so even a probe that reports the
+    //                old name doesn't prove the rename won't land
+    //                moments later (rd-3 review). The probe is used
+    //                only in the ONE direction it's definitive: seeing
+    //                the NEW canonical name proves the rename applied →
+    //                contract. Every other 5xx-class outcome keeps the
+    //                superset (both slugs) + logs — never compensate on
+    //                uncertainty. Worst case is an inert extra entry;
+    //                compensating a rename that lands strands every
+    //                shepherd. (3xx lands here too rather than in the
+    //                "rejected" band — it's not evidence of failure.)
     // Cleanup is best-effort in all branches (affected users already
     // hold the live slug; failures log inside the helper), and the
     // engine's response passes through regardless.
     if (engineRes.ok) {
       await contractOrgModeRights(env, migrationRecords, modeName, newName);
-    } else if (engineRes.status < 500) {
+    } else if (engineRes.status >= 400 && engineRes.status < 500) {
       await contractOrgModeRights(env, migrationRecords, newName, modeName);
     } else {
-      const probe = await fetchCurrentResource(
-        env,
-        "mode",
-        org,
-        modeName
-      ).catch(() => null);
-      if (probe && probe.name === newName) {
+      const probe = await preflightMode(env, org, modeName);
+      if (probe.status === "found" && probe.mode.name === newName) {
         await contractOrgModeRights(env, migrationRecords, modeName, newName);
-      } else if (probe && probe.name === modeName) {
-        await contractOrgModeRights(env, migrationRecords, newName, modeName);
       } else {
         console.error(
-          `rename ${modeName}→${newName} (org=${resolved.org}): engine 5xx and probe inconclusive; leaving rights superset in place`
+          `rename ${modeName}→${newName} (org=${resolved.org}): engine returned ${engineRes.status} and the probe could not confirm the rename applied; leaving rights superset in place`
         );
       }
     }

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -1,6 +1,10 @@
 import type { Env } from "./helpers";
 import { errorResponse } from "./helpers";
-import { contractOrgModeRights, expandOrgModeRights } from "./rights-migration";
+import {
+  contractOrgModeRights,
+  expandOrgModeRights,
+  type MigrationRecord,
+} from "./rights-migration";
 import type { LanguageRights, SessionData } from "./types";
 
 // `undefined` is the back-compat default for users predating the rights
@@ -115,6 +119,11 @@ async function proxyToEngine(
 // signal so a future `{label: "new"}` PUT for languages stays on the edit
 // gate even though today's portal only sends `document`.
 interface ResourceShape {
+  // Canonical slug from the engine's admin view. The rename arm's
+  // preflights compare it against URL/body slugs — the engine resolves
+  // slugs through aliases (findModeBySlug honors aliases, engine #284),
+  // so the addressed slug and the mode's canonical name can differ.
+  name?: string;
   document?: string;
   label?: string;
   description?: string;
@@ -437,19 +446,61 @@ export async function handleConfig(
     }
     // The migration needs `newName` before the engine call, so the arm
     // reads the body (one-shot stream) and passes the parsed copy back
-    // through proxyToEngine. Only presence is validated here — slug
-    // format, self-rename, and collisions (409) are the engine's calls,
-    // and its status + message pass through faithfully.
-    let renameBody: { newName?: unknown };
+    // through proxyToEngine. `| null` in the cast: the JSON literal
+    // `null` parses without throwing, and dereferencing it would 500
+    // instead of the 400 every other malformed body gets.
+    let renameBody: { newName?: unknown } | null;
     try {
-      renameBody = (await request.json()) as { newName?: unknown };
+      renameBody = (await request.json()) as { newName?: unknown } | null;
     } catch {
       return errorResponse("Invalid JSON", 400);
     }
     const newName =
-      typeof renameBody.newName === "string" ? renameBody.newName.trim() : "";
+      typeof renameBody?.newName === "string" ? renameBody.newName.trim() : "";
     if (!newName) {
       return errorResponse("Missing newName", 400);
+    }
+
+    // Preflight 1 — the addressed slug must be the mode's CANONICAL
+    // name. The engine resolves the rename source through aliases
+    // (findModeBySlug honors aliases, engine #284), while this arm's
+    // authz + migration key on the addressed slug. Without this check a
+    // shepherd holding rights only on a stale ALIAS (e.g. left behind
+    // by a retire-and-forward) could rename — and thereby capture — the
+    // aliased-to mode, stranding its real shepherds. Runs AFTER authz,
+    // so a no-rights caller can't probe mode existence through it.
+    const sourceMode = await fetchCurrentResource(env, "mode", org, modeName);
+    if (!sourceMode) {
+      return errorResponse("Mode not found", 404);
+    }
+    const canonicalName =
+      typeof sourceMode.name === "string" ? sourceMode.name : modeName;
+    if (canonicalName !== modeName) {
+      return errorResponse(
+        `"${modeName}" is an alias of "${canonicalName}" — rename the mode via its canonical slug`,
+        409
+      );
+    }
+
+    // Preflight 2 — collision check BEFORE expanding rights. Without
+    // it, renaming TO an existing mode's slug would grant every
+    // old-slug holder rights on that live mode for the window between
+    // expand and the engine's 409 (and permanently, if compensation's
+    // best-effort write fails). The engine GET resolves aliases, so a
+    // newName matching another mode's name OR alias surfaces here; a
+    // newName that is THIS mode's own alias returns the same mode and
+    // falls through — that's the engine's valid promote-own-alias
+    // un-rename.
+    const targetMode = await fetchCurrentResource(env, "mode", org, newName);
+    if (
+      targetMode &&
+      typeof targetMode.name === "string" &&
+      targetMode.name !== canonicalName
+    ) {
+      return errorResponse(
+        `Slug "${newName}" already belongs to another mode (as a name or alias) in this org`,
+        409
+      );
     }
 
     // Phase 1 — expand: affected users hold BOTH slugs. Aborts (500)
@@ -460,9 +511,9 @@ export async function handleConfig(
     // paths: stored `user.org` values are raw strings, so an org slug
     // that encodes differently (space, non-ASCII) would otherwise match
     // nobody and silently strand every shepherd (Frank rd-1 P1).
-    let expandedUserKeys: string[];
+    let migrationRecords: MigrationRecord[];
     try {
-      expandedUserKeys = await expandOrgModeRights(
+      migrationRecords = await expandOrgModeRights(
         env,
         resolved.org,
         modeName,
@@ -472,40 +523,81 @@ export async function handleConfig(
       return errorResponse("Rights migration failed; rename aborted", 500);
     }
 
-    const engineRes = await proxyToEngine(
-      request,
-      env,
-      `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_rename`,
-      ["POST"],
-      // Forward the TRIMMED newName — the same value the migration used.
-      // The browser slugifies before sending, but the BFF is the API
-      // boundary: a direct call with `" conversation "` must not migrate
-      // rights to `conversation` while the engine receives the padded
-      // original (Frank rd-1 P2).
-      { ...renameBody, newName }
-    );
+    // Engine call under try/catch: a thrown fetch (network blip, DNS)
+    // is an AMBIGUOUS outcome — the rename may or may not have applied.
+    // Keep the superset (both slugs) rather than guessing: compensating
+    // a rename that actually landed would strand every shepherd, while
+    // a stale extra entry is inert. 502 tells the caller to retry.
+    let engineRes: Response;
+    try {
+      engineRes = await proxyToEngine(
+        request,
+        env,
+        `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_rename`,
+        ["POST"],
+        // Forward the TRIMMED newName — the same value the migration
+        // used (Frank rd-1 P2).
+        { ...renameBody, newName }
+      );
+    } catch (err) {
+      console.error(
+        `rename ${modeName}→${newName} (org=${resolved.org}): engine call threw after expand; leaving rights superset in place`,
+        err
+      );
+      return errorResponse(
+        "Engine unreachable; rename may not have applied. Retry the rename.",
+        502
+      );
+    }
 
-    // Phase 3 — contract on success (drop the old slug), compensate on
-    // engine failure (drop the never-live new slug). Both are best-
-    // effort: affected users already hold the live slug either way, so
-    // a failed cleanup leaves a harmless stale entry (logged inside the
-    // helper), and the engine's response passes through regardless.
+    // Phase 3 — classify the outcome:
+    //   2xx  → rename applied → contract (drop the old slug).
+    //   4xx  → engine definitively rejected (validation/collision/404)
+    //          → compensate (drop the never-live new slug).
+    //   5xx  → AMBIGUOUS (the engine may have persisted the rename and
+    //          failed afterwards, or a gateway may have emitted the 5xx
+    //          after commit). Disambiguate with a re-GET of the old
+    //          slug — alias-aware resolution means it returns the mode
+    //          either way, and its canonical name tells us whether the
+    //          rename landed. If the probe itself fails, keep the
+    //          superset: never compensate on uncertainty.
+    // Cleanup is best-effort in all branches (affected users already
+    // hold the live slug; failures log inside the helper), and the
+    // engine's response passes through regardless.
     if (engineRes.ok) {
-      await contractOrgModeRights(env, expandedUserKeys, modeName, newName);
+      await contractOrgModeRights(env, migrationRecords, modeName, newName);
+    } else if (engineRes.status < 500) {
+      await contractOrgModeRights(env, migrationRecords, newName, modeName);
     } else {
-      await contractOrgModeRights(env, expandedUserKeys, newName, modeName);
+      const probe = await fetchCurrentResource(
+        env,
+        "mode",
+        org,
+        modeName
+      ).catch(() => null);
+      if (probe && probe.name === newName) {
+        await contractOrgModeRights(env, migrationRecords, modeName, newName);
+      } else if (probe && probe.name === modeName) {
+        await contractOrgModeRights(env, migrationRecords, newName, modeName);
+      } else {
+        console.error(
+          `rename ${modeName}→${newName} (org=${resolved.org}): engine 5xx and probe inconclusive; leaving rights superset in place`
+        );
+      }
     }
     return engineRes;
   }
 
-  // /api/config/modes/{name}/_clone → POST. Same admin-only gate as
-  // _rename (#241 PR B). The engine creates a new mode with the new
-  // slug + optional label; content is copied verbatim from the source.
-  // Rights don't migrate — mode_edit_rights / mode_publish_rights are
-  // slug-scoped and no shepherd holds rights on the fresh slug yet, so
-  // gating this to admin/cross-org avoids handing a non-admin a mode
-  // they can't edit. Matched above the catch-all for the same regex-
-  // ordering reason as _rename.
+  // /api/config/modes/{name}/_clone → POST. Admin/cross-org ONLY —
+  // deliberately STRICTER than _rename, which #240 opened to edit-
+  // rights shepherds. The engine creates a new mode with the new slug +
+  // optional label; content is copied verbatim from the source. Rights
+  // don't migrate — mode_edit_rights / mode_publish_rights are slug-
+  // scoped and no shepherd holds rights on the fresh slug yet, so a
+  // non-admin cloning would land on a mode they can't edit. Opening
+  // this needs a cloner-auto-grant decision (rights-migration.ts
+  // primitives are ready; product call pending). Matched above the
+  // catch-all for the same regex-ordering reason as _rename.
   // `[^/]+` for the same reason as _rename above.
   const modeCloneMatch = pathname.match(
     /^\/api\/config\/modes\/([^/]+)\/_clone$/
@@ -530,11 +622,13 @@ export async function handleConfig(
   // silently resolve to the target — the "bring FIA Coach users over
   // silently" flow from Ian's #232 plan §3.
   //
-  // Same admin/cross-org gate as _rename and _clone. Retire deletes a
-  // mode + widens the target's alias set, both of which are org-wide
-  // config changes; per-user mode rights are slug-scoped, so gating
-  // to admin/cross-org matches the trust bar of PUT/DELETE-modes
-  // today. `[^/]+` for the same reason as _rename and _clone above.
+  // Admin/cross-org ONLY — deliberately STRICTER than _rename, which
+  // #240 opened to edit-rights shepherds. Retire deletes a mode +
+  // widens the target's alias set, both org-wide config changes;
+  // whether the retired mode's shepherds should inherit rights on the
+  // forward target is an open product call (rights-migration.ts
+  // primitives are ready). `[^/]+` for the same reason as _rename and
+  // _clone above.
   const modeRetireMatch = pathname.match(
     /^\/api\/config\/modes\/([^/]+)\/_retire$/
   );

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -136,16 +136,19 @@ async function fetchCurrentResource(
   org: string,
   name: string
 ): Promise<ResourceShape | null> {
-  // Any non-found state → null. 404 means the resource doesn't exist
-  // yet (creation); any other failure (auth, 5xx, network blip) is
-  // DELIBERATELY collapsed to null too, so the PUT gate falls through
-  // to creation semantics. The downstream proxy PUT will fail naturally
-  // if the engine is genuinely down — duplicating the failure mode at
-  // the gate makes verb-restricted shepherds the first to lose autosave
-  // during transient engine flakiness for no security benefit. Creation
-  // semantics demand at minimum edit on any editorial field and publish
-  // on `published: true`, so the fall-through is conservative
-  // (stricter, not laxer) than the diff path would have produced.
+  // Any non-found RESPONSE → null. 404 means the resource doesn't
+  // exist yet (creation); other non-2xx statuses (auth, engine 5xx)
+  // are DELIBERATELY collapsed to null too, so the PUT gate falls
+  // through to creation semantics — which demand at minimum edit on
+  // any editorial field and publish on `published: true`, stricter
+  // than the diff path would have produced.
+  //
+  // A THROWN fetch or malformed 2xx body is NOT collapsed: it
+  // propagates and fails the request, exactly as on main (rd-5
+  // review; pinned by test). Do not add a catch here or in
+  // fetchResourceState — swallowing throws widens the creation
+  // fallback and lets an edit-only shepherd unpublish a live mode
+  // during an engine blip.
   const state = await fetchResourceState(env, kind, org, name);
   return state.status === "found" ? state.mode : null;
 }

--- a/worker/helpers.ts
+++ b/worker/helpers.ts
@@ -31,3 +31,22 @@ export function requireSameOrigin(request: Request): Response | null {
   }
   return null;
 }
+
+// Paginated KV key listing — the AUTH_KV store has no secondary indexes,
+// so every "all users" / "all sessions" operation is a prefix scan. One
+// shared loop (rd-3 review: three hand-rolled copies had accumulated in
+// admin.ts, auth.ts, and rights-migration.ts) so a future change to
+// list semantics — an org index, error handling, limits — lands once.
+export async function listKvKeys(
+  kv: KVNamespace,
+  prefix: string
+): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const list = await kv.list({ prefix, cursor });
+    keys.push(...list.keys.map((k) => k.name));
+    cursor = list.list_complete ? undefined : list.cursor;
+  } while (cursor);
+  return keys;
+}

--- a/worker/rights-migration.ts
+++ b/worker/rights-migration.ts
@@ -47,18 +47,14 @@ export const MODE_RIGHTS_FIELDS = [
   "mode_publish_rights",
 ] as const satisfies readonly (keyof StoredUser)[];
 
-// Includes the legacy single-bit field: a future language rename must
-// migrate it too, since `rightsFor` falls back to it when the verb
-// fields are unset.
-export const LANGUAGE_RIGHTS_FIELDS = [
-  "language_edit_rights",
-  "language_publish_rights",
-  "language_rights",
-] as const satisfies readonly (keyof StoredUser)[];
-
-export type RightsField =
-  | (typeof MODE_RIGHTS_FIELDS)[number]
-  | (typeof LANGUAGE_RIGHTS_FIELDS)[number];
+// A future language rename would add the three language fields here
+// (including the legacy `language_rights` bit, whose undefined-means-
+// full semantics differ from modes — the expandRights passthrough is
+// correct for it, but the consumer must decide how "*"-equivalent
+// legacy users interact with per-slug migration). Deliberately not
+// pre-declared: no consumer exists yet, and an unused constant would
+// assert semantics nobody has validated.
+export type RightsField = (typeof MODE_RIGHTS_FIELDS)[number];
 
 // Add `to` wherever `from` is held. `"*"` and `undefined` pass through
 // untouched — wildcard resolves at gate time and needs no entry; for
@@ -95,32 +91,41 @@ export function removeSlugIfPartnerPresent(
   return rights.filter((slug) => slug !== remove);
 }
 
+// The unit contract and compensate operate on: which FIELDS of which
+// user the expand actually modified. Per-field (not per-user) recording
+// is load-bearing: a user can hold a legitimate pre-existing grant on
+// the new slug in one field (say publish on "conversation") while the
+// expand only touched the other (edit gained "conversation" alongside
+// "spoken"). A per-user record would let compensation's partner-guard
+// pass on the untouched field and strip the pre-existing grant.
+export interface MigrationRecord {
+  key: string;
+  fields: RightsField[];
+}
+
 // Apply a per-field transform to a user record. Mutates in place;
-// returns true when any field changed.
+// returns the fields that changed.
 function applyToUser(
   user: StoredUser,
   fields: readonly RightsField[],
   transform: (rights: LanguageRights | undefined) => string[] | null
-): boolean {
-  let changed = false;
+): RightsField[] {
+  const changed: RightsField[] = [];
   for (const field of fields) {
     const next = transform(user[field]);
     if (next !== null) {
       user[field] = next;
-      changed = true;
+      changed.push(field);
     }
   }
   return changed;
 }
 
-// Enumerate every stored user in `org`. AUTH_KV has no org index — this
-// mirrors the listUsers scan in worker/admin.ts (full `user:` prefix,
-// filter by `.org` in code). Fine at current org sizes; if user counts
-// grow enough to hurt, an org index is the fix, not a smarter scan.
-async function listOrgUsers(
-  env: Env,
-  org: string
-): Promise<{ key: string; user: StoredUser }[]> {
+// Enumerate every `user:` key. AUTH_KV has no org index — same paginated
+// scan as worker/admin.ts listUsers. Fine at current org sizes; if user
+// counts ever approach the Workers subrequest cap, an org index is the
+// fix, not a smarter scan (flagged in #240's design notes).
+async function listUserKeys(env: Env): Promise<string[]> {
   const keys: string[] = [];
   let cursor: string | undefined;
   do {
@@ -128,54 +133,65 @@ async function listOrgUsers(
     keys.push(...list.keys.map((k) => k.name));
     cursor = list.list_complete ? undefined : list.cursor;
   } while (cursor);
-
-  const entries = await Promise.all(
-    keys.map(async (key) => {
-      const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
-      if (!user || user.org !== org) return null;
-      return { key, user };
-    })
-  );
-  return entries.filter((e): e is { key: string; user: StoredUser } => !!e);
+  return keys;
 }
 
 // Phase 1: add `newSlug` alongside `oldSlug` for every affected user in
-// `org`. Returns the KV keys of the users actually modified — contract
-// and compensate operate ONLY on this set, so a user who legitimately
-// held BOTH slugs before the rename is never touched by the cleanup
-// phases (compensating them would strip a pre-existing grant).
+// `org`. Each record is re-read immediately before its write (read →
+// transform → put per key), so a concurrent admin edit to the same user
+// is only at risk during a single key's read-write gap — not the whole
+// scan duration. KV has no CAS; two truly simultaneous writes to one
+// user remain last-write-wins (accepted at current scale, #240 design
+// question 2).
+//
+// Returns records of the users/fields actually modified — contract and
+// compensate operate ONLY on those fields, so a user who legitimately
+// held BOTH slugs before the rename (or held the new slug in a field
+// the expand didn't touch) is never affected by cleanup.
 //
 // Throws if any write fails, AFTER attempting to compensate the writes
-// that did land — the caller should abort the rename (the engine call
+// that did land — the caller must abort the rename (the engine call
 // hasn't happened yet, so the old slug is still live and untouched).
 export async function expandOrgModeRights(
   env: Env,
   org: string,
   oldSlug: string,
   newSlug: string
-): Promise<string[]> {
-  const entries = await listOrgUsers(env, org);
-  const affected = entries.filter(({ user }) =>
-    applyToUser(user, MODE_RIGHTS_FIELDS, (r) =>
-      expandRights(r, oldSlug, newSlug)
-    )
-  );
-  if (affected.length === 0) return [];
+): Promise<MigrationRecord[]> {
+  const keys = await listUserKeys(env);
 
   const results = await Promise.allSettled(
-    affected.map(({ key, user }) => env.AUTH_KV.put(key, JSON.stringify(user)))
+    keys.map(async (key): Promise<MigrationRecord | null> => {
+      const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
+      if (!user || user.org !== org) return null;
+      const fields = applyToUser(user, MODE_RIGHTS_FIELDS, (r) =>
+        expandRights(r, oldSlug, newSlug)
+      );
+      if (fields.length === 0) return null;
+      await env.AUTH_KV.put(key, JSON.stringify(user));
+      return { key, fields };
+    })
   );
-  const written = affected
-    .filter((_, i) => results[i]?.status === "fulfilled")
-    .map(({ key }) => key);
 
-  if (written.length < affected.length) {
+  const written: MigrationRecord[] = [];
+  let failed = false;
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      if (result.value) written.push(result.value);
+    } else {
+      failed = true;
+    }
+  }
+
+  if (failed) {
     // Partial expand — roll back what landed so the caller can abort
-    // with a clean store. If the rollback itself also fails, affected
-    // users hold an extra entry for a slug that doesn't exist (the
-    // engine was never called): no live access changes, but a future
-    // mode created with that slug would inherit accidental shepherds —
-    // hence the loud log.
+    // with a clean store. (A rejected entry may have failed on the read
+    // OR the put; either way its user is untouched or unrecorded, and
+    // unrecorded-but-written is impossible since the put is the last
+    // step.) If the rollback itself also fails, affected users hold an
+    // extra entry for a slug that doesn't exist (the engine was never
+    // called): no live access changes, but a future mode created with
+    // that slug would inherit accidental shepherds — hence the loud log.
     await contractOrgModeRights(env, written, newSlug, oldSlug).catch((err) =>
       console.error(
         `rights-migration: rollback after partial expand failed (org=${org}, ${oldSlug}→${newSlug}); stale "${newSlug}" entries may remain`,
@@ -187,26 +203,29 @@ export async function expandOrgModeRights(
   return written;
 }
 
-// Phases 3a/3b: remove `removeSlug` (keeping `keepSlug`) from the users
-// expanded in phase 1. Best-effort by design — by the time this runs,
-// the engine outcome is settled and every affected user already holds
-// the live slug, so a failed removal only leaves a harmless stale entry
-// (logged, never surfaced to the caller as an error).
+// Phases 3a/3b: remove `removeSlug` (keeping `keepSlug`) from exactly
+// the fields recorded by the expand. Best-effort by design — by the
+// time this runs, the engine outcome is settled and every affected user
+// already holds the live slug, so a failed removal only leaves a
+// harmless stale entry (logged, never surfaced to the caller as an
+// error).
 export async function contractOrgModeRights(
   env: Env,
-  userKeys: string[],
+  records: MigrationRecord[],
   removeSlug: string,
   keepSlug: string
 ): Promise<void> {
   await Promise.all(
-    userKeys.map(async (key) => {
+    records.map(async ({ key, fields }) => {
       try {
         const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
         if (!user) return;
-        const changed = applyToUser(user, MODE_RIGHTS_FIELDS, (r) =>
+        const changed = applyToUser(user, fields, (r) =>
           removeSlugIfPartnerPresent(r, removeSlug, keepSlug)
         );
-        if (changed) await env.AUTH_KV.put(key, JSON.stringify(user));
+        if (changed.length > 0) {
+          await env.AUTH_KV.put(key, JSON.stringify(user));
+        }
       } catch (err) {
         console.error(
           `rights-migration: cleanup failed for ${key} (remove "${removeSlug}", keep "${keepSlug}") — stale entry remains`,

--- a/worker/rights-migration.ts
+++ b/worker/rights-migration.ts
@@ -1,0 +1,218 @@
+import type { Env } from "./helpers";
+import type { LanguageRights, StoredUser } from "./types";
+
+// #240 — per-user rights migration for slug-changing mode ops.
+//
+// Per-user mode rights (`mode_edit_rights` / `mode_publish_rights`) are
+// arrays of mode SLUGS. The engine's `_rename` op reslugs a mode in
+// place; without migration, every shepherd holding rights on the old
+// slug is stranded (the worker gate matches the exact slug string —
+// aliases are deliberately not consulted, see gateConfigMutation).
+//
+// ## Atomicity model: expand → engine op → contract
+//
+// KV has no transactions and the engine is a remote call, so true
+// atomicity is unavailable. Instead the migration holds one invariant
+// at every intermediate point: a user's rights always cover whichever
+// slug is currently live.
+//
+//   1. EXPAND  — add the new slug to every affected user (old kept).
+//   2. ENGINE  — call `_rename`.
+//   3a. CONTRACT   (engine 2xx)     — remove the old slug.
+//   3b. COMPENSATE (engine non-2xx) — remove the new slug.
+//
+// A crash or write failure at any point leaves affected users with a
+// SUPERSET of their correct rights, never less: after a failed engine
+// call they still hold the old (live) slug; after a successful rename
+// they hold the new (live) slug plus at worst a stale old entry, which
+// is inert (the old slug survives only as an alias, and nothing in the
+// authz path reads aliases). Contrast with migrate-then-rename, whose
+// failed rollback leaves users pointing ONLY at a slug that doesn't
+// exist — locked out.
+//
+// The removal primitive is shared by contract and compensate: it never
+// removes a slug unless its partner is present in the same array, so a
+// removal can never shrink a user's rights below the live slug.
+//
+// ## Scope / reuse
+//
+// The pure helpers are field-agnostic; `MODE_RIGHTS_FIELDS` /
+// `LANGUAGE_RIGHTS_FIELDS` parameterize the kind so future consumers
+// (retire-and-forward rights inheritance, clone auto-grant, language
+// rename) reuse the same primitives. Only the mode-rename orchestration
+// is wired up today (#240 scope).
+
+export const MODE_RIGHTS_FIELDS = [
+  "mode_edit_rights",
+  "mode_publish_rights",
+] as const satisfies readonly (keyof StoredUser)[];
+
+// Includes the legacy single-bit field: a future language rename must
+// migrate it too, since `rightsFor` falls back to it when the verb
+// fields are unset.
+export const LANGUAGE_RIGHTS_FIELDS = [
+  "language_edit_rights",
+  "language_publish_rights",
+  "language_rights",
+] as const satisfies readonly (keyof StoredUser)[];
+
+export type RightsField =
+  | (typeof MODE_RIGHTS_FIELDS)[number]
+  | (typeof LANGUAGE_RIGHTS_FIELDS)[number];
+
+// Add `to` wherever `from` is held. `"*"` and `undefined` pass through
+// untouched — wildcard resolves at gate time and needs no entry; for
+// modes `undefined` means no access (nothing to widen), and for the
+// legacy language field it means full access (same as wildcard).
+// Returns the new array, or null when no change is needed (from absent,
+// or to already present).
+export function expandRights(
+  rights: LanguageRights | undefined,
+  from: string,
+  to: string
+): string[] | null {
+  if (rights === undefined || rights === "*") return null;
+  if (!rights.includes(from)) return null;
+  if (rights.includes(to)) return null;
+  return [...rights, to].sort();
+}
+
+// Remove `remove` — but ONLY when `keep` is present in the same array.
+// This single guard is what makes contract and compensate safe to run
+// against any intermediate state: the removal can never take away a
+// user's only path to the live slug.
+//   contract   = removeSlugIfPartnerPresent(rights, oldSlug, newSlug)
+//   compensate = removeSlugIfPartnerPresent(rights, newSlug, oldSlug)
+// Returns the new array, or null when no change is needed.
+export function removeSlugIfPartnerPresent(
+  rights: LanguageRights | undefined,
+  remove: string,
+  keep: string
+): string[] | null {
+  if (rights === undefined || rights === "*") return null;
+  if (!rights.includes(remove)) return null;
+  if (!rights.includes(keep)) return null;
+  return rights.filter((slug) => slug !== remove);
+}
+
+// Apply a per-field transform to a user record. Mutates in place;
+// returns true when any field changed.
+function applyToUser(
+  user: StoredUser,
+  fields: readonly RightsField[],
+  transform: (rights: LanguageRights | undefined) => string[] | null
+): boolean {
+  let changed = false;
+  for (const field of fields) {
+    const next = transform(user[field]);
+    if (next !== null) {
+      user[field] = next;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+// Enumerate every stored user in `org`. AUTH_KV has no org index — this
+// mirrors the listUsers scan in worker/admin.ts (full `user:` prefix,
+// filter by `.org` in code). Fine at current org sizes; if user counts
+// grow enough to hurt, an org index is the fix, not a smarter scan.
+async function listOrgUsers(
+  env: Env,
+  org: string
+): Promise<{ key: string; user: StoredUser }[]> {
+  const keys: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const list = await env.AUTH_KV.list({ prefix: "user:", cursor });
+    keys.push(...list.keys.map((k) => k.name));
+    cursor = list.list_complete ? undefined : list.cursor;
+  } while (cursor);
+
+  const entries = await Promise.all(
+    keys.map(async (key) => {
+      const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
+      if (!user || user.org !== org) return null;
+      return { key, user };
+    })
+  );
+  return entries.filter((e): e is { key: string; user: StoredUser } => !!e);
+}
+
+// Phase 1: add `newSlug` alongside `oldSlug` for every affected user in
+// `org`. Returns the KV keys of the users actually modified — contract
+// and compensate operate ONLY on this set, so a user who legitimately
+// held BOTH slugs before the rename is never touched by the cleanup
+// phases (compensating them would strip a pre-existing grant).
+//
+// Throws if any write fails, AFTER attempting to compensate the writes
+// that did land — the caller should abort the rename (the engine call
+// hasn't happened yet, so the old slug is still live and untouched).
+export async function expandOrgModeRights(
+  env: Env,
+  org: string,
+  oldSlug: string,
+  newSlug: string
+): Promise<string[]> {
+  const entries = await listOrgUsers(env, org);
+  const affected = entries.filter(({ user }) =>
+    applyToUser(user, MODE_RIGHTS_FIELDS, (r) =>
+      expandRights(r, oldSlug, newSlug)
+    )
+  );
+  if (affected.length === 0) return [];
+
+  const results = await Promise.allSettled(
+    affected.map(({ key, user }) => env.AUTH_KV.put(key, JSON.stringify(user)))
+  );
+  const written = affected
+    .filter((_, i) => results[i]?.status === "fulfilled")
+    .map(({ key }) => key);
+
+  if (written.length < affected.length) {
+    // Partial expand — roll back what landed so the caller can abort
+    // with a clean store. If the rollback itself also fails, affected
+    // users hold an extra entry for a slug that doesn't exist (the
+    // engine was never called): no live access changes, but a future
+    // mode created with that slug would inherit accidental shepherds —
+    // hence the loud log.
+    await contractOrgModeRights(env, written, newSlug, oldSlug).catch((err) =>
+      console.error(
+        `rights-migration: rollback after partial expand failed (org=${org}, ${oldSlug}→${newSlug}); stale "${newSlug}" entries may remain`,
+        err
+      )
+    );
+    throw new Error("rights migration failed: could not update all users");
+  }
+  return written;
+}
+
+// Phases 3a/3b: remove `removeSlug` (keeping `keepSlug`) from the users
+// expanded in phase 1. Best-effort by design — by the time this runs,
+// the engine outcome is settled and every affected user already holds
+// the live slug, so a failed removal only leaves a harmless stale entry
+// (logged, never surfaced to the caller as an error).
+export async function contractOrgModeRights(
+  env: Env,
+  userKeys: string[],
+  removeSlug: string,
+  keepSlug: string
+): Promise<void> {
+  await Promise.all(
+    userKeys.map(async (key) => {
+      try {
+        const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
+        if (!user) return;
+        const changed = applyToUser(user, MODE_RIGHTS_FIELDS, (r) =>
+          removeSlugIfPartnerPresent(r, removeSlug, keepSlug)
+        );
+        if (changed) await env.AUTH_KV.put(key, JSON.stringify(user));
+      } catch (err) {
+        console.error(
+          `rights-migration: cleanup failed for ${key} (remove "${removeSlug}", keep "${keepSlug}") — stale entry remains`,
+          err
+        );
+      }
+    })
+  );
+}

--- a/worker/rights-migration.ts
+++ b/worker/rights-migration.ts
@@ -1,4 +1,5 @@
 import type { Env } from "./helpers";
+import { listKvKeys } from "./helpers";
 import type { LanguageRights, StoredUser } from "./types";
 
 // #240 — per-user rights migration for slug-changing mode ops.
@@ -61,7 +62,9 @@ export type RightsField = (typeof MODE_RIGHTS_FIELDS)[number];
 // modes `undefined` means no access (nothing to widen), and for the
 // legacy language field it means full access (same as wildcard).
 // Returns the new array, or null when no change is needed (from absent,
-// or to already present).
+// or to already present). Appends WITHOUT sorting: expand+compensate on
+// a failed rename must be write-neutral, and a sort would permanently
+// reorder arrays for an operation that did nothing (rd-3 review).
 export function expandRights(
   rights: LanguageRights | undefined,
   from: string,
@@ -70,7 +73,7 @@ export function expandRights(
   if (rights === undefined || rights === "*") return null;
   if (!rights.includes(from)) return null;
   if (rights.includes(to)) return null;
-  return [...rights, to].sort();
+  return [...rights, to];
 }
 
 // Remove `remove` — but ONLY when `keep` is present in the same array.
@@ -121,21 +124,6 @@ function applyToUser(
   return changed;
 }
 
-// Enumerate every `user:` key. AUTH_KV has no org index — same paginated
-// scan as worker/admin.ts listUsers. Fine at current org sizes; if user
-// counts ever approach the Workers subrequest cap, an org index is the
-// fix, not a smarter scan (flagged in #240's design notes).
-async function listUserKeys(env: Env): Promise<string[]> {
-  const keys: string[] = [];
-  let cursor: string | undefined;
-  do {
-    const list = await env.AUTH_KV.list({ prefix: "user:", cursor });
-    keys.push(...list.keys.map((k) => k.name));
-    cursor = list.list_complete ? undefined : list.cursor;
-  } while (cursor);
-  return keys;
-}
-
 // Phase 1: add `newSlug` alongside `oldSlug` for every affected user in
 // `org`. Each record is re-read immediately before its write (read →
 // transform → put per key), so a concurrent admin edit to the same user
@@ -158,7 +146,7 @@ export async function expandOrgModeRights(
   oldSlug: string,
   newSlug: string
 ): Promise<MigrationRecord[]> {
-  const keys = await listUserKeys(env);
+  const keys = await listKvKeys(env.AUTH_KV, "user:");
 
   const results = await Promise.allSettled(
     keys.map(async (key): Promise<MigrationRecord | null> => {
@@ -175,11 +163,18 @@ export async function expandOrgModeRights(
 
   const written: MigrationRecord[] = [];
   let failed = false;
-  for (const result of results) {
+  for (const [i, result] of results.entries()) {
     if (result.status === "fulfilled") {
       if (result.value) written.push(result.value);
     } else {
       failed = true;
+      // Name the key and reason — the only evidence an operator gets
+      // when diagnosing a production KV failure via cf-logs (rd-3
+      // review: this was the one failure branch with zero diagnostics).
+      console.error(
+        `rights-migration: expand failed for ${keys[i]} (org=${org}, ${oldSlug}→${newSlug})`,
+        result.reason
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Closes the gap that kept #232 open. Per-user `mode_edit_rights` / `mode_publish_rights` are slug-scoped arrays, and nothing in the authz path reads aliases — so renaming a mode stranded every shepherd holding the old slug. That's why the rename arm shipped admin-only in PR #238. This PR migrates those arrays around the engine rename and opens rename (worker arm + client button) to shepherds with **edit rights on the source mode**.

## Atomicity model: expand → engine op → contract

KV has no transactions and the engine is a remote call, so rather than claiming rollback atomicity, the migration holds one invariant at every intermediate point: **a user's rights always cover whichever slug is live.**

1. **Expand** — add the new slug to every affected user in the target org (old kept). Records exactly which users it modified.
2. **Engine** — `_rename` proxied; engine status/body pass through faithfully (409 collisions, 400 validation, promote-own-alias all remain the engine's calls).
3. **Contract** (2xx) — remove the old slug from the recorded set. **Compensate** (non-2xx) — remove the never-live new slug instead.

Failure analysis (why this ordering, versus the issue's two candidates):

| Ordering | Worst-case partial state | Effect |
|---|---|---|
| migrate → rename, rollback on failure | rollback fails → rights point ONLY at a slug that doesn't exist | **lockout** |
| rename → migrate | crash between steps → rights point ONLY at the old slug (now just an alias) | **lockout** |
| **expand → rename → contract** | cleanup fails → user holds live slug + one stale extra entry | inert (logged) |

The removal primitive refuses to remove a slug unless its partner is present in the same array, so contract/compensate can run against any drifted state without shrinking a user below the live slug. A user who legitimately held **both** slugs before the rename is outside the recorded set and never touched (pinned by test). A partial expand rolls itself back and aborts with 500 **before** the engine is called.

**Sessions need no handling:** `validateSession` re-hydrates rights from the live `user:` record on every request, so the KV rewrite propagates on each user's next request — including the renaming shepherd themself (acceptance criterion: they keep editing the renamed mode immediately).

## Architecture for the follow-ups

`worker/rights-migration.ts` keeps the pure helpers field-parameterized (`MODE_RIGHTS_FIELDS` / `LANGUAGE_RIGHTS_FIELDS`, the latter including the legacy `language_rights` bit), so the same primitives serve, without redesign:

- **retire-and-forward rights inheritance** (whether the retired mode's shepherds inherit the target is a product call — arm stays admin-gated here),
- **clone auto-grant** (cloner needs rights on the new slug or they self-lockout — also its own decision),
- **language rename** if it ever ships.

## Gate changes

- **Worker rename arm**: admin / cross-org / edit-on-source (direct check — `gateConfigMutation`'s POST branch was tried and reverted in #241 PR B). Publish-only shepherds stay 403 (rename is edit-side). Method check precedes the body read (non-POST still 405s); missing/malformed `newName` → 400 before any engine call or migration.
- **Client** (`modes.tsx`): `canRenameSelected = isAdmin || isCrossOrg || canEditSelected`. Clone/retire booleans unchanged.

## Test plan

- [x] `tests/rights-migration.test.ts` (new): pure-helper coverage (expand/remove idempotency, wildcard + undefined passthrough, the partner guard) + KV orchestration (recorded-set semantics, org filtering, vanished-record tolerance)
- [x] `tests/config-authz.test.ts`: flips the #238-review crux case (shepherd with rights → now 200); adds edit-only → 200, publish-only → 403, wrong-mode → 403, malformed body → 400, GET → 405; new migration side-effect block asserting stored KV records directly — success migrates both verb fields, engine failure compensates to the exact prior state, wildcard/unrelated/other-org users untouched, cross-org migrates the **target** org only
- [x] Suite 427 → 452; lint / typecheck / build / format clean
- [ ] Staging: as a non-admin shepherd with edit rights on one mode, rename it → keep editing it immediately; verify a second shepherd on the same mode also keeps access
- [ ] Staging: rename to a colliding slug → 409 surfaces in the dialog and rights are unchanged

Closes #240. Once merged and verified, #232 can close.