### PR TITLE
fix(#247): stop 403ing same-org ?org= param; surface rights-list load errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/admin-user-create-dialog.tsx
+++ b/src/components/admin-user-create-dialog.tsx
@@ -319,6 +319,7 @@ export function AdminUserCreateDialog({
               onChange={setLangEdit}
               availableItems={languagesQuery.data?.languages}
               loadError={languagesQuery.isError}
+              onRetry={() => void languagesQuery.refetch()}
             />
             <RightsSelector
               kind="language"
@@ -327,6 +328,7 @@ export function AdminUserCreateDialog({
               onChange={setLangPublish}
               availableItems={languagesQuery.data?.languages}
               loadError={languagesQuery.isError}
+              onRetry={() => void languagesQuery.refetch()}
             />
             <RightsSelector
               kind="mode"
@@ -335,6 +337,7 @@ export function AdminUserCreateDialog({
               onChange={setModeEdit}
               availableItems={modesQuery.data?.modes}
               loadError={modesQuery.isError}
+              onRetry={() => void modesQuery.refetch()}
             />
             <RightsSelector
               kind="mode"
@@ -343,6 +346,7 @@ export function AdminUserCreateDialog({
               onChange={setModePublish}
               availableItems={modesQuery.data?.modes}
               loadError={modesQuery.isError}
+              onRetry={() => void modesQuery.refetch()}
             />
 
             {errorText && (

--- a/src/components/admin-user-create-dialog.tsx
+++ b/src/components/admin-user-create-dialog.tsx
@@ -318,6 +318,7 @@ export function AdminUserCreateDialog({
               value={langEdit}
               onChange={setLangEdit}
               availableItems={languagesQuery.data?.languages}
+              loadError={languagesQuery.isError}
             />
             <RightsSelector
               kind="language"
@@ -325,6 +326,7 @@ export function AdminUserCreateDialog({
               value={langPublish}
               onChange={setLangPublish}
               availableItems={languagesQuery.data?.languages}
+              loadError={languagesQuery.isError}
             />
             <RightsSelector
               kind="mode"
@@ -332,6 +334,7 @@ export function AdminUserCreateDialog({
               value={modeEdit}
               onChange={setModeEdit}
               availableItems={modesQuery.data?.modes}
+              loadError={modesQuery.isError}
             />
             <RightsSelector
               kind="mode"
@@ -339,6 +342,7 @@ export function AdminUserCreateDialog({
               value={modePublish}
               onChange={setModePublish}
               availableItems={modesQuery.data?.modes}
+              loadError={modesQuery.isError}
             />
 
             {errorText && (

--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -359,6 +359,7 @@ export function AdminUserEditDialog({
               onChange={setLangEdit}
               availableItems={languagesQuery.data?.languages}
               loadError={languagesQuery.isError}
+              onRetry={() => void languagesQuery.refetch()}
               showLegacyHint={showLegacyLang}
             />
             <RightsSelector
@@ -368,6 +369,7 @@ export function AdminUserEditDialog({
               onChange={setLangPublish}
               availableItems={languagesQuery.data?.languages}
               loadError={languagesQuery.isError}
+              onRetry={() => void languagesQuery.refetch()}
               showLegacyHint={showLegacyLang}
             />
             <RightsSelector
@@ -377,6 +379,7 @@ export function AdminUserEditDialog({
               onChange={setModeEdit}
               availableItems={modesQuery.data?.modes}
               loadError={modesQuery.isError}
+              onRetry={() => void modesQuery.refetch()}
             />
             <RightsSelector
               kind="mode"
@@ -385,6 +388,7 @@ export function AdminUserEditDialog({
               onChange={setModePublish}
               availableItems={modesQuery.data?.modes}
               loadError={modesQuery.isError}
+              onRetry={() => void modesQuery.refetch()}
             />
 
             <div className="space-y-2">

--- a/src/components/admin-user-edit-dialog.tsx
+++ b/src/components/admin-user-edit-dialog.tsx
@@ -358,6 +358,7 @@ export function AdminUserEditDialog({
               value={langEdit}
               onChange={setLangEdit}
               availableItems={languagesQuery.data?.languages}
+              loadError={languagesQuery.isError}
               showLegacyHint={showLegacyLang}
             />
             <RightsSelector
@@ -366,6 +367,7 @@ export function AdminUserEditDialog({
               value={langPublish}
               onChange={setLangPublish}
               availableItems={languagesQuery.data?.languages}
+              loadError={languagesQuery.isError}
               showLegacyHint={showLegacyLang}
             />
             <RightsSelector
@@ -374,6 +376,7 @@ export function AdminUserEditDialog({
               value={modeEdit}
               onChange={setModeEdit}
               availableItems={modesQuery.data?.modes}
+              loadError={modesQuery.isError}
             />
             <RightsSelector
               kind="mode"
@@ -381,6 +384,7 @@ export function AdminUserEditDialog({
               value={modePublish}
               onChange={setModePublish}
               availableItems={modesQuery.data?.modes}
+              loadError={modesQuery.isError}
             />
 
             <div className="space-y-2">

--- a/src/components/rights-selector.tsx
+++ b/src/components/rights-selector.tsx
@@ -29,6 +29,12 @@ interface RightsSelectorProps {
   // undefined) and would show "Loading…" forever on a dead query —
   // exactly how the #247 BFF 403 hid itself on staging.
   loadError?: boolean;
+  // Refetches the failed list. The dialogs stay mounted across
+  // open/close (admin-users.tsx renders them unconditionally), so an
+  // errored query never refetches on reopen — a button wired to
+  // query.refetch() is the only real recovery short of a window
+  // refocus.
+  onRetry?: () => void;
   kind: RightsKind;
   verb: RightsVerb;
   disabled?: boolean;
@@ -80,6 +86,7 @@ export function RightsSelector({
   onChange,
   availableItems,
   loadError = false,
+  onRetry,
   kind,
   verb,
   disabled = false,
@@ -87,6 +94,13 @@ export function RightsSelector({
 }: RightsSelectorProps) {
   const isFull = value === "*";
   const isLegacy = value === undefined;
+  // Legacy language rights convert to "Specific" by seeding the full
+  // item list (see the onChange below). With the list unavailable
+  // (loading or errored) that seed would be [], silently collapsing the
+  // user's legacy full access to an explicit no-access grant — so the
+  // Specific option is unclickable until the list actually loads.
+  const specificNeedsItems =
+    isLegacy && kind === "language" && availableItems === undefined;
   const selected = useMemo<Set<string>>(
     () => (Array.isArray(value) ? new Set(value) : new Set()),
     [value]
@@ -133,12 +147,23 @@ export function RightsSelector({
           </div>
         </label>
 
-        <label className="hover:bg-accent flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors">
+        <label
+          className={cn(
+            "flex items-start gap-3 rounded-md border p-3 transition-colors",
+            specificNeedsItems
+              ? "cursor-not-allowed opacity-60"
+              : "hover:bg-accent cursor-pointer"
+          )}
+        >
           <input
             type="radio"
             name={radioName}
+            disabled={specificNeedsItems}
             checked={!isFull && !isLegacy}
             onChange={() => {
+              // Hard guard behind the disabled attribute: never seed
+              // from an absent list.
+              if (specificNeedsItems) return;
               if (isLegacy && kind === "language") {
                 // Legacy languages = back-compat full access. Pre-
                 // populate the explicit list with every available
@@ -167,47 +192,64 @@ export function RightsSelector({
               </div>
             </div>
 
-            {!isFull && !isLegacy && (
-              <div className="flex flex-wrap gap-1.5">
-                {loadError && availableItems === undefined ? (
-                  <span className="text-destructive text-xs">
-                    Couldn't load {kind}s. Close the dialog and try again.
-                  </span>
-                ) : availableItems === undefined ? (
-                  <span className="text-muted-foreground text-xs">
-                    Loading {kind}s…
-                  </span>
-                ) : availableItems.length === 0 ? (
-                  <span className="text-muted-foreground text-xs">
-                    No {kind}s defined yet.
-                  </span>
-                ) : (
-                  availableItems.map((item) => {
-                    const checked = selected.has(item.name);
-                    return (
-                      <button
-                        key={item.name}
-                        type="button"
-                        onClick={() => toggleItem(item.name)}
-                        className={cn(
-                          "rounded-full border px-2.5 py-1 text-xs transition-colors",
-                          checked
-                            ? "bg-primary text-primary-foreground border-primary"
-                            : "bg-background hover:bg-accent"
-                        )}
-                      >
-                        {checked && (
-                          <span className="mr-1" aria-hidden="true">
-                            ✓
-                          </span>
-                        )}
-                        {item.label || item.name}
-                      </button>
-                    );
-                  })
+            {/* The error line renders regardless of which option is
+                selected — it also explains why the Specific radio is
+                disabled for legacy-language users while the list is
+                unavailable. */}
+            {loadError && availableItems === undefined && (
+              <span className="text-destructive text-xs">
+                Couldn't load {kind}s.
+                {onRetry && (
+                  <button
+                    type="button"
+                    onClick={onRetry}
+                    className="ml-1.5 underline underline-offset-2"
+                  >
+                    Retry
+                  </button>
                 )}
-              </div>
+              </span>
             )}
+
+            {!isFull &&
+              !isLegacy &&
+              !(loadError && availableItems === undefined) && (
+                <div className="flex flex-wrap gap-1.5">
+                  {availableItems === undefined ? (
+                    <span className="text-muted-foreground text-xs">
+                      Loading {kind}s…
+                    </span>
+                  ) : availableItems.length === 0 ? (
+                    <span className="text-muted-foreground text-xs">
+                      No {kind}s defined yet.
+                    </span>
+                  ) : (
+                    availableItems.map((item) => {
+                      const checked = selected.has(item.name);
+                      return (
+                        <button
+                          key={item.name}
+                          type="button"
+                          onClick={() => toggleItem(item.name)}
+                          className={cn(
+                            "rounded-full border px-2.5 py-1 text-xs transition-colors",
+                            checked
+                              ? "bg-primary text-primary-foreground border-primary"
+                              : "bg-background hover:bg-accent"
+                          )}
+                        >
+                          {checked && (
+                            <span className="mr-1" aria-hidden="true">
+                              ✓
+                            </span>
+                          )}
+                          {item.label || item.name}
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              )}
           </div>
         </label>
       </fieldset>

--- a/src/components/rights-selector.tsx
+++ b/src/components/rights-selector.tsx
@@ -24,6 +24,11 @@ interface RightsSelectorProps {
   value: LanguageRights | undefined;
   onChange: (next: LanguageRights) => void;
   availableItems: { name: string; label?: string }[] | undefined;
+  // True when the list fetch failed. Without this the selector can't
+  // tell "still loading" from "errored" (both leave availableItems
+  // undefined) and would show "Loading…" forever on a dead query —
+  // exactly how the #247 BFF 403 hid itself on staging.
+  loadError?: boolean;
   kind: RightsKind;
   verb: RightsVerb;
   disabled?: boolean;
@@ -74,6 +79,7 @@ export function RightsSelector({
   value,
   onChange,
   availableItems,
+  loadError = false,
   kind,
   verb,
   disabled = false,
@@ -163,7 +169,11 @@ export function RightsSelector({
 
             {!isFull && !isLegacy && (
               <div className="flex flex-wrap gap-1.5">
-                {availableItems === undefined ? (
+                {loadError && availableItems === undefined ? (
+                  <span className="text-destructive text-xs">
+                    Couldn't load {kind}s. Close the dialog and try again.
+                  </span>
+                ) : availableItems === undefined ? (
                   <span className="text-muted-foreground text-xs">
                     Loading {kind}s…
                   </span>

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -2481,17 +2481,17 @@ describe("config authz — same-org ?org= (#247)", () => {
     );
   });
 
-  it("?org= matches case-insensitively and resolves to session.org's casing", async () => {
-    // Org values are free-text at creation ("Test Organization one"), so
-    // the client and the session can disagree on case. The upstream KV
-    // key is case-sensitive — resolve to the session's canonical casing,
-    // never the param's.
+  it("?org= with spaces matches exactly against session.org (real-world org shape)", async () => {
+    // Org values are free-text at creation ("Test Organization one") and
+    // the portal only ever sends values read back from stored records, so
+    // the same-org path always compares byte-identical strings — spaces
+    // and casing included.
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRequestWithQuery(
         "GET",
         "/api/config/languages",
-        `org=${encodeURIComponent("Test ORGANIZATION one")}`
+        `org=${encodeURIComponent("Test Organization one")}`
       ),
       env,
       makeSession({
@@ -2506,6 +2506,24 @@ describe("config authz — same-org ?org= (#247)", () => {
     expect(String(fetchSpy.mock.calls[0]![0])).toContain(
       `/api/v1/admin/orgs/${encodeURIComponent("Test Organization one")}/languages`
     );
+  });
+
+  it("non-super ?org=<case-variant of own org> → 403 (case-variants are NOT same-org)", async () => {
+    // KV keys are case-sensitive, so "ACME" is a distinct org from
+    // "acme" — matching it as same-org would silently retarget the
+    // request to the caller's home KV entry. Org identity stays an
+    // exact compare everywhere in the worker (admin.ts does the same);
+    // a case-variant from a non-super caller is a loud 403, like any
+    // other org.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/languages", "org=ACME"),
+      env,
+      makeSession({ org: "acme", isAdmin: true, isSuperAdmin: false }),
+      "/api/config/languages"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("org admin PUT modes/{name} with ?org=<own org> → same-org authz applies (admin passes)", async () => {
@@ -2548,8 +2566,6 @@ describe("config authz — same-org ?org= (#247)", () => {
   });
 
   it("non-super with ?org=<different case of OTHER org> → still 403", async () => {
-    // Case-insensitive matching must only widen the SAME-org path, not
-    // soften the cross-org reject.
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRequestWithQuery("GET", "/api/config/languages", "org=OTHER"),
@@ -2561,25 +2577,22 @@ describe("config authz — same-org ?org= (#247)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("super-admin ?org=<own org, different case> → treated as same-org (rights enforced)", async () => {
-    // Pre-#247 this compared exactly, so a case-differing self-reference
-    // slipped through as crossOrg and BYPASSED the caller's own
-    // language_rights (the Frank #185 hole, case-variant edition).
+  it("super-admin ?org=<case-variant of own org> → cross-org to the case-variant org (distinct KV entry stays addressable)", async () => {
+    // "ACME" and "acme" are distinct KV entries. A super-admin naming
+    // the case-variant must reach THAT org — resolving it as same-org
+    // would silently read/write the home org's config while the caller
+    // believes they're operating on the other one. This mirrors the
+    // pre-#247 exact-compare behavior.
     const fetchSpy = spyFetch();
-    const res = await handleConfig(
-      makeRequestWithQuery("PUT", "/api/config/languages/english", "org=ACME", {
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ document: "# English\n" }),
-      }),
+    await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/languages", "org=ACME"),
       env,
-      makeSession({
-        org: "acme",
-        isSuperAdmin: true,
-        language_rights: ["spanish"],
-      }),
-      "/api/config/languages/english"
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/languages"
     );
-    expect(res.status).toBe(403);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/ACME/languages"
+    );
   });
 });

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -2437,3 +2437,149 @@ describe("config authz — cross-org via ?org= (#166)", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Same-org ?org= for every caller (#247)
+// ---------------------------------------------------------------------------
+//
+// The user dialogs scope their language/mode list fetches to the target
+// user's org, which for org admins is always their own org — so the param
+// arrives on every request from those surfaces. Rejecting it with the
+// #166 super-admin gate broke the rights selectors (and the #248
+// empty-drafts CTA) for every non-super-admin: the fetch 403'd, the query
+// errored, and the selector sat on "Loading…" forever (Elsy's staging
+// re-test). `?org=<own org>` must resolve exactly like an absent param.
+
+describe("config authz — same-org ?org= (#247)", () => {
+  it("org admin GET languages with ?org=<own org> → proxies (no 403)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/languages", "org=acme"),
+      env,
+      makeSession({ org: "acme", isAdmin: true, isSuperAdmin: false }),
+      "/api/config/languages"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/languages"
+    );
+  });
+
+  it("plain user GET modes with ?org=<own org> → proxies (read is open)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/modes", "org=acme"),
+      env,
+      makeSession({ org: "acme", isAdmin: false, isSuperAdmin: false }),
+      "/api/config/modes"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/modes"
+    );
+  });
+
+  it("?org= matches case-insensitively and resolves to session.org's casing", async () => {
+    // Org values are free-text at creation ("Test Organization one"), so
+    // the client and the session can disagree on case. The upstream KV
+    // key is case-sensitive — resolve to the session's canonical casing,
+    // never the param's.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery(
+        "GET",
+        "/api/config/languages",
+        `org=${encodeURIComponent("Test ORGANIZATION one")}`
+      ),
+      env,
+      makeSession({
+        org: "Test Organization one",
+        isAdmin: true,
+        isSuperAdmin: false,
+      }),
+      "/api/config/languages"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      `/api/v1/admin/orgs/${encodeURIComponent("Test Organization one")}/languages`
+    );
+  });
+
+  it("org admin PUT modes/{name} with ?org=<own org> → same-org authz applies (admin passes)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("PUT", "/api/config/modes/spoken", "org=acme", {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## Identity\n" }),
+      }),
+      env,
+      makeSession({ org: "acme", isAdmin: true, isSuperAdmin: false }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/modes/spoken"
+    );
+  });
+
+  it("non-super with ?org=<own org> + restricted language_rights → 403 (same-org gate not bypassed)", async () => {
+    // The param must not grant anything the bare same-org path wouldn't:
+    // crossOrg stays false, so per-row language_rights are enforced.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("PUT", "/api/config/languages/english", "org=acme", {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# English\n" }),
+      }),
+      env,
+      makeSession({
+        org: "acme",
+        isAdmin: false,
+        isSuperAdmin: false,
+        language_rights: ["spanish"],
+      }),
+      "/api/config/languages/english"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-super with ?org=<different case of OTHER org> → still 403", async () => {
+    // Case-insensitive matching must only widen the SAME-org path, not
+    // soften the cross-org reject.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/languages", "org=OTHER"),
+      env,
+      makeSession({ org: "acme", isAdmin: true, isSuperAdmin: false }),
+      "/api/config/languages"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("super-admin ?org=<own org, different case> → treated as same-org (rights enforced)", async () => {
+    // Pre-#247 this compared exactly, so a case-differing self-reference
+    // slipped through as crossOrg and BYPASSED the caller's own
+    // language_rights (the Frank #185 hole, case-variant edition).
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("PUT", "/api/config/languages/english", "org=ACME", {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# English\n" }),
+      }),
+      env,
+      makeSession({
+        org: "acme",
+        isSuperAdmin: true,
+        language_rights: ["spanish"],
+      }),
+      "/api/config/languages/english"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -408,14 +408,19 @@ function isAdminMutation(method: string, session: SessionData): boolean {
 // dialogs always scope their language/mode list fetches to the target
 // user's org, which for org admins is their own org — rejecting it
 // broke those fetches with a 403 for every non-super-admin). The match
-// is trim+lowercase, mirroring `isCrossOrgTarget` in
-// src/lib/language-bootstrap-gate.ts, and resolves to `session.org`'s
-// canonical casing so the upstream KV key never depends on how the
-// client spelled the param.
+// is EXACT (post-trim), deliberately: org identity must mean one thing
+// inside the worker, and worker/admin.ts compares orgs exactly. The
+// portal only ever sends org values read back from stored records
+// (session.org, user.org), so the strings are byte-identical on every
+// legitimate same-org path; a case-variant is either a genuinely
+// distinct org (KV keys are case-sensitive) or a probe, and both must
+// stay loud/cross-org rather than silently retarget to session.org.
+// (src/lib/language-bootstrap-gate.ts lowercases for CTA *wording* on
+// free-text input — a display decision, not an authz one.)
 //
-// A genuinely different org stays super-admin only, and rejects loud
-// rather than silently falling back to session.org so a UI bug or
-// hostile probe surfaces visibly instead of masquerading as a same-org
+// A different org stays super-admin only, and rejects loud rather
+// than silently falling back to session.org so a UI bug or hostile
+// probe surfaces visibly instead of masquerading as a same-org
 // request.
 //
 // `crossOrg` reflects whether the resolved target differs from the
@@ -439,7 +444,7 @@ function resolveOrg(
     return { error: errorResponse("Invalid org parameter", 400) };
   }
 
-  if (trimmed.toLowerCase() === session.org.trim().toLowerCase()) {
+  if (trimmed === session.org) {
     return { crossOrg: false, org: session.org };
   }
 

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -401,9 +401,22 @@ function isAdminMutation(method: string, session: SessionData): boolean {
   return (method === "PUT" || method === "DELETE") && !hasAdminPowers(session);
 }
 
-// Cross-org override via ?org=<slug>. Super-admin only; reject loud rather
-// than silently falling back to session.org so a UI bug or hostile probe
-// surfaces visibly instead of masquerading as a same-org request.
+// Org targeting via ?org=<slug>.
+//
+// `?org=<caller's own org>` is semantically a same-org request for ANY
+// caller, so it resolves like the param was absent (#247: the user
+// dialogs always scope their language/mode list fetches to the target
+// user's org, which for org admins is their own org — rejecting it
+// broke those fetches with a 403 for every non-super-admin). The match
+// is trim+lowercase, mirroring `isCrossOrgTarget` in
+// src/lib/language-bootstrap-gate.ts, and resolves to `session.org`'s
+// canonical casing so the upstream KV key never depends on how the
+// client spelled the param.
+//
+// A genuinely different org stays super-admin only, and rejects loud
+// rather than silently falling back to session.org so a UI bug or
+// hostile probe surfaces visibly instead of masquerading as a same-org
+// request.
 //
 // `crossOrg` reflects whether the resolved target differs from the
 // caller's home org — not merely whether the param was present. A super
@@ -426,6 +439,10 @@ function resolveOrg(
     return { error: errorResponse("Invalid org parameter", 400) };
   }
 
+  if (trimmed.toLowerCase() === session.org.trim().toLowerCase()) {
+    return { crossOrg: false, org: session.org };
+  }
+
   if (session.isSuperAdmin !== true) {
     return {
       error: errorResponse(
@@ -435,7 +452,7 @@ function resolveOrg(
     };
   }
 
-  return { crossOrg: trimmed !== session.org, org: trimmed };
+  return { crossOrg: true, org: trimmed };
 }
 
 export async function handleConfig(


### PR DESCRIPTION
## Summary

Root-cause fix for the **#247 reopen** (Elsy's staging re-test, 2026-07-02). Touches #247 but deliberately no `Closes` keyword — Elsy should re-verify on staging before the issue closes.

### The bug chain

1. The create/edit-user dialogs scope their language/mode list fetches to the **target user's org** (#181 review F8) — so `?org=` is appended to every request from those surfaces, including a plain org admin targeting **their own org**.
2. The BFF's `resolveOrg` (worker/config.ts) treated *any* `?org=` from a non-super-admin as a cross-org attempt → **403 "Cross-org config access requires isSuperAdmin"**.
3. The queries errored → the rights selectors sat on **"Loading languages…" forever** (the selector can't distinguish loading from errored — both leave `availableItems` undefined), and the #248 empty-drafts CTA (gated on a *successful* empty fetch) never rendered.

Elsy's screenshots show exactly this: "Loading languages…" stuck in the edit dialog for an org-admin session. This broke the language **and mode** rights selectors for **every non-super-admin**, not just empty orgs.

### The fix

- **`resolveOrg`**: `?org=` matching the caller's own org (trim + case-insensitive, mirroring `isCrossOrgTarget` in `src/lib/language-bootstrap-gate.ts`) now resolves exactly like an absent param — `crossOrg: false`, canonical `session.org` casing for the upstream KV key. Genuinely different orgs stay super-admin-only with the loud 403 (#166 behavior unchanged). Side effect: a super-admin's *case-variant* self-referential `?org=` is now correctly same-org, closing a case-variant edition of the rights-bypass hole Frank caught in #185.
- **`RightsSelector`**: new `loadError` prop renders a visible error line instead of an indefinite "Loading…" when the list query failed (the rd-5 F2 residual that masked this bug on staging). Wired from both dialogs for all four selectors.

### Upstream question answered (was pending with @IanLindsley)

I read bt-servant-worker's `GET /api/v1/admin/orgs/:org/languages` handler directly: a never-seen org **returns 200 `{ org, languages: [] }`** (KV miss coalesces via `?? { languages: [] }`). So success-empty is the correct CTA gate once the fetch actually goes through — no worker-side change needed.

### Tests

7 new cases in `tests/config-authz.test.ts`:
- org admin / plain user `?org=<own org>` → proxies (no 403)
- case-insensitive match resolves to session casing (KV key never depends on client spelling)
- `?org=<own org>` grants nothing the bare path wouldn't (language_rights still enforced)
- cross-org `?org=` from non-super still 403s, including case variants
- super-admin case-variant self-reference → same-org (rights enforced)

**482/482 passing.** Version 1.10.1 → 1.10.2 so the staging re-verify is unambiguous.

## Test plan

- [x] Full suite green locally (482 tests)
- [x] lint / typecheck / build clean
- [ ] CI green
- [ ] Elsy re-tests her #247 repro on staging (org admin in "Test Organization one" → selectors populate; empty org → CTA renders)