### PR TITLE
fix(#247): follow-up — legacy seed guard on empty list, slash-org same-org, Retry out of label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/rights-selector.tsx
+++ b/src/components/rights-selector.tsx
@@ -95,16 +95,19 @@ export function RightsSelector({
   const isFull = value === "*";
   const isLegacy = value === undefined;
   // Legacy language rights convert to "Specific" by seeding the full
-  // item list (see the onChange below). If that seed would be [] — the
-  // list is unavailable (loading/errored) OR genuinely empty — the
-  // click would silently collapse the user's legacy full access
-  // (which also covers every FUTURE language) to an explicit
-  // no-access grant, so the Specific option is unclickable until
-  // there's something real to seed from.
+  // item list (see the onChange below). While the list is UNAVAILABLE
+  // (loading or errored) that seed would be [] by accident, silently
+  // collapsing the user's legacy full access to an explicit no-access
+  // grant — so the Specific option is unclickable until the fetch
+  // settles. A loaded-EMPTY list is different: seeding [] is then the
+  // only truthful conversion and deliberately stays clickable — it's
+  // the admin's only way to revoke a legacy grant (which also covers
+  // every FUTURE language) before an org has content. The status line
+  // below the options spells out that consequence (#253 review: an
+  // earlier draft disabled the empty case too, making legacy access
+  // irrevocable in a zero-language org).
   const specificNeedsItems =
-    isLegacy &&
-    kind === "language" &&
-    (availableItems === undefined || availableItems.length === 0);
+    isLegacy && kind === "language" && availableItems === undefined;
   const selected = useMemo<Set<string>>(
     () => (Array.isArray(value) ? new Set(value) : new Set()),
     [value]
@@ -258,12 +261,20 @@ export function RightsSelector({
             )}
           </span>
         )}
-        {specificNeedsItems && availableItems !== undefined && (
+        {specificNeedsItems && !loadError && (
           <span className="text-muted-foreground block text-xs">
-            No {kind}s defined yet — create one before narrowing this user's
-            access.
+            Loading {kind}s…
           </span>
         )}
+        {isLegacy &&
+          kind === "language" &&
+          availableItems !== undefined &&
+          availableItems.length === 0 && (
+            <span className="text-muted-foreground block text-xs">
+              No {kind}s defined yet. Choosing "Specific {kind}s" locks in no
+              access — including {kind}s created later.
+            </span>
+          )}
       </fieldset>
 
       {Array.isArray(value) && value.length > 0 && (

--- a/src/components/rights-selector.tsx
+++ b/src/components/rights-selector.tsx
@@ -108,6 +108,13 @@ export function RightsSelector({
   // irrevocable in a zero-language org).
   const specificNeedsItems =
     isLegacy && kind === "language" && availableItems === undefined;
+  // Shared by the chip-area suppression and the sibling error line so
+  // the two can't drift (they must flip together — showing the error
+  // AND the stale "Loading…" chip area reads as two states at once).
+  const listUnavailable = loadError && availableItems === undefined;
+  const listLoaded = availableItems !== undefined;
+  const loadingLabel = `Loading ${kind}s…`;
+  const emptyLabel = `No ${kind}s defined yet.`;
   const selected = useMemo<Set<string>>(
     () => (Array.isArray(value) ? new Set(value) : new Set()),
     [value]
@@ -199,45 +206,43 @@ export function RightsSelector({
               </div>
             </div>
 
-            {!isFull &&
-              !isLegacy &&
-              !(loadError && availableItems === undefined) && (
-                <div className="flex flex-wrap gap-1.5">
-                  {availableItems === undefined ? (
-                    <span className="text-muted-foreground text-xs">
-                      Loading {kind}s…
-                    </span>
-                  ) : availableItems.length === 0 ? (
-                    <span className="text-muted-foreground text-xs">
-                      No {kind}s defined yet.
-                    </span>
-                  ) : (
-                    availableItems.map((item) => {
-                      const checked = selected.has(item.name);
-                      return (
-                        <button
-                          key={item.name}
-                          type="button"
-                          onClick={() => toggleItem(item.name)}
-                          className={cn(
-                            "rounded-full border px-2.5 py-1 text-xs transition-colors",
-                            checked
-                              ? "bg-primary text-primary-foreground border-primary"
-                              : "bg-background hover:bg-accent"
-                          )}
-                        >
-                          {checked && (
-                            <span className="mr-1" aria-hidden="true">
-                              ✓
-                            </span>
-                          )}
-                          {item.label || item.name}
-                        </button>
-                      );
-                    })
-                  )}
-                </div>
-              )}
+            {!isFull && !isLegacy && !listUnavailable && (
+              <div className="flex flex-wrap gap-1.5">
+                {availableItems === undefined ? (
+                  <span className="text-muted-foreground text-xs">
+                    {loadingLabel}
+                  </span>
+                ) : availableItems.length === 0 ? (
+                  <span className="text-muted-foreground text-xs">
+                    {emptyLabel}
+                  </span>
+                ) : (
+                  availableItems.map((item) => {
+                    const checked = selected.has(item.name);
+                    return (
+                      <button
+                        key={item.name}
+                        type="button"
+                        onClick={() => toggleItem(item.name)}
+                        className={cn(
+                          "rounded-full border px-2.5 py-1 text-xs transition-colors",
+                          checked
+                            ? "bg-primary text-primary-foreground border-primary"
+                            : "bg-background hover:bg-accent"
+                        )}
+                      >
+                        {checked && (
+                          <span className="mr-1" aria-hidden="true">
+                            ✓
+                          </span>
+                        )}
+                        {item.label || item.name}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            )}
           </div>
         </label>
 
@@ -247,7 +252,7 @@ export function RightsSelector({
             relying on when a forwarded click would rewrite the rights
             value. Rendered in every radio state, these also explain the
             disabled Specific option for legacy-language users. */}
-        {loadError && availableItems === undefined && (
+        {listUnavailable && (
           <span className="text-destructive block text-xs">
             Couldn't load {kind}s.
             {onRetry && (
@@ -263,16 +268,16 @@ export function RightsSelector({
         )}
         {specificNeedsItems && !loadError && (
           <span className="text-muted-foreground block text-xs">
-            Loading {kind}s…
+            {loadingLabel}
           </span>
         )}
         {isLegacy &&
           kind === "language" &&
-          availableItems !== undefined &&
+          listLoaded &&
           availableItems.length === 0 && (
             <span className="text-muted-foreground block text-xs">
-              No {kind}s defined yet. Choosing "Specific {kind}s" locks in no
-              access — including {kind}s created later.
+              {emptyLabel} Choosing "Specific {kind}s" locks in no access —
+              including {kind}s created later.
             </span>
           )}
       </fieldset>

--- a/src/components/rights-selector.tsx
+++ b/src/components/rights-selector.tsx
@@ -95,12 +95,16 @@ export function RightsSelector({
   const isFull = value === "*";
   const isLegacy = value === undefined;
   // Legacy language rights convert to "Specific" by seeding the full
-  // item list (see the onChange below). With the list unavailable
-  // (loading or errored) that seed would be [], silently collapsing the
-  // user's legacy full access to an explicit no-access grant — so the
-  // Specific option is unclickable until the list actually loads.
+  // item list (see the onChange below). If that seed would be [] — the
+  // list is unavailable (loading/errored) OR genuinely empty — the
+  // click would silently collapse the user's legacy full access
+  // (which also covers every FUTURE language) to an explicit
+  // no-access grant, so the Specific option is unclickable until
+  // there's something real to seed from.
   const specificNeedsItems =
-    isLegacy && kind === "language" && availableItems === undefined;
+    isLegacy &&
+    kind === "language" &&
+    (availableItems === undefined || availableItems.length === 0);
   const selected = useMemo<Set<string>>(
     () => (Array.isArray(value) ? new Set(value) : new Set()),
     [value]
@@ -192,25 +196,6 @@ export function RightsSelector({
               </div>
             </div>
 
-            {/* The error line renders regardless of which option is
-                selected — it also explains why the Specific radio is
-                disabled for legacy-language users while the list is
-                unavailable. */}
-            {loadError && availableItems === undefined && (
-              <span className="text-destructive text-xs">
-                Couldn't load {kind}s.
-                {onRetry && (
-                  <button
-                    type="button"
-                    onClick={onRetry}
-                    className="ml-1.5 underline underline-offset-2"
-                  >
-                    Retry
-                  </button>
-                )}
-              </span>
-            )}
-
             {!isFull &&
               !isLegacy &&
               !(loadError && availableItems === undefined) && (
@@ -252,6 +237,33 @@ export function RightsSelector({
               )}
           </div>
         </label>
+
+        {/* Status lines live OUTSIDE the radio's <label>: an interactive
+            Retry button inside it would depend on label activation not
+            forwarding to the radio — spec-compliant, but not worth
+            relying on when a forwarded click would rewrite the rights
+            value. Rendered in every radio state, these also explain the
+            disabled Specific option for legacy-language users. */}
+        {loadError && availableItems === undefined && (
+          <span className="text-destructive block text-xs">
+            Couldn't load {kind}s.
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="ml-1.5 underline underline-offset-2"
+              >
+                Retry
+              </button>
+            )}
+          </span>
+        )}
+        {specificNeedsItems && availableItems !== undefined && (
+          <span className="text-muted-foreground block text-xs">
+            No {kind}s defined yet — create one before narrowing this user's
+            access.
+          </span>
+        )}
       </fieldset>
 
       {Array.isArray(value) && value.length > 0 && (

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -1568,6 +1568,38 @@ describe("admin users — path-shaped org names (#253)", () => {
     expect((body as { user: { org: string } }).user.org).toBe("team/alpha");
   });
 
+  it("create with non-string org (number) → 400, not an uncaught TypeError 500", async () => {
+    const { status } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: {
+        email: "new@acme.com",
+        password: "Str0ng-Passw0rd!",
+        name: "New",
+        org: 123,
+      },
+    });
+    expect(status).toBe(400);
+  });
+
+  it("update with non-string org/name → 400, not an uncaught TypeError 500", async () => {
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    for (const body of [{ org: 123 }, { name: ["x"] }]) {
+      const { status } = await call({
+        method: "PUT",
+        pathname: `/api/admin/users/${bob.email}`,
+        headers: { "X-Admin-Secret": ADMIN_SECRET },
+        body,
+      });
+      expect(status).toBe(400);
+    }
+  });
+
   it("pre-existing slash-org user can still be updated (guard is create/move only)", async () => {
     // Directly seeded with a slash org — simulates a value stored before
     // this guard existed. Renaming (org untouched) must still work.

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -1498,3 +1498,68 @@ describe("verb-perms — parseRights validation errors", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Path-shaped org names rejected at create/move (#253 review)
+// ---------------------------------------------------------------------------
+//
+// session.org is interpolated into upstream URLs across the worker
+// (chat.ts/baruch.ts raw; config.ts encoded, where bare dot segments
+// still survive encoding and URL-normalize into traversal). Rejecting
+// the shapes at the door keeps them out of every downstream builder;
+// values stored before this guard are handled at the consumers.
+
+describe("admin users — path-shaped org names (#253)", () => {
+  it.each(["team/alpha", ".", ".."])(
+    "create user with org %j → 400",
+    async (badOrg) => {
+      const { status } = await call({
+        method: "POST",
+        pathname: "/api/admin/users",
+        headers: { "X-Admin-Secret": ADMIN_SECRET },
+        body: {
+          email: "new@acme.com",
+          password: "Str0ng-Passw0rd!",
+          name: "New",
+          org: badOrg,
+        },
+      });
+      expect(status).toBe(400);
+    }
+  );
+
+  it.each(["a/b", ".", ".."])("move user to org %j → 400", async (badOrg) => {
+    const bob = await seedUser({
+      email: "bob@acme.com",
+      name: "Bob",
+      org: "acme",
+    });
+    const { status } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${bob.email}`,
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: { org: badOrg },
+    });
+    expect(status).toBe(400);
+  });
+
+  it("pre-existing slash-org user can still be updated (guard is create/move only)", async () => {
+    // Directly seeded with a slash org — simulates a value stored before
+    // this guard existed. Renaming (org untouched) must still work.
+    const legacy = await seedUser({
+      email: "legacy@slash.org",
+      name: "Legacy",
+      org: "team/alpha",
+    });
+    const { status, body } = await call({
+      method: "PUT",
+      pathname: `/api/admin/users/${legacy.email}`,
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: { name: "Legacy Renamed" },
+    });
+    expect(status).toBe(200);
+    expect((body as { user: { name: string } }).user.name).toBe(
+      "Legacy Renamed"
+    );
+  });
+});

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -1510,25 +1510,22 @@ describe("verb-perms — parseRights validation errors", () => {
 // values stored before this guard are handled at the consumers.
 
 describe("admin users — path-shaped org names (#253)", () => {
-  it.each(["team/alpha", ".", ".."])(
-    "create user with org %j → 400",
-    async (badOrg) => {
-      const { status } = await call({
-        method: "POST",
-        pathname: "/api/admin/users",
-        headers: { "X-Admin-Secret": ADMIN_SECRET },
-        body: {
-          email: "new@acme.com",
-          password: "Str0ng-Passw0rd!",
-          name: "New",
-          org: badOrg,
-        },
-      });
-      expect(status).toBe(400);
-    }
-  );
+  it.each([".", ".."])("create user with org %j → 400", async (badOrg) => {
+    const { status } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Admin-Secret": ADMIN_SECRET },
+      body: {
+        email: "new@acme.com",
+        password: "Str0ng-Passw0rd!",
+        name: "New",
+        org: badOrg,
+      },
+    });
+    expect(status).toBe(400);
+  });
 
-  it.each(["a/b", ".", ".."])("move user to org %j → 400", async (badOrg) => {
+  it.each([".", ".."])("move user to org %j → 400", async (badOrg) => {
     const bob = await seedUser({
       email: "bob@acme.com",
       name: "Bob",
@@ -1541,6 +1538,34 @@ describe("admin users — path-shaped org names (#253)", () => {
       body: { org: badOrg },
     });
     expect(status).toBe(400);
+  });
+
+  it("org admin of an existing slash-named org can create users in it (#253 review P2)", async () => {
+    // Slash is NOT rejected: every upstream URL builder encodes the org,
+    // and rejecting the shape before the own-org equality check stranded
+    // existing slash tenants' membership management entirely.
+    const admin = await seedUser({
+      email: "admin@slash.org",
+      name: "Slash Admin",
+      org: "team/alpha",
+      isAdmin: true,
+    });
+    const session = await seedSession(admin);
+
+    const { status, body } = await call({
+      method: "POST",
+      pathname: "/api/admin/users",
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      sessionId: session,
+      body: {
+        email: "new@slash.org",
+        password: "Str0ng-Passw0rd!",
+        name: "New Member",
+        org: "team/alpha",
+      },
+    });
+    expect(status).toBe(201);
+    expect((body as { user: { org: string } }).user.org).toBe("team/alpha");
   });
 
   it("pre-existing slash-org user can still be updated (guard is create/move only)", async () => {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { handleMe } from "../worker/auth";
+import { handleLogin, handleMe } from "../worker/auth";
 import { generateSalt, hashPassword } from "../worker/crypto";
 import type { LanguageRights, SessionData, StoredUser } from "../worker/types";
 
@@ -263,6 +263,33 @@ describe("validateSession — dot-segment org fails closed (#253)", () => {
         env
       );
       expect(res.status).toBe(401);
+    }
+  );
+});
+
+describe("handleLogin — dot-segment org fails closed (#253)", () => {
+  it.each([".", ".."])(
+    "correct credentials against org %j → 403 with a real message, no session minted",
+    async (dotOrg) => {
+      // Without the login-side mirror of validateSession's guard, login
+      // 200s and every later request 401s — an unexplained loop that
+      // also orphans a session record per attempt.
+      await seedUser({ email: "dot@acme.com", name: "Dot", org: dotOrg });
+
+      const res = await handleLogin(
+        new Request("https://portal.example.test/api/auth/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: "dot@acme.com",
+            password: "test-password",
+          }),
+        }),
+        env
+      );
+      expect(res.status).toBe(403);
+      const sessions = await env.AUTH_KV.list({ prefix: "session:" });
+      expect(sessions.keys).toHaveLength(0);
     }
   );
 });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -233,3 +233,36 @@ describe("validateSession lazy-mapping (#181) — via handleMe", () => {
     expect(me.mode_publish_rights).toBe("*");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Dot-segment org names fail closed at session validation (#253 review P1)
+// ---------------------------------------------------------------------------
+//
+// admin.ts rejects "." / ".." at user create/move, but a stored value
+// predating that guard hydrates into session.org and reaches upstream
+// URL builders where dots survive encodeURIComponent and /orgs/../x
+// normalizes past the org scope. validateSession is the single choke
+// point every authenticated request crosses.
+
+describe("validateSession — dot-segment org fails closed (#253)", () => {
+  it.each([".", ".."])(
+    "user stored with org %j → session invalid (401 from /api/me)",
+    async (dotOrg) => {
+      const user = await seedUser({
+        email: "dot@acme.com",
+        name: "Dot",
+        org: dotOrg,
+      });
+      const session = await seedLegacySession(user);
+
+      const res = await handleMe(
+        new Request("https://portal.example.test/api/me", {
+          method: "GET",
+          headers: { Cookie: `session=${session}` },
+        }),
+        env
+      );
+      expect(res.status).toBe(401);
+    }
+  );
+});

--- a/tests/chat-user-override.test.ts
+++ b/tests/chat-user-override.test.ts
@@ -157,8 +157,7 @@ describe("chat user_id override — real-user IDOR guard (#253)", () => {
 
   it("KV error during the scan → 503 fail-closed, engine untouched, error logged", async () => {
     // The guard must not fail OPEN: an induced storage error would
-    // otherwise bypass the IDOR check entirely. Fresh UUID so the
-    // per-isolate synthetic-id memo can't short-circuit past the scan.
+    // otherwise bypass the IDOR check entirely.
     const fetchSpy = spyFetch();
     vi.spyOn(env.AUTH_KV, "list").mockRejectedValue(new Error("kv blip"));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/tests/chat-user-override.test.ts
+++ b/tests/chat-user-override.test.ts
@@ -92,6 +92,24 @@ describe("chat user_id override — real-user IDOR guard (#253)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("UPPERCASED victim UUID → still 403 (guard compares case-insensitively)", async () => {
+    // UUID_V4_RE accepts uppercase hex; stored ids are lowercase. A
+    // case-sensitive compare would let an uppercased copy of the
+    // victim's id slip past the scan (#253 review round 6).
+    const victim = await seedStoredUser("victim@acme.com");
+    const fetchSpy = spyFetch();
+    const res = await handleDeleteHistory(
+      new Request(
+        `https://portal.example.test/api/chat/history?user_id=${victim.id.toUpperCase()}`,
+        { method: "DELETE" }
+      ),
+      env,
+      makeSession()
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("synthetic UUID override (matches no stored user) → proxies as before", async () => {
     await seedStoredUser("someone@acme.com");
     const synthetic = crypto.randomUUID();

--- a/tests/chat-user-override.test.ts
+++ b/tests/chat-user-override.test.ts
@@ -155,6 +155,44 @@ describe("chat user_id override — real-user IDOR guard (#253)", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("KV error during the scan → 503 fail-closed, engine untouched, error logged", async () => {
+    // The guard must not fail OPEN: an induced storage error would
+    // otherwise bypass the IDOR check entirely. Fresh UUID so the
+    // per-isolate synthetic-id memo can't short-circuit past the scan.
+    const fetchSpy = spyFetch();
+    vi.spyOn(env.AUTH_KV, "list").mockRejectedValue(new Error("kv blip"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await handleDeleteHistory(
+      new Request(
+        `https://portal.example.test/api/chat/history?user_id=${crypto.randomUUID()}`,
+        { method: "DELETE" }
+      ),
+      env,
+      makeSession()
+    );
+    expect(res.status).toBe(503);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("non-matching UPPERCASE override forwards VERBATIM (engine-side ids may be case-sensitive)", async () => {
+    await seedStoredUser("someone@acme.com");
+    const syntheticUpper = crypto.randomUUID().toUpperCase();
+    const fetchSpy = spyFetch();
+    const res = await handleHistory(
+      new Request(
+        `https://portal.example.test/api/chat/history?user_id=${syntheticUpper}`,
+        { method: "GET" }
+      ),
+      env,
+      makeSession()
+    );
+    expect(res.status).toBe(200);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      `/users/${syntheticUpper}/`
+    );
+  });
+
   it("no override → session.userId (unchanged default path)", async () => {
     const session = makeSession();
     const fetchSpy = spyFetch();

--- a/tests/chat-user-override.test.ts
+++ b/tests/chat-user-override.test.ts
@@ -1,0 +1,155 @@
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { handleDeleteHistory, handleHistory } from "../worker/chat";
+import type { SessionData, StoredUser } from "../worker/types";
+
+// The user_id override exists for the test-chat panel's synthetic UUIDs.
+// Portal user IDs are ALSO crypto.randomUUID(), so shape-validation alone
+// was an IDOR: any authenticated user could read or delete a colleague's
+// history/memory by passing their id (#253 review). The worker is the
+// only enforcement point under the trusted-portal model.
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(async () => {
+  let cursor: string | undefined;
+  do {
+    const list = await env.AUTH_KV.list({ cursor });
+    for (const key of list.keys) {
+      await env.AUTH_KV.delete(key.name);
+    }
+    cursor = list.list_complete ? undefined : list.cursor;
+  } while (cursor);
+});
+
+function makeSession(overrides: Partial<SessionData> = {}): SessionData {
+  return {
+    userId: crypto.randomUUID(),
+    email: "alice@acme.com",
+    name: "Alice",
+    org: "acme",
+    isAdmin: false,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+async function seedStoredUser(email: string): Promise<StoredUser> {
+  const stored: StoredUser = {
+    id: crypto.randomUUID(),
+    email,
+    name: "Someone",
+    org: "acme",
+    passwordHash: "x",
+    salt: "y",
+    isAdmin: false,
+  };
+  await env.AUTH_KV.put(`user:${email}`, JSON.stringify(stored));
+  return stored;
+}
+
+function spyFetch() {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ entries: [] }), { status: 200 })
+      )
+    );
+}
+
+describe("chat user_id override — real-user IDOR guard (#253)", () => {
+  it("DELETE history targeting another stored user's id → 403, engine untouched", async () => {
+    const victim = await seedStoredUser("victim@acme.com");
+    const fetchSpy = spyFetch();
+    const res = await handleDeleteHistory(
+      new Request(
+        `https://portal.example.test/api/chat/history?user_id=${victim.id}`,
+        { method: "DELETE" }
+      ),
+      env,
+      makeSession()
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("GET history targeting another stored user's id → 403 (reads are covered too)", async () => {
+    const victim = await seedStoredUser("victim@acme.com");
+    const fetchSpy = spyFetch();
+    const res = await handleHistory(
+      new Request(
+        `https://portal.example.test/api/chat/history?user_id=${victim.id}`,
+        { method: "GET" }
+      ),
+      env,
+      makeSession()
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("synthetic UUID override (matches no stored user) → proxies as before", async () => {
+    await seedStoredUser("someone@acme.com");
+    const synthetic = crypto.randomUUID();
+    const fetchSpy = spyFetch();
+    const res = await handleHistory(
+      new Request(
+        `https://portal.example.test/api/chat/history?user_id=${synthetic}`,
+        { method: "GET" }
+      ),
+      env,
+      makeSession()
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      `/users/${synthetic}/`
+    );
+  });
+
+  it("caller's OWN id as override → proxies (self-targeting is fine)", async () => {
+    const session = makeSession();
+    // The caller may also exist as a stored user — their own id must pass.
+    const self: StoredUser = {
+      id: session.userId,
+      email: session.email,
+      name: session.name,
+      org: session.org,
+      passwordHash: "x",
+      salt: "y",
+      isAdmin: false,
+    };
+    await env.AUTH_KV.put(`user:${session.email}`, JSON.stringify(self));
+    const fetchSpy = spyFetch();
+    const res = await handleHistory(
+      new Request(
+        `https://portal.example.test/api/chat/history?user_id=${session.userId}`,
+        { method: "GET" }
+      ),
+      env,
+      session
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("no override → session.userId (unchanged default path)", async () => {
+    const session = makeSession();
+    const fetchSpy = spyFetch();
+    const res = await handleHistory(
+      new Request("https://portal.example.test/api/chat/history", {
+        method: "GET",
+      }),
+      env,
+      session
+    );
+    expect(res.status).toBe(200);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      `/users/${session.userId}/`
+    );
+  });
+});

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -2462,6 +2462,69 @@ describe("config authz — cross-org via ?org= (#166)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Path-shaped orgs (#253 review)
+// ---------------------------------------------------------------------------
+//
+// Slash-named orgs must ride every engine-path builder ENCODED — the
+// verb-perms gate's current-state lookup included (a raw interpolation
+// reads /orgs/team/alpha/..., the engine 404s, and the gate collapses a
+// legitimate publish flip into creation semantics → 403). Dot-segment
+// orgs can't be neutralized by encoding at all and are rejected on the
+// RESOLVED org, session-default path included.
+
+describe("config authz — path-shaped orgs (#253 review)", () => {
+  it("publish-only shepherd PUT flip in a slash-named org → 200; gate lookup and proxy both hit the ENCODED org path", async () => {
+    const fetchSpy = spyFetchWithCurrent("language", {
+      document: "# same\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request(
+        `https://portal.example.test/api/config/languages/spanish?org=${encodeURIComponent("team/alpha")}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ document: "# same\n", published: true }),
+        }
+      ),
+      env,
+      makeSession({
+        org: "team/alpha",
+        language_edit_rights: [],
+        language_publish_rights: ["spanish"],
+      }),
+      "/api/config/languages/spanish"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/team%2Falpha/languages/spanish"
+    );
+    expect(String(fetchSpy.mock.calls[1]![0])).toContain(
+      "/api/v1/admin/orgs/team%2Falpha/languages/spanish"
+    );
+  });
+
+  it("session.org '.' or '..' with NO ?org= → 400 (validated on the resolved org, not just the param)", async () => {
+    // A param-only check misses an org literally named "." reaching
+    // engine paths through the no-param session default: dots survive
+    // encodeURIComponent and /orgs/../x URL-normalizes into traversal.
+    for (const dots of [".", ".."]) {
+      const fetchSpy = spyFetch();
+      const res = await handleConfig(
+        makeRequest("GET", "/api/config/modes"),
+        env,
+        makeSession({ org: dots, isAdmin: true }),
+        "/api/config/modes"
+      );
+      expect(res.status).toBe(400);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      vi.restoreAllMocks();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Same-org ?org= for every caller (#247)
 // ---------------------------------------------------------------------------
 //

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -2082,9 +2082,9 @@ describe("config authz — #181 verb diff (pure function)", () => {
 // Super admins need to edit modes/languages/prompt-overrides in orgs they
 // don't sit in (Tim's 2026-05-21 Zoom — Elsy as super-admin couldn't see
 // Word Collective from her uW session). Closing the gap with an explicit
-// `?org=<slug>` query param: super-admin only, loud 403 for non-super,
-// 400 on empty/path-traversal shapes. No behavior change when the param
-// is absent — that's the everyday org-admin path.
+// `?org=<slug>` query param: cross-org is super-admin only (loud 403
+// for non-super), 400 on empty/dot-segment shapes. No behavior change
+// when the param is absent — that's the everyday org-admin path.
 
 function makeRequestWithQuery(
   method: string,
@@ -2150,16 +2150,39 @@ describe("config authz — cross-org via ?org= (#166)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("?org=foo/bar (path-traversal shape) → 400 even for super-admin", async () => {
+  it("?org=foo/bar (slash-named org) → proxies with the slash encoded (#253 review P2)", async () => {
+    // Slash-named orgs are creatable (admin.ts only trims), so they must
+    // be addressable; path safety comes from handleConfig's
+    // encodeURIComponent, not from rejecting the shape.
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRequestWithQuery("GET", "/api/config/modes", "org=foo%2Fbar"),
       env,
-      makeSession({ isSuperAdmin: true }),
+      makeSession({ org: "acme", isSuperAdmin: true }),
       "/api/config/modes"
     );
-    expect(res.status).toBe(400);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/foo%2Fbar/modes"
+    );
+  });
+
+  it("?org=. and ?org=.. → 400 even for super-admin (dot segments survive encoding)", async () => {
+    // encodeURIComponent leaves dots alone and the URL parser normalizes
+    // /orgs/../x into a traversal — bare dot orgs stay rejected.
+    for (const dots of [".", ".."]) {
+      const fetchSpy = spyFetch();
+      const res = await handleConfig(
+        makeRequestWithQuery("GET", "/api/config/modes", `org=${dots}`),
+        env,
+        makeSession({ org: "acme", isSuperAdmin: true }),
+        "/api/config/modes"
+      );
+      expect(res.status).toBe(400);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      vi.restoreAllMocks();
+    }
   });
 
   it("no ?org= + super-admin → uses session.org (regression: same-org path unchanged)", async () => {
@@ -2602,7 +2625,10 @@ describe("config authz — same-org ?org= (#247)", () => {
     );
   });
 
-  it("super-admin CROSS-org ?org=<slash-named other org> → still 400 (slash reject intact for cross-org)", async () => {
+  it("super-admin CROSS-org ?org=<slash-named other org> → proxies encoded (#253 review P2)", async () => {
+    // A super-admin provisioning users in a slash-named org they don't
+    // sit in needs the dialogs' list fetches to resolve, same as the
+    // org's own admins.
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRequestWithQuery(
@@ -2614,7 +2640,26 @@ describe("config authz — same-org ?org= (#247)", () => {
       makeSession({ org: "acme", isSuperAdmin: true }),
       "/api/config/languages"
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/team%2Falpha/languages"
+    );
+  });
+
+  it("non-super with ?org=<slash-named OTHER org> → still 403 (cross-org gate unchanged)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery(
+        "GET",
+        "/api/config/languages",
+        `org=${encodeURIComponent("team/alpha")}`
+      ),
+      env,
+      makeSession({ org: "acme", isAdmin: true, isSuperAdmin: false }),
+      "/api/config/languages"
+    );
+    expect(res.status).toBe(403);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -2577,6 +2577,47 @@ describe("config authz — same-org ?org= (#247)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("org admin of a slash-named org with ?org=<own org> → proxies (same-org check runs before slash reject)", async () => {
+    // Org names are free-text and worker/admin.ts only trims — a
+    // slash-named org is creatable, and its admins' dialog fetches echo
+    // it back as ?org=. Rejecting it would resurrect the exact #247
+    // dead-selector symptom (as a 400) for that org. The same-org
+    // branch resolves to session.org, which handleConfig
+    // encodeURIComponent's, so no path shape reaches the upstream URL.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery(
+        "GET",
+        "/api/config/languages",
+        `org=${encodeURIComponent("team/alpha")}`
+      ),
+      env,
+      makeSession({ org: "team/alpha", isAdmin: true, isSuperAdmin: false }),
+      "/api/config/languages"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/team%2Falpha/languages"
+    );
+  });
+
+  it("super-admin CROSS-org ?org=<slash-named other org> → still 400 (slash reject intact for cross-org)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery(
+        "GET",
+        "/api/config/languages",
+        `org=${encodeURIComponent("team/alpha")}`
+      ),
+      env,
+      makeSession({ org: "acme", isSuperAdmin: true }),
+      "/api/config/languages"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("super-admin ?org=<case-variant of own org> → cross-org to the case-variant org (distinct KV entry stays addressable)", async () => {
     // "ACME" and "acme" are distinct KV entries. A super-admin naming
     // the case-variant must reach THAT org — resolving it as same-org

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -2168,10 +2168,12 @@ describe("config authz — cross-org via ?org= (#166)", () => {
     );
   });
 
-  it("?org=. and ?org=.. → 400 even for super-admin (dot segments survive encoding)", async () => {
-    // encodeURIComponent leaves dots alone and the URL parser normalizes
-    // /orgs/../x into a traversal — bare dot orgs stay rejected.
-    for (const dots of [".", ".."]) {
+  it.each([".", ".."])(
+    "?org=%j → 400 even for super-admin (dot segments survive encoding)",
+    async (dots) => {
+      // encodeURIComponent leaves dots alone and the URL parser
+      // normalizes /orgs/../x into a traversal — bare dot orgs stay
+      // rejected.
       const fetchSpy = spyFetch();
       const res = await handleConfig(
         makeRequestWithQuery("GET", "/api/config/modes", `org=${dots}`),
@@ -2181,9 +2183,8 @@ describe("config authz — cross-org via ?org= (#166)", () => {
       );
       expect(res.status).toBe(400);
       expect(fetchSpy).not.toHaveBeenCalled();
-      vi.restoreAllMocks();
     }
-  });
+  );
 
   it("no ?org= + super-admin → uses session.org (regression: same-org path unchanged)", async () => {
     const fetchSpy = spyFetch();
@@ -2505,11 +2506,12 @@ describe("config authz — path-shaped orgs (#253 review)", () => {
     );
   });
 
-  it("session.org '.' or '..' with NO ?org= → 400 (validated on the resolved org, not just the param)", async () => {
-    // A param-only check misses an org literally named "." reaching
-    // engine paths through the no-param session default: dots survive
-    // encodeURIComponent and /orgs/../x URL-normalizes into traversal.
-    for (const dots of [".", ".."]) {
+  it.each([".", ".."])(
+    "session.org %j with NO ?org= → 400 (validated on the resolved org, not just the param)",
+    async (dots) => {
+      // A param-only check misses an org literally named "." reaching
+      // engine paths through the no-param session default: dots survive
+      // encodeURIComponent and /orgs/../x URL-normalizes into traversal.
       const fetchSpy = spyFetch();
       const res = await handleConfig(
         makeRequest("GET", "/api/config/modes"),
@@ -2519,8 +2521,27 @@ describe("config authz — path-shaped orgs (#253 review)", () => {
       );
       expect(res.status).toBe(400);
       expect(fetchSpy).not.toHaveBeenCalled();
-      vi.restoreAllMocks();
     }
+  );
+
+  it("?org=<trimmed echo of whitespace-padded session org> → same-org (both sides trimmed)", async () => {
+    // buildConfigUrl trims the param, so a legacy stored org " team"
+    // echoes back as "team" — comparing against the untrimmed session
+    // value would 403 its own admin (the #247 symptom again). Resolves
+    // to the RAW session.org so the engine path matches the no-param
+    // branch.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequestWithQuery("GET", "/api/config/languages", "org=team"),
+      env,
+      makeSession({ org: " team", isAdmin: true, isSuperAdmin: false }),
+      "/api/config/languages"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      `/api/v1/admin/orgs/${encodeURIComponent(" team")}/languages`
+    );
   });
 });
 

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -10,18 +10,20 @@ import type { LanguageRights, StoredUser } from "./types";
 // fields added in #181 — they all use the same `LanguageRights` shape.
 // `fieldName` is interpolated into error messages so a bad `mode_edit_rights`
 // payload doesn't surface as a misleading "language_rights" error.
-// Org names are free-text, but path-shaped values are rejected at the
-// door: session.org is interpolated into upstream URLs across the worker
-// (chat.ts and baruch.ts interpolate it raw; config.ts encodes but bare
-// "."/".." survive encodeURIComponent and URL-normalize into traversal).
-// Guarding creation and move keeps such values out of every downstream
-// URL builder at once (#253 review P2). Stored orgs predating this guard
-// are handled defensively where they're consumed (config.ts resolveOrg).
+// Org names are free-text — slashes included: every upstream URL builder
+// encodeURIComponent's the org (config.ts, chat.ts, baruch.ts), which
+// neutralizes "/". An earlier draft rejected slashes here too, which
+// stranded existing slash-named orgs' own admins from creating users in
+// their org (#253 review P2 — the shape guard ran before the own-org
+// equality check). The ONLY shapes rejected are bare "." / "..":
+// encoding can't neutralize them (/orgs/../x URL-normalizes past the
+// org scope) and no legitimate org carries those names. Stored values
+// predating this guard fail closed at validateSession.
 function isPathShapedOrg(org: string): boolean {
-  return org === "." || org === ".." || org.includes("/");
+  return org === "." || org === "..";
 }
 
-const ORG_SHAPE_ERROR = 'org cannot be "." or ".." or contain "/"';
+const ORG_SHAPE_ERROR = 'org cannot be "." or ".."';
 
 function parseRights(
   value: unknown,

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -4,12 +4,6 @@ import type { Env } from "./helpers";
 import { errorResponse, jsonResponse, listKvKeys } from "./helpers";
 import type { LanguageRights, StoredUser } from "./types";
 
-// Accepts `"*"` or an array of non-empty trimmed strings. Returns `undefined`
-// when the input is unset so the caller can treat that as "leave existing
-// value alone". Shared by `language_rights` (legacy) and the four verb-perms
-// fields added in #181 — they all use the same `LanguageRights` shape.
-// `fieldName` is interpolated into error messages so a bad `mode_edit_rights`
-// payload doesn't surface as a misleading "language_rights" error.
 // Org names are free-text — slashes included: every upstream URL builder
 // encodeURIComponent's the org (config.ts, chat.ts, baruch.ts), which
 // neutralizes "/". An earlier draft rejected slashes here too, which
@@ -25,6 +19,12 @@ function isPathShapedOrg(org: string): boolean {
 
 const ORG_SHAPE_ERROR = 'org cannot be "." or ".."';
 
+// Accepts `"*"` or an array of non-empty trimmed strings. Returns `undefined`
+// when the input is unset so the caller can treat that as "leave existing
+// value alone". Shared by `language_rights` (legacy) and the four verb-perms
+// fields added in #181 — they all use the same `LanguageRights` shape.
+// `fieldName` is interpolated into error messages so a bad `mode_edit_rights`
+// payload doesn't surface as a misleading "language_rights" error.
 function parseRights(
   value: unknown,
   fieldName: string
@@ -233,10 +233,19 @@ async function createUser(
     return errorResponse("Invalid JSON", 400);
   }
 
-  const email = body.email?.trim().toLowerCase();
-  const password = body.password;
-  const name = body.name?.trim();
-  const org = body.org?.trim();
+  // typeof guards, not just `?.`: a non-string field (client bug,
+  // curl typo like org: 123) would reach .trim() and throw an uncaught
+  // TypeError — an opaque 500 instead of the 400 every other malformed
+  // field gets, and it would bypass the shape checks below entirely
+  // (#253 review).
+  const email =
+    typeof body.email === "string"
+      ? body.email.trim().toLowerCase()
+      : undefined;
+  const password =
+    typeof body.password === "string" ? body.password : undefined;
+  const name = typeof body.name === "string" ? body.name.trim() : undefined;
+  const org = typeof body.org === "string" ? body.org.trim() : undefined;
 
   if (!email || !password || !name || !org) {
     return errorResponse("email, password, name, and org are required", 400);
@@ -373,6 +382,15 @@ async function updateUser(
     body = (await request.json()) as typeof body;
   } catch {
     return errorResponse("Invalid JSON", 400);
+  }
+
+  // Same typeof rationale as createUser: reject non-string name/org
+  // before any .trim() below can throw into an opaque 500 (#253 review).
+  if (body.name !== undefined && typeof body.name !== "string") {
+    return errorResponse("name must be a string", 400);
+  }
+  if (body.org !== undefined && typeof body.org !== "string") {
+    return errorResponse("org must be a string", 400);
   }
 
   // Only cross-org scopes may grant or revoke isSuperAdmin. Reject loud

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -1,7 +1,12 @@
 import { getSessionId, invalidateUserSessions, validateSession } from "./auth";
 import { generateSalt, hashPassword, timingSafeEqual } from "./crypto";
 import type { Env } from "./helpers";
-import { errorResponse, jsonResponse, listKvKeys } from "./helpers";
+import {
+  errorResponse,
+  isPathShapedOrg,
+  jsonResponse,
+  listKvKeys,
+} from "./helpers";
 import type { LanguageRights, StoredUser } from "./types";
 
 // Org names are free-text — slashes included: every upstream URL builder
@@ -9,14 +14,8 @@ import type { LanguageRights, StoredUser } from "./types";
 // neutralizes "/". An earlier draft rejected slashes here too, which
 // stranded existing slash-named orgs' own admins from creating users in
 // their org (#253 review P2 — the shape guard ran before the own-org
-// equality check). The ONLY shapes rejected are bare "." / "..":
-// encoding can't neutralize them (/orgs/../x URL-normalizes past the
-// org scope) and no legitimate org carries those names. Stored values
-// predating this guard fail closed at validateSession.
-function isPathShapedOrg(org: string): boolean {
-  return org === "." || org === "..";
-}
-
+// equality check). Only isPathShapedOrg's bare "." / ".." are rejected;
+// stored values predating this guard fail closed at validateSession.
 const ORG_SHAPE_ERROR = 'org cannot be "." or ".."';
 
 // Accepts `"*"` or an array of non-empty trimmed strings. Returns `undefined`

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -10,6 +10,19 @@ import type { LanguageRights, StoredUser } from "./types";
 // fields added in #181 — they all use the same `LanguageRights` shape.
 // `fieldName` is interpolated into error messages so a bad `mode_edit_rights`
 // payload doesn't surface as a misleading "language_rights" error.
+// Org names are free-text, but path-shaped values are rejected at the
+// door: session.org is interpolated into upstream URLs across the worker
+// (chat.ts and baruch.ts interpolate it raw; config.ts encodes but bare
+// "."/".." survive encodeURIComponent and URL-normalize into traversal).
+// Guarding creation and move keeps such values out of every downstream
+// URL builder at once (#253 review P2). Stored orgs predating this guard
+// are handled defensively where they're consumed (config.ts resolveOrg).
+function isPathShapedOrg(org: string): boolean {
+  return org === "." || org === ".." || org.includes("/");
+}
+
+const ORG_SHAPE_ERROR = 'org cannot be "." or ".." or contain "/"';
+
 function parseRights(
   value: unknown,
   fieldName: string
@@ -226,6 +239,9 @@ async function createUser(
   if (!email || !password || !name || !org) {
     return errorResponse("email, password, name, and org are required", 400);
   }
+  if (isPathShapedOrg(org)) {
+    return errorResponse(ORG_SHAPE_ERROR, 400);
+  }
 
   // Org-scoped admins can only create users in their own org.
   if (scope.kind === "org" && org !== scope.org) {
@@ -408,6 +424,9 @@ async function updateUser(
     const trimmed = body.org.trim();
     if (!trimmed) {
       return errorResponse("org cannot be empty", 400);
+    }
+    if (isPathShapedOrg(trimmed)) {
+      return errorResponse(ORG_SHAPE_ERROR, 400);
     }
     user.org = trimmed;
   }

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -118,6 +118,18 @@ export async function validateSession(
     return null;
   }
 
+  // Fail closed on traversal-capable org names (#253 review P1).
+  // admin.ts rejects "." / ".." at user create/move, but a stored value
+  // predating that guard hydrates into session.org and reaches upstream
+  // URL builders (chat.ts, baruch.ts, config.ts) where bare dots
+  // survive encodeURIComponent and /orgs/../x normalizes past the org
+  // scope. No legitimate org is named "." or ".." — locking the
+  // account out (recoverable via an admin org-move) beats letting its
+  // every request escape its org prefix.
+  if (user.org === "." || user.org === "..") {
+    return null;
+  }
+
   // Lazy-migrate the legacy single-bit `language_rights` into the two
   // verb-perms fields when the stored record predates #181. Partner-
   // aware: if either verb-perm is explicit, the unset partner falls

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -218,6 +218,19 @@ export async function handleLogin(
     return errorResponse("Invalid email or password", 401);
   }
 
+  // Mirror of validateSession's dot-org fail-closed check (#253 review):
+  // without it, correct credentials against a "."/"..'-org record mint a
+  // session that every subsequent request rejects — an unexplained
+  // login-then-logged-out loop plus an orphaned KV session per attempt.
+  // Reject at login with a real message instead. Runs AFTER the password
+  // check so it can't be used to probe which emails exist.
+  if (user.org === "." || user.org === "..") {
+    return errorResponse(
+      "This account's organization is invalid; ask an admin to move it to a valid org",
+      403
+    );
+  }
+
   const sessionId = crypto.randomUUID();
   // Same partner-aware lazy migration as validateSession — keeps the
   // freshly-minted session shape identical to a re-hydrated one so the

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -1,6 +1,11 @@
 import { generateSalt, hashPassword, timingSafeEqual } from "./crypto";
 import type { Env } from "./helpers";
-import { errorResponse, jsonResponse, listKvKeys } from "./helpers";
+import {
+  errorResponse,
+  jsonResponse,
+  listKvKeys,
+  isPathShapedOrg,
+} from "./helpers";
 import type { LanguageRights, SessionData, StoredUser } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -126,7 +131,7 @@ export async function validateSession(
   // scope. No legitimate org is named "." or ".." — locking the
   // account out (recoverable via an admin org-move) beats letting its
   // every request escape its org prefix.
-  if (user.org === "." || user.org === "..") {
+  if (isPathShapedOrg(user.org)) {
     return null;
   }
 
@@ -224,7 +229,7 @@ export async function handleLogin(
   // login-then-logged-out loop plus an orphaned KV session per attempt.
   // Reject at login with a real message instead. Runs AFTER the password
   // check so it can't be used to probe which emails exist.
-  if (user.org === "." || user.org === "..") {
+  if (isPathShapedOrg(user.org)) {
     return errorResponse(
       "This account's organization is invalid; ask an admin to move it to a valid org",
       403

--- a/worker/baruch.ts
+++ b/worker/baruch.ts
@@ -108,7 +108,7 @@ export async function handleBaruchHistory(
   );
 
   const params = new URLSearchParams({ limit, offset });
-  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/orgs/${session.org}/users/${session.userId}/history?${params.toString()}`;
+  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/orgs/${encodeURIComponent(session.org)}/users/${session.userId}/history?${params.toString()}`;
 
   const baruchRes = await baruchFetch(env, baruchUrl, {
     headers: {
@@ -199,7 +199,7 @@ export async function handleBaruchDeleteHistory(
     return errorResponse("Method not allowed", 405);
   }
 
-  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/orgs/${session.org}/users/${session.userId}/history`;
+  const baruchUrl = `${env.BARUCH_BASE_URL}/api/v1/orgs/${encodeURIComponent(session.org)}/users/${session.userId}/history`;
 
   const baruchRes = await baruchFetch(env, baruchUrl, {
     method: "DELETE",

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -17,10 +17,18 @@ const UUID_V4_RE =
 // (single shared engine key) this worker is the only enforcement point
 // (#253 review). An override is therefore rejected when it matches any
 // OTHER portal user's stored id; synthetic test IDs match nobody and
-// pass. The per-request scan over user records mirrors what
-// /api/admin/users already does per list call — org user counts are
-// small. Residual: engine-side IDs the portal doesn't store (e.g.
+// pass. Residual: engine-side IDs the portal doesn't store (e.g.
 // messaging end-users) can't be checked here.
+//
+// Per-isolate memo of ids already verified as matching no stored user,
+// so the test-chat panel doesn't pay a full user scan per message.
+// Sound because stored ids are minted server-side (crypto.randomUUID at
+// create) — an id that matched nobody can't become a stored user's id
+// later. Cleared wholesale at a size cap; it's an optimization, not
+// state anything depends on.
+const verifiedSyntheticIds = new Set<string>();
+const VERIFIED_SYNTHETIC_IDS_CAP = 256;
+
 async function resolveUserId(
   env: Env,
   override: string | null | undefined,
@@ -32,11 +40,16 @@ async function resolveUserId(
   // Compare lowercased: UUID_V4_RE accepts uppercase hex, and stored ids
   // (crypto.randomUUID) are lowercase — a case-sensitive compare would
   // let an uppercased copy of a victim's id slip past both checks and
-  // reach the engine (#253 review round 6). The resolved id keeps the
-  // canonical lowercase form for the same reason.
+  // reach the engine (#253 review round 6). Comparisons only: the
+  // FORWARDED id stays verbatim, because a non-matching override may be
+  // an engine-side id the portal doesn't store, and case-folding one of
+  // those would silently retarget the request (round 7).
   const normalized = override.toLowerCase();
   if (normalized === session.userId.toLowerCase()) {
     return { userId: session.userId };
+  }
+  if (verifiedSyntheticIds.has(normalized)) {
+    return { userId: override };
   }
   // Fail CLOSED on a KV blip: this is a security guard, and failing open
   // would let an induced storage error bypass it. The 503 is retryable
@@ -44,23 +57,36 @@ async function resolveUserId(
   // traffic never enters this branch.
   try {
     const keys = await listKvKeys(env.AUTH_KV, "user:");
-    // Parallel like admin.ts listUsers — the common case (synthetic
-    // test-chat id) matches nobody, so a serial loop would put N
+    // Parallel like admin.ts listUsers — a serial loop would put N
     // round-trips on the chat hot path.
     const users = await Promise.all(
       keys.map((key) => env.AUTH_KV.get<StoredUser>(key, { type: "json" }))
     );
-    if (users.some((user) => user?.id.toLowerCase() === normalized)) {
+    if (
+      users.some(
+        // typeof guard: a malformed record whose id is absent must scan
+        // past, not throw into the catch below — one corrupt KV entry
+        // would otherwise turn every overridden request into a
+        // permanent 'retryable' 503 (round 7).
+        (user) =>
+          typeof user?.id === "string" && user.id.toLowerCase() === normalized
+      )
+    ) {
       return {
         error: errorResponse("user_id may not target another user", 403),
       };
     }
-  } catch {
+  } catch (error) {
+    console.error("user_id verification scan failed:", error);
     return {
       error: errorResponse("Could not verify user_id; try again", 503),
     };
   }
-  return { userId: normalized };
+  if (verifiedSyntheticIds.size >= VERIFIED_SYNTHETIC_IDS_CAP) {
+    verifiedSyntheticIds.clear();
+  }
+  verifiedSyntheticIds.add(normalized);
+  return { userId: override };
 }
 
 export async function handleStream(

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -1,20 +1,47 @@
 import type { Env } from "./helpers";
-import { errorResponse, jsonResponse } from "./helpers";
-import type { SessionData } from "./types";
+import { errorResponse, jsonResponse, listKvKeys } from "./helpers";
+import type { SessionData, StoredUser } from "./types";
 
 const CLIENT_ID = "admin-portal";
 
-// Only accept user_id overrides that are valid UUID v4 (from crypto.randomUUID).
-// This prevents IDOR — real user IDs from the auth system are not UUIDs.
 const UUID_V4_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-function resolveUserId(
+// The user_id override exists for the test-chat panel: the portal mints a
+// synthetic UUID per session (ui-store testChatUserId) so test
+// conversations don't touch the caller's own history. Synthetic and real
+// IDs are indistinguishable by shape — portal user IDs are ALSO
+// crypto.randomUUID() (worker/admin.ts) — so shape alone was an IDOR:
+// any authenticated user could read or delete a colleague's history/
+// memory by passing their user ID, and under the trusted-portal model
+// (single shared engine key) this worker is the only enforcement point
+// (#253 review). An override is therefore rejected when it matches any
+// OTHER portal user's stored id; synthetic test IDs match nobody and
+// pass. The per-request scan over user records mirrors what
+// /api/admin/users already does per list call — org user counts are
+// small. Residual: engine-side IDs the portal doesn't store (e.g.
+// messaging end-users) can't be checked here.
+async function resolveUserId(
+  env: Env,
   override: string | null | undefined,
   session: SessionData
-): string {
-  if (override && UUID_V4_RE.test(override)) return override;
-  return session.userId;
+): Promise<{ userId: string } | { error: Response }> {
+  if (!override || !UUID_V4_RE.test(override)) {
+    return { userId: session.userId };
+  }
+  if (override === session.userId) {
+    return { userId: override };
+  }
+  const keys = await listKvKeys(env.AUTH_KV, "user:");
+  for (const key of keys) {
+    const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
+    if (user?.id === override) {
+      return {
+        error: errorResponse("user_id may not target another user", 403),
+      };
+    }
+  }
+  return { userId: override };
 }
 
 export async function handleStream(
@@ -37,11 +64,14 @@ export async function handleStream(
     return errorResponse("Missing 'message' field", 400);
   }
 
+  const resolvedUser = await resolveUserId(env, body.user_id, session);
+  if ("error" in resolvedUser) return resolvedUser.error;
+
   const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/chat/stream`;
   const engineBody = {
     message: body.message,
     message_type: body.message_type || "text",
-    user_id: resolveUserId(body.user_id, session),
+    user_id: resolvedUser.userId,
     org: session.org,
     client_id: CLIENT_ID,
   };
@@ -91,7 +121,13 @@ export async function handleHistory(
     Math.max(parseInt(url.searchParams.get("offset") || "0", 10) || 0, 0)
   );
 
-  const userId = resolveUserId(url.searchParams.get("user_id"), session);
+  const resolvedUser = await resolveUserId(
+    env,
+    url.searchParams.get("user_id"),
+    session
+  );
+  if ("error" in resolvedUser) return resolvedUser.error;
+  const userId = resolvedUser.userId;
   const params = new URLSearchParams({ limit, offset });
   const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/orgs/${encodeURIComponent(session.org)}/users/${userId}/history?${params.toString()}`;
 
@@ -131,7 +167,13 @@ export async function handleDeleteHistory(
   }
 
   const url = new URL(request.url);
-  const userId = resolveUserId(url.searchParams.get("user_id"), session);
+  const resolvedUser = await resolveUserId(
+    env,
+    url.searchParams.get("user_id"),
+    session
+  );
+  if ("error" in resolvedUser) return resolvedUser.error;
+  const userId = resolvedUser.userId;
   const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/admin/orgs/${encodeURIComponent(session.org)}/users/${userId}/history`;
 
   const engineRes = await fetch(engineUrl, {
@@ -162,7 +204,13 @@ export async function handleDeleteMemory(
   }
 
   const url = new URL(request.url);
-  const userId = resolveUserId(url.searchParams.get("user_id"), session);
+  const resolvedUser = await resolveUserId(
+    env,
+    url.searchParams.get("user_id"),
+    session
+  );
+  if ("error" in resolvedUser) return resolvedUser.error;
+  const userId = resolvedUser.userId;
   const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/admin/orgs/${encodeURIComponent(session.org)}/users/${userId}/memory`;
 
   const engineRes = await fetch(engineUrl, {

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -93,7 +93,7 @@ export async function handleHistory(
 
   const userId = resolveUserId(url.searchParams.get("user_id"), session);
   const params = new URLSearchParams({ limit, offset });
-  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/orgs/${session.org}/users/${userId}/history?${params.toString()}`;
+  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/orgs/${encodeURIComponent(session.org)}/users/${userId}/history?${params.toString()}`;
 
   const engineRes = await fetch(engineUrl, {
     headers: {
@@ -132,7 +132,7 @@ export async function handleDeleteHistory(
 
   const url = new URL(request.url);
   const userId = resolveUserId(url.searchParams.get("user_id"), session);
-  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/admin/orgs/${session.org}/users/${userId}/history`;
+  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/admin/orgs/${encodeURIComponent(session.org)}/users/${userId}/history`;
 
   const engineRes = await fetch(engineUrl, {
     method: "DELETE",
@@ -163,7 +163,7 @@ export async function handleDeleteMemory(
 
   const url = new URL(request.url);
   const userId = resolveUserId(url.searchParams.get("user_id"), session);
-  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/admin/orgs/${session.org}/users/${userId}/memory`;
+  const engineUrl = `${env.ENGINE_BASE_URL}/api/v1/admin/orgs/${encodeURIComponent(session.org)}/users/${userId}/memory`;
 
   const engineRes = await fetch(engineUrl, {
     method: "DELETE",

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -20,15 +20,12 @@ const UUID_V4_RE =
 // pass. Residual: engine-side IDs the portal doesn't store (e.g.
 // messaging end-users) can't be checked here.
 //
-// Per-isolate memo of ids already verified as matching no stored user,
-// so the test-chat panel doesn't pay a full user scan per message.
-// Sound because stored ids are minted server-side (crypto.randomUUID at
-// create) — an id that matched nobody can't become a stored user's id
-// later. Cleared wholesale at a size cap; it's an optimization, not
-// state anything depends on.
-const verifiedSyntheticIds = new Set<string>();
-const VERIFIED_SYNTHETIC_IDS_CAP = 256;
-
+// Deliberately NO caching of scan verdicts: KV list/get are eventually
+// consistent, so a no-match verdict raced against user creation can be
+// stale — memoizing it would convert that transient window into a
+// durable per-isolate bypass for the new user's id (#253 review round
+// 8; an earlier draft did exactly that). The per-request scan cost is
+// the accepted price until the session-carried allow-list follow-up.
 async function resolveUserId(
   env: Env,
   override: string | null | undefined,
@@ -47,9 +44,6 @@ async function resolveUserId(
   const normalized = override.toLowerCase();
   if (normalized === session.userId.toLowerCase()) {
     return { userId: session.userId };
-  }
-  if (verifiedSyntheticIds.has(normalized)) {
-    return { userId: override };
   }
   // Fail CLOSED on a KV blip: this is a security guard, and failing open
   // would let an induced storage error bypass it. The 503 is retryable
@@ -82,10 +76,6 @@ async function resolveUserId(
       error: errorResponse("Could not verify user_id; try again", 503),
     };
   }
-  if (verifiedSyntheticIds.size >= VERIFIED_SYNTHETIC_IDS_CAP) {
-    verifiedSyntheticIds.clear();
-  }
-  verifiedSyntheticIds.add(normalized);
   return { userId: override };
 }
 

--- a/worker/chat.ts
+++ b/worker/chat.ts
@@ -29,19 +29,38 @@ async function resolveUserId(
   if (!override || !UUID_V4_RE.test(override)) {
     return { userId: session.userId };
   }
-  if (override === session.userId) {
-    return { userId: override };
+  // Compare lowercased: UUID_V4_RE accepts uppercase hex, and stored ids
+  // (crypto.randomUUID) are lowercase — a case-sensitive compare would
+  // let an uppercased copy of a victim's id slip past both checks and
+  // reach the engine (#253 review round 6). The resolved id keeps the
+  // canonical lowercase form for the same reason.
+  const normalized = override.toLowerCase();
+  if (normalized === session.userId.toLowerCase()) {
+    return { userId: session.userId };
   }
-  const keys = await listKvKeys(env.AUTH_KV, "user:");
-  for (const key of keys) {
-    const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
-    if (user?.id === override) {
+  // Fail CLOSED on a KV blip: this is a security guard, and failing open
+  // would let an induced storage error bypass it. The 503 is retryable
+  // and scoped to overridden requests (test-chat panel); non-overridden
+  // traffic never enters this branch.
+  try {
+    const keys = await listKvKeys(env.AUTH_KV, "user:");
+    // Parallel like admin.ts listUsers — the common case (synthetic
+    // test-chat id) matches nobody, so a serial loop would put N
+    // round-trips on the chat hot path.
+    const users = await Promise.all(
+      keys.map((key) => env.AUTH_KV.get<StoredUser>(key, { type: "json" }))
+    );
+    if (users.some((user) => user?.id.toLowerCase() === normalized)) {
       return {
         error: errorResponse("user_id may not target another user", 403),
       };
     }
+  } catch {
+    return {
+      error: errorResponse("Could not verify user_id; try again", 503),
+    };
   }
-  return { userId: override };
+  return { userId: normalized };
 }
 
 export async function handleStream(

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -1,5 +1,5 @@
 import type { Env } from "./helpers";
-import { errorResponse } from "./helpers";
+import { errorResponse, isPathShapedOrg } from "./helpers";
 import {
   contractOrgModeRights,
   expandOrgModeRights,
@@ -484,7 +484,7 @@ function resolveOrg(
   // session.org (#253 review P2). admin.ts rejects these at user
   // create/move, but stored values predating that guard must still be
   // stopped here.
-  if (resolved.org === "." || resolved.org === "..") {
+  if (isPathShapedOrg(resolved.org)) {
     return { error: errorResponse("Invalid org", 400) };
   }
 

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -456,7 +456,13 @@ function resolveOrg(
     if (!trimmed) {
       return { error: errorResponse("Invalid org parameter", 400) };
     }
-    if (trimmed === session.org) {
+    if (trimmed === session.org.trim()) {
+      // Trim BOTH sides: buildConfigUrl trims the param before sending,
+      // so a legacy whitespace-padded stored org (" team") would never
+      // equal its own trimmed echo and its admin would land in the
+      // cross-org 403 — the #247 symptom again (#253 review). Resolve
+      // to the RAW session.org so the engine path matches what the
+      // no-param branch produces for the same caller.
       resolved = { crossOrg: false, org: session.org };
     } else if (session.isSuperAdmin !== true) {
       return {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -440,12 +440,24 @@ function resolveOrg(
   }
 
   const trimmed = orgParam.trim();
-  if (!trimmed || trimmed.includes("/")) {
+  if (!trimmed) {
     return { error: errorResponse("Invalid org parameter", 400) };
   }
 
+  // Same-org match runs BEFORE the slash reject: org names are free-text
+  // (worker/admin.ts only trims — it never rejects slashes), so a
+  // slash-named org is creatable, and its own admins' dialog fetches
+  // send it back as ?org=. The same-org branch resolves to session.org
+  // (encodeURIComponent'd at use), so no path shape from the param ever
+  // reaches the upstream URL here.
   if (trimmed === session.org) {
     return { crossOrg: false, org: session.org };
+  }
+
+  // Cross-org targeting keeps the slash reject: a path-shaped slug from
+  // a super-admin is a probe or a UI bug, never a legitimate target.
+  if (trimmed.includes("/")) {
+    return { error: errorResponse("Invalid org parameter", 400) };
   }
 
   if (session.isSuperAdmin !== true) {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -495,7 +495,13 @@ export async function handleConfig(
   if ("error" in resolved) {
     return resolved.error;
   }
-  const org = encodeURIComponent(resolved.org);
+  // Named so the raw-vs-encoded distinction travels with the variable:
+  // the round-3 double-encoding bug happened because a pre-encoded local
+  // called `org` was passed where raw resolved.org was expected. Helpers
+  // that take an org (fetchResourceState, preflightMode,
+  // gateConfigMutation, the rights migration) take RAW resolved.org;
+  // path templates below take this.
+  const encodedOrg = encodeURIComponent(resolved.org);
 
   // /api/config/prompt-overrides → GET (any session) / PUT/DELETE (admin)
   if (pathname === "/api/config/prompt-overrides") {
@@ -505,7 +511,7 @@ export async function handleConfig(
     return proxyToEngine(
       request,
       env,
-      `/api/v1/admin/orgs/${org}/prompt-overrides`,
+      `/api/v1/admin/orgs/${encodedOrg}/prompt-overrides`,
       ["GET", "PUT", "DELETE"]
     );
   }
@@ -666,7 +672,7 @@ export async function handleConfig(
       engineRes = await proxyToEngine(
         request,
         env,
-        `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_rename`,
+        `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}/_rename`,
         ["POST"],
         // Forward the TRIMMED newName — the same value the migration
         // used (Frank rd-1 P2).
@@ -743,7 +749,7 @@ export async function handleConfig(
     return proxyToEngine(
       request,
       env,
-      `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_clone`,
+      `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}/_clone`,
       ["POST"]
     );
   }
@@ -773,7 +779,7 @@ export async function handleConfig(
     return proxyToEngine(
       request,
       env,
-      `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}/_retire`,
+      `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}/_retire`,
       ["POST"]
     );
   }
@@ -797,7 +803,7 @@ export async function handleConfig(
       return proxyToEngine(
         request,
         env,
-        `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}`,
+        `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}`,
         ["GET", "PUT", "DELETE"],
         gate.parsedBody
       );
@@ -805,7 +811,7 @@ export async function handleConfig(
     return proxyToEngine(
       request,
       env,
-      `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(modeName)}`,
+      `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}`,
       ["GET", "PUT", "DELETE"]
     );
   }
@@ -829,7 +835,7 @@ export async function handleConfig(
       return proxyToEngine(
         request,
         env,
-        `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(languageName)}`,
+        `/api/v1/admin/orgs/${encodedOrg}/languages/${encodeURIComponent(languageName)}`,
         ["GET", "PUT", "DELETE"],
         gate.parsedBody
       );
@@ -837,7 +843,7 @@ export async function handleConfig(
     return proxyToEngine(
       request,
       env,
-      `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(languageName)}`,
+      `/api/v1/admin/orgs/${encodedOrg}/languages/${encodeURIComponent(languageName)}`,
       ["GET", "PUT", "DELETE"]
     );
   }
@@ -852,7 +858,7 @@ export async function handleConfig(
     return proxyToEngine(
       request,
       env,
-      `/api/v1/admin/orgs/${org}/users/${encodeURIComponent(userId)}/mode`,
+      `/api/v1/admin/orgs/${encodedOrg}/users/${encodeURIComponent(userId)}/mode`,
       ["PUT", "DELETE"]
     );
   }
@@ -867,23 +873,29 @@ export async function handleConfig(
     return proxyToEngine(
       request,
       env,
-      `/api/v1/admin/orgs/${org}/users/${encodeURIComponent(userId)}/memory`,
+      `/api/v1/admin/orgs/${encodedOrg}/users/${encodeURIComponent(userId)}/memory`,
       ["GET", "DELETE"]
     );
   }
 
   // /api/config/modes → GET
   if (pathname === "/api/config/modes") {
-    return proxyToEngine(request, env, `/api/v1/admin/orgs/${org}/modes`, [
-      "GET",
-    ]);
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${encodedOrg}/modes`,
+      ["GET"]
+    );
   }
 
   // /api/config/languages → GET
   if (pathname === "/api/config/languages") {
-    return proxyToEngine(request, env, `/api/v1/admin/orgs/${org}/languages`, [
-      "GET",
-    ]);
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${encodedOrg}/languages`,
+      ["GET"]
+    );
   }
 
   // /api/config/language-scaffold → GET (org-scope; worker returns
@@ -894,7 +906,7 @@ export async function handleConfig(
     return proxyToEngine(
       request,
       env,
-      `/api/v1/admin/orgs/${org}/language-scaffold`,
+      `/api/v1/admin/orgs/${encodedOrg}/language-scaffold`,
       ["GET"]
     );
   }

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -439,25 +439,25 @@ function resolveOrg(
     return { crossOrg: false, org: session.org };
   }
 
+  // Org names are free-text (worker/admin.ts only trims at create/
+  // rename), so slashes and other path-looking shapes are creatable and
+  // MUST resolve — rejecting them re-breaks the dialogs' list fetches
+  // (the #247 symptom) for anyone operating on such an org, same-org or
+  // cross-org. Path safety doesn't depend on this reject: every URL
+  // interpolation of the resolved org goes through the single
+  // encodeURIComponent in handleConfig, which neutralizes "/" (and the
+  // non-URL uses are KV-scoped, where any string is inert). The two
+  // shapes encoding can't neutralize are bare "." and ".." — dots
+  // survive encodeURIComponent and the URL parser normalizes dot
+  // segments, so those stay rejected. They can't be real org names
+  // without being indistinguishable from traversal.
   const trimmed = orgParam.trim();
-  if (!trimmed) {
+  if (!trimmed || trimmed === "." || trimmed === "..") {
     return { error: errorResponse("Invalid org parameter", 400) };
   }
 
-  // Same-org match runs BEFORE the slash reject: org names are free-text
-  // (worker/admin.ts only trims — it never rejects slashes), so a
-  // slash-named org is creatable, and its own admins' dialog fetches
-  // send it back as ?org=. The same-org branch resolves to session.org
-  // (encodeURIComponent'd at use), so no path shape from the param ever
-  // reaches the upstream URL here.
   if (trimmed === session.org) {
     return { crossOrg: false, org: session.org };
-  }
-
-  // Cross-org targeting keeps the slash reject: a path-shaped slug from
-  // a super-admin is a probe or a UI bug, never a legitimate target.
-  if (trimmed.includes("/")) {
-    return { error: errorResponse("Invalid org parameter", 400) };
   }
 
   if (session.isSuperAdmin !== true) {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -175,10 +175,15 @@ async function fetchResourceState(
   org: string,
   name: string
 ): Promise<ResourceState> {
+  // Takes the RAW org and encodes here (#253 review): callers used to
+  // disagree — the rename preflights passed the pre-encoded handleConfig
+  // local while gateConfigMutation passed raw resolved.org, so a
+  // slash-named org's PUT gate looked up /orgs/team/alpha/... and the
+  // engine's 404 silently rerouted the mutation to creation semantics.
   const enginePath =
     kind === "language"
-      ? `/api/v1/admin/orgs/${org}/languages/${encodeURIComponent(name)}`
-      : `/api/v1/admin/orgs/${org}/modes/${encodeURIComponent(name)}`;
+      ? `/api/v1/admin/orgs/${encodeURIComponent(org)}/languages/${encodeURIComponent(name)}`
+      : `/api/v1/admin/orgs/${encodeURIComponent(org)}/modes/${encodeURIComponent(name)}`;
   const res = await fetch(`${env.ENGINE_BASE_URL}${enginePath}`, {
     headers: { Authorization: `Bearer ${env.ENGINE_API_KEY}` },
   });
@@ -435,41 +440,49 @@ function resolveOrg(
   session: SessionData
 ): { crossOrg: boolean; org: string } | { error: Response } {
   const orgParam = new URL(request.url).searchParams.get("org");
+
+  // Slash-named orgs are addressable: org names are free-text (stored
+  // values may predate admin.ts's shape guard), and every engine-URL
+  // interpolation of the resolved org is encodeURIComponent'd (the
+  // handleConfig local for proxy paths, fetchResourceState internally
+  // for the gate's lookups), which neutralizes "/". Rejecting the shape
+  // here would re-break the dialogs' list fetches (the #247 symptom)
+  // for anyone operating on such an org.
+  let resolved: { crossOrg: boolean; org: string };
   if (orgParam === null) {
-    return { crossOrg: false, org: session.org };
+    resolved = { crossOrg: false, org: session.org };
+  } else {
+    const trimmed = orgParam.trim();
+    if (!trimmed) {
+      return { error: errorResponse("Invalid org parameter", 400) };
+    }
+    if (trimmed === session.org) {
+      resolved = { crossOrg: false, org: session.org };
+    } else if (session.isSuperAdmin !== true) {
+      return {
+        error: errorResponse(
+          "Cross-org config access requires isSuperAdmin",
+          403
+        ),
+      };
+    } else {
+      resolved = { crossOrg: true, org: trimmed };
+    }
   }
 
-  // Org names are free-text (worker/admin.ts only trims at create/
-  // rename), so slashes and other path-looking shapes are creatable and
-  // MUST resolve — rejecting them re-breaks the dialogs' list fetches
-  // (the #247 symptom) for anyone operating on such an org, same-org or
-  // cross-org. Path safety doesn't depend on this reject: every URL
-  // interpolation of the resolved org goes through the single
-  // encodeURIComponent in handleConfig, which neutralizes "/" (and the
-  // non-URL uses are KV-scoped, where any string is inert). The two
-  // shapes encoding can't neutralize are bare "." and ".." — dots
-  // survive encodeURIComponent and the URL parser normalizes dot
-  // segments, so those stay rejected. They can't be real org names
-  // without being indistinguishable from traversal.
-  const trimmed = orgParam.trim();
-  if (!trimmed || trimmed === "." || trimmed === "..") {
-    return { error: errorResponse("Invalid org parameter", 400) };
+  // The one shape encoding can't neutralize: bare "." / ".." survive
+  // encodeURIComponent and URL parsers normalize the dot segment into
+  // traversal (/orgs/../x → /x). Validated on the RESOLVED org — the
+  // no-param session default included — because a param-only check
+  // misses an org literally named "." reaching engine paths through
+  // session.org (#253 review P2). admin.ts rejects these at user
+  // create/move, but stored values predating that guard must still be
+  // stopped here.
+  if (resolved.org === "." || resolved.org === "..") {
+    return { error: errorResponse("Invalid org", 400) };
   }
 
-  if (trimmed === session.org) {
-    return { crossOrg: false, org: session.org };
-  }
-
-  if (session.isSuperAdmin !== true) {
-    return {
-      error: errorResponse(
-        "Cross-org config access requires isSuperAdmin",
-        403
-      ),
-    };
-  }
-
-  return { crossOrg: true, org: trimmed };
+  return resolved;
 }
 
 export async function handleConfig(
@@ -583,9 +596,11 @@ export async function handleConfig(
     // newName that is THIS mode's own alias returns the same mode and
     // falls through — that's the engine's valid promote-own-alias
     // un-rename.
+    // Raw resolved.org — fetchResourceState encodes internally; passing
+    // the pre-encoded `org` local would double-encode (#253 review).
     const [source, target] = await Promise.all([
-      preflightMode(env, org, modeName),
-      preflightMode(env, org, newName),
+      preflightMode(env, resolved.org, modeName),
+      preflightMode(env, resolved.org, newName),
     ]);
     // Source-first evaluation, FULLY: the source's definitive answers
     // (missing → 404, alias-addressed → 409) take precedence over a
@@ -694,7 +709,7 @@ export async function handleConfig(
     } else if (engineRes.status >= 400 && engineRes.status < 500) {
       await contractOrgModeRights(env, migrationRecords, newName, modeName);
     } else {
-      const probe = await preflightMode(env, org, modeName);
+      const probe = await preflightMode(env, resolved.org, modeName);
       if (probe.status === "found" && probe.mode.name === newName) {
         await contractOrgModeRights(env, migrationRecords, modeName, newName);
       } else {

--- a/worker/helpers.ts
+++ b/worker/helpers.ts
@@ -50,3 +50,13 @@ export async function listKvKeys(
   } while (cursor);
   return keys;
 }
+
+// Traversal-capable org names — the one shape encodeURIComponent can't
+// neutralize (/orgs/../x URL-normalizes past the org scope). Single copy
+// because it's enforced at multiple choke points (admin.ts create/move,
+// auth.ts login + session validation, config.ts resolveOrg): a hardening
+// applied to one inline copy would silently miss the others (#253
+// review round 6).
+export function isPathShapedOrg(org: string): boolean {
+  return org === "." || org === "..";
+}


### PR DESCRIPTION
## Summary

Follow-up to **#252** (merged earlier today): the round-2 multi-agent re-review completed after the merge and confirmed two residual correctness bugs plus one hardening item. Touches #247; no `Closes` keyword — Elsy's staging verification still gates that issue.

### Fixes

1. **Legacy-language seed on a success-empty list** (`rights-selector.tsx`) — the round-1 guard only covered `availableItems === undefined`. With a successfully-loaded **empty** list (exactly the #248 empty-org state), clicking "Specific languages" for a legacy user seeded `[]`, silently converting legacy full access — which also covers every *future* language — into an explicit no-access grant. The Specific option is now disabled until there's something real to seed from, with a muted status line explaining why.

2. **Slash-named orgs never reached the same-org allowance** (`worker/config.ts`) — the pre-existing `includes("/")` 400 ran before the new equality check, and org creation (`admin.ts`) only trims, never rejects slashes. A slash-named org's own admins would still have dead dialog fetches — the original #247 symptom as a 400. The same-org equality check now runs first (it resolves to `session.org`, which `handleConfig` `encodeURIComponent`s, so no path shape from the param reaches the upstream URL). Cross-org slash targets still 400.

3. **Retry button out of the radio's `<label>`** (`rights-selector.tsx`) — an interactive button inside the label relied on label activation not forwarding to the radio; a forwarded click would rewrite the rights value. Status lines now render as siblings of the label, in every radio state.

### Declined from the same review

Per-selector error-line duplication (up to two identical lines per failed query). Low severity, cosmetic, and deduping means another prop-API reshape — one line per verb section is arguably informative.

### Tests

2 new cases: slash-named same-org proxies with the slug encoded; cross-org slash still 400. **485/485 passing.** Version 1.10.2 → 1.10.3.

## Test plan

- [x] Full suite green locally (485 tests)
- [x] lint / typecheck / build clean
- [ ] CI green