### PR TITLE
fix(#247): admin bootstrap carve-out — same-org admins can create the first language draft

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.10.1",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-admin-portal",
-      "version": "1.10.1",
+      "version": "1.10.4",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
+import { fetchMe } from "@/lib/auth-api";
 import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import { LanguageForbiddenError } from "@/lib/languages-api";
@@ -11,6 +12,7 @@ import {
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
   filterByAnyRights,
+  hasAdminPowers,
   hasAnyLanguageAccess,
   hasAnyRights,
   hasRights,
@@ -49,6 +51,7 @@ const AUTO_SAVE_DEBOUNCE_MS = 800;
 
 export function LanguagesPage() {
   const user = useAuthStore((s) => s.user);
+  const setUser = useAuthStore((s) => s.setUser);
   const selectedLanguage = useUiStore((s) => s.selectedLanguage);
   const setSelectedLanguage = useUiStore((s) => s.setSelectedLanguage);
   const showDrafts = useUiStore((s) => s.showDrafts);
@@ -73,12 +76,19 @@ export function LanguagesPage() {
   // rd-2 P1).
   const editRights = isCrossOrg ? "*" : effectiveLanguageEditRights(user);
   const publishRights = isCrossOrg ? "*" : effectiveLanguagePublishRights(user);
-  const hasAccess = isCrossOrg || hasAnyLanguageAccess(user);
+  // #247 — admins always reach the page and the Create affordance: the
+  // worker allows a same-org admin to CREATE a draft that doesn't exist
+  // yet (and auto-grants them both verbs on it), which is the only way
+  // a fresh org's first draft can come into existence when every user
+  // holds explicit (non-"*") rights.
+  const isAdmin = hasAdminPowers(user);
+  const hasAccess = isCrossOrg || isAdmin || hasAnyLanguageAccess(user);
 
   // Per-row capability gates passed to LanguageSelector. Languages
-  // don't carry an admin trump (PR #185 enforced per-row even for
-  // super-admins), so these are pure verb-perm reads.
-  const canCreate = hasAnyRights(editRights);
+  // don't carry an admin trump for EXISTING rows (PR #185 enforced
+  // per-row even for super-admins), so the selected-row gates are pure
+  // verb-perm reads; only creation (#247 above) consults isAdmin.
+  const canCreate = hasAnyRights(editRights) || isAdmin;
   const canEditSelected =
     selectedLanguage !== null && hasRights(editRights, selectedLanguage);
   const canPublishSelected =
@@ -350,10 +360,29 @@ export function LanguagesPage() {
             published: false,
           },
         },
-        { onSuccess: () => setSelectedLanguage(name) }
+        {
+          onSuccess: () => {
+            setSelectedLanguage(name);
+            // #247 — a bootstrap create auto-grants the creator both
+            // verbs on the new slug server-side, but the session user in
+            // the auth store still carries the pre-grant rights, and the
+            // page's list filter + edit gates read from it. Refresh so
+            // the draft the admin just created doesn't render read-only
+            // (or vanish from the list) until the next full reload. A
+            // failed refresh is left alone — rights arrive on any later
+            // session hydration, and a null (401) means the session died,
+            // which the next API call surfaces through the usual path.
+            void fetchMe().then(
+              (fresh) => {
+                if (fresh) setUser(fresh);
+              },
+              () => undefined
+            );
+          },
+        }
       );
     },
-    [saveLanguage, scaffoldQuery.data, setSelectedLanguage]
+    [saveLanguage, scaffoldQuery.data, setSelectedLanguage, setUser]
   );
 
   const handleSetPublished = useCallback(

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
+  applyLocalBootstrapGrant,
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
   filterByAnyRights,
@@ -362,34 +363,23 @@ export function LanguagesPage() {
         {
           onSuccess: () => {
             setSelectedLanguage(name);
-            // #247 — a bootstrap create auto-grants the creator both
+            // #247 — a BOOTSTRAP create auto-grants the creator both
             // verbs on the new slug server-side, but the session user in
             // the auth store still carries the pre-grant rights, and the
             // page's list filter + edit gates read from it. Mirror the
             // grant locally instead of refetching /me: KV read-after-
             // write isn't guaranteed, so an immediate refetch could
             // re-store the STALE pre-grant record (and a late-resolving
-            // refetch could repopulate the store after a logout). The
-            // effective* helpers apply the same partner-aware rule the
-            // worker grants under, so materializing their result + slug
-            // reproduces the server-side outcome; the next full session
-            // hydration converges on the server state either way.
+            // refetch could repopulate the store after a logout).
+            // applyLocalBootstrapGrant infers WHETHER the carve-out
+            // fired (null = ordinary create, worker granted nothing —
+            // mirroring then would invent permissions, #256 review
+            // round 2) and reproduces the server-side grant when it
+            // did; the next full session hydration converges on the
+            // server state either way.
             if (!isCrossOrg && user) {
-              const withSlug = (
-                rights: ReturnType<typeof effectiveLanguageEditRights>
-              ) =>
-                rights === undefined || rights === "*" || rights.includes(name)
-                  ? rights
-                  : [...rights, name];
-              setUser({
-                ...user,
-                language_edit_rights: withSlug(
-                  effectiveLanguageEditRights(user)
-                ),
-                language_publish_rights: withSlug(
-                  effectiveLanguagePublishRights(user)
-                ),
-              });
+              const granted = applyLocalBootstrapGrant(user, name);
+              if (granted) setUser(granted);
             }
           },
         }

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -8,7 +8,7 @@ import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
-  applyLocalBootstrapGrant,
+  mirrorBootstrapGrant,
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
   filterByAnyRights,
@@ -119,6 +119,14 @@ export function LanguagesPage() {
       ),
     };
   }, [languagesQuery.data, editRights, publishRights]);
+
+  // Every keystroke re-renders this page (the editor draft lives in
+  // component state), so the raw-name list for the create-dialog
+  // collision check must keep a stable identity between data changes.
+  const takenNames = useMemo(
+    () => languagesQuery.data?.languages.map((l) => l.name) ?? [],
+    [languagesQuery.data]
+  );
 
   // Local document draft (auto-save target).
   //
@@ -361,38 +369,31 @@ export function LanguagesPage() {
           },
         },
         {
-          onSuccess: () => {
+          onSuccess: (data) => {
             setSelectedLanguage(name);
-            // #247 — a BOOTSTRAP create auto-grants the creator both
-            // verbs on the new slug server-side, but the session user in
-            // the auth store still carries the pre-grant rights, and the
-            // page's list filter + edit gates read from it. Mirror the
-            // grant locally instead of refetching /me: KV read-after-
-            // write isn't guaranteed, so an immediate refetch could
-            // re-store the STALE pre-grant record (and a late-resolving
-            // refetch could repopulate the store after a logout).
-            // applyLocalBootstrapGrant infers WHETHER the carve-out
-            // fired (null = ordinary create, worker granted nothing —
-            // mirroring then would invent permissions, #256 review
-            // round 2) and reproduces the server-side grant when it
-            // did; the next full session hydration converges on the
-            // server state either way.
-            if (!isCrossOrg && user) {
-              const granted = applyLocalBootstrapGrant(user, name);
-              if (granted) setUser(granted);
+            // #247 — when the worker's bootstrap carve-out created this
+            // draft, it auto-granted the creator both verbs server-side,
+            // but the session user in the auth store still carries the
+            // pre-grant rights, and the page's list filter + edit gates
+            // read from it. Mirror the grant locally, keyed STRICTLY on
+            // the worker's X-Bootstrap-Grant signal — an ordinary create
+            // performs no server grant, and inferring the carve-out from
+            // the local rights snapshot broke under session skew and
+            // published:true shapes (#256 rds 2–3). Local mirror rather
+            // than a /me refetch because KV read-after-write isn't
+            // guaranteed: an immediate refetch could re-store the STALE
+            // pre-grant record. Read the store at callback time, not
+            // the render snapshot — a slow create must not clobber
+            // store writes that landed mid-flight (#256 rd-3).
+            if (data.bootstrapGranted && !isCrossOrg) {
+              const current = useAuthStore.getState().user;
+              if (current) setUser(mirrorBootstrapGrant(current, name));
             }
           },
         }
       );
     },
-    [
-      saveLanguage,
-      scaffoldQuery.data,
-      setSelectedLanguage,
-      setUser,
-      user,
-      isCrossOrg,
-    ]
+    [saveLanguage, scaffoldQuery.data, setSelectedLanguage, setUser, isCrossOrg]
   );
 
   const handleSetPublished = useCallback(
@@ -498,9 +499,7 @@ export function LanguagesPage() {
               canDeleteSelected={canDeleteSelected}
               isScaffoldReady={scaffoldQuery.isSuccess}
               scaffoldError={scaffoldQuery.isError}
-              takenNames={
-                languagesQuery.data?.languages.map((l) => l.name) ?? []
-              }
+              takenNames={takenNames}
             />
           </div>
 
@@ -580,7 +579,8 @@ export function LanguagesPage() {
           <EmptyState
             canCreate={canCreate}
             hasAny={(authorizedLanguagesData?.languages.length ?? 0) > 0}
-            hasHidden={(languagesQuery.data?.languages.length ?? 0) > 0}
+            hasHidden={takenNames.length > 0}
+            isAdmin={isAdmin}
           />
         ) : (
           <>
@@ -702,19 +702,32 @@ interface EmptyStateProps {
       even when drafts exist — telling them "No languages yet" would
       misrepresent the org and invite name collisions. */
   hasHidden: boolean;
+  /** Only admins may create a NEW name in an org whose drafts are all
+      hidden from them (the worker's carve-out is admin-only) — a
+      non-admin whose rights are all inert entries would 403 on any
+      new slug, so the copy must not invite them to create (#256 rd-2
+      F2). */
+  isAdmin: boolean;
 }
 
-function EmptyState({ canCreate, hasAny, hasHidden }: EmptyStateProps) {
+function EmptyState({
+  canCreate,
+  hasAny,
+  hasHidden,
+  isAdmin,
+}: EmptyStateProps) {
   return (
     <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
       <p className="text-sm">
         {hasAny
           ? "Pick a language above to start editing."
-          : canCreate
-            ? hasHidden
-              ? "This org has languages, but none you have access to. Create a new draft, or ask a shepherd or admin for access to an existing one."
-              : "No languages yet. Create one to get started."
-            : "No languages are available for your account."}
+          : hasHidden
+            ? isAdmin
+              ? "This org has languages, but none you have access to. Create a new draft, or ask a shepherd for access to an existing one."
+              : "This org has languages, but none you have access to. Ask a shepherd or admin for access."
+            : canCreate
+              ? "No languages yet. Create one to get started."
+              : "No languages are available for your account."}
       </p>
     </div>
   );

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
-import { fetchMe } from "@/lib/auth-api";
 import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import { LanguageForbiddenError } from "@/lib/languages-api";
@@ -366,23 +365,44 @@ export function LanguagesPage() {
             // #247 — a bootstrap create auto-grants the creator both
             // verbs on the new slug server-side, but the session user in
             // the auth store still carries the pre-grant rights, and the
-            // page's list filter + edit gates read from it. Refresh so
-            // the draft the admin just created doesn't render read-only
-            // (or vanish from the list) until the next full reload. A
-            // failed refresh is left alone — rights arrive on any later
-            // session hydration, and a null (401) means the session died,
-            // which the next API call surfaces through the usual path.
-            void fetchMe().then(
-              (fresh) => {
-                if (fresh) setUser(fresh);
-              },
-              () => undefined
-            );
+            // page's list filter + edit gates read from it. Mirror the
+            // grant locally instead of refetching /me: KV read-after-
+            // write isn't guaranteed, so an immediate refetch could
+            // re-store the STALE pre-grant record (and a late-resolving
+            // refetch could repopulate the store after a logout). The
+            // effective* helpers apply the same partner-aware rule the
+            // worker grants under, so materializing their result + slug
+            // reproduces the server-side outcome; the next full session
+            // hydration converges on the server state either way.
+            if (!isCrossOrg && user) {
+              const withSlug = (
+                rights: ReturnType<typeof effectiveLanguageEditRights>
+              ) =>
+                rights === undefined || rights === "*" || rights.includes(name)
+                  ? rights
+                  : [...rights, name];
+              setUser({
+                ...user,
+                language_edit_rights: withSlug(
+                  effectiveLanguageEditRights(user)
+                ),
+                language_publish_rights: withSlug(
+                  effectiveLanguagePublishRights(user)
+                ),
+              });
+            }
           },
         }
       );
     },
-    [saveLanguage, scaffoldQuery.data, setSelectedLanguage, setUser]
+    [
+      saveLanguage,
+      scaffoldQuery.data,
+      setSelectedLanguage,
+      setUser,
+      user,
+      isCrossOrg,
+    ]
   );
 
   const handleSetPublished = useCallback(
@@ -488,6 +508,9 @@ export function LanguagesPage() {
               canDeleteSelected={canDeleteSelected}
               isScaffoldReady={scaffoldQuery.isSuccess}
               scaffoldError={scaffoldQuery.isError}
+              takenNames={
+                languagesQuery.data?.languages.map((l) => l.name) ?? []
+              }
             />
           </div>
 
@@ -567,6 +590,7 @@ export function LanguagesPage() {
           <EmptyState
             canCreate={canCreate}
             hasAny={(authorizedLanguagesData?.languages.length ?? 0) > 0}
+            hasHidden={(languagesQuery.data?.languages.length ?? 0) > 0}
           />
         ) : (
           <>
@@ -681,17 +705,25 @@ export function LanguagesPage() {
 
 interface EmptyStateProps {
   canCreate: boolean;
+  /** The user's rights-filtered list has entries. */
   hasAny: boolean;
+  /** The org's RAW list has entries (visible to this user or not).
+      #247: an admin with no per-row rights sees an empty filtered list
+      even when drafts exist — telling them "No languages yet" would
+      misrepresent the org and invite name collisions. */
+  hasHidden: boolean;
 }
 
-function EmptyState({ canCreate, hasAny }: EmptyStateProps) {
+function EmptyState({ canCreate, hasAny, hasHidden }: EmptyStateProps) {
   return (
     <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
       <p className="text-sm">
         {hasAny
           ? "Pick a language above to start editing."
           : canCreate
-            ? "No languages yet. Create one to get started."
+            ? hasHidden
+              ? "This org has languages, but none you have access to. Create a new draft, or ask a shepherd or admin for access to an existing one."
+              : "No languages yet. Create one to get started."
             : "No languages are available for your account."}
       </p>
     </div>

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -38,7 +38,13 @@ export function ActivityBar() {
   // `hasAnyModeAccess` does NOT (modes had no per-row pre-#181 so
   // undefined-undefined means "no access" for non-admins), which is
   // why the Modes entry combines it with the admin trump.
-  const canAccessLanguages = hasAnyLanguageAccess(user);
+  //
+  // #247 — admins get the Languages entry regardless of per-row rights:
+  // the worker lets a same-org admin CREATE drafts that don't exist yet
+  // (breaking the no-rights-without-drafts bootstrap deadlock), so the
+  // entry point must be reachable. Existing drafts remain per-row-gated
+  // on the page and in the worker (PR #185 — no admin trump there).
+  const canAccessLanguages = isAdmin || hasAnyLanguageAccess(user);
   const canEditModes = isAdmin || hasAnyModeAccess(user);
 
   return (

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -59,6 +59,13 @@ interface LanguageSelectorProps {
       before the scaffold arrives would silently save a blank document. */
   isScaffoldReady: boolean;
   scaffoldError: boolean;
+  /** ALL language names in the org — unfiltered, unlike `languagesData`
+      (which the parent pre-filters to rows the user holds a verb on).
+      #247: admins can create drafts without holding rights on existing
+      rows, so their filtered list can be empty while names are taken; a
+      collision would otherwise surface as a bare worker 403 from an
+      affordance the UI offered. */
+  takenNames: string[];
 }
 
 function isPublished(lang: Pick<Language, "published">): boolean {
@@ -82,10 +89,12 @@ export function LanguageSelector({
   canDeleteSelected,
   isScaffoldReady,
   scaffoldError,
+  takenNames,
 }: LanguageSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
   const [newLabel, setNewLabel] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
 
   // Destructive-confirmation dialogs are controlled so we can keep them
   // open on async failure and render the error inline (#102). Closing on
@@ -133,11 +142,22 @@ export function LanguageSelector({
       .replace(/[^a-z0-9\-_]/g, "")
       .replace(/^-+|-+$/g, "");
     if (!slug) return;
+    // Collision check against the UNFILTERED org list: the rows the
+    // user can't see (no verb rights) still own their names, and the
+    // worker will 403 a PUT against them. Client-side only — the
+    // worker's existence probe remains the enforcement.
+    if (takenNames.includes(slug)) {
+      setCreateError(
+        `A language named "${slug}" already exists in this org. Pick a different name, or ask its shepherd (or an admin) for access.`
+      );
+      return;
+    }
     onCreateLanguage(slug, newLabel.trim());
     setNewName("");
     setNewLabel("");
     setShowCreate(false);
-  }, [newName, newLabel, onCreateLanguage]);
+    setCreateError(null);
+  }, [newName, newLabel, onCreateLanguage, takenNames]);
 
   return (
     <div className="space-y-3">
@@ -356,7 +376,10 @@ export function LanguageSelector({
               <Input
                 id="lang-name"
                 value={newName}
-                onChange={(e) => setNewName(e.target.value)}
+                onChange={(e) => {
+                  setNewName(e.target.value);
+                  setCreateError(null);
+                }}
                 placeholder="e.g. arabic"
                 className="h-8 text-sm"
               />
@@ -374,6 +397,11 @@ export function LanguageSelector({
               />
             </div>
           </div>
+          {createError && (
+            <p className="text-destructive mt-3 text-xs" role="alert">
+              {createError}
+            </p>
+          )}
           {!isScaffoldReady && (
             <p
               className={
@@ -393,7 +421,10 @@ export function LanguageSelector({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setShowCreate(false)}
+              onClick={() => {
+                setShowCreate(false);
+                setCreateError(null);
+              }}
             >
               Cancel
             </Button>

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { faLanguage } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Eye, EyeOff, Plus, Send, SendHorizontal, Trash2 } from "lucide-react";
@@ -125,7 +125,13 @@ export function LanguageSelector({
     );
   }, [onDeleteLanguage, selectedLanguage]);
 
-  const languages = languagesData?.languages ?? [];
+  // Memoized: handleCreate's collision check depends on this, and the
+  // `?? []` fallback would otherwise mint a fresh array identity every
+  // render (react-hooks/exhaustive-deps).
+  const languages = useMemo(
+    () => languagesData?.languages ?? [],
+    [languagesData]
+  );
   const selectedData =
     languages.find((l) => l.name === selectedLanguage) ?? null;
   const selectedIsPublished = selectedData ? isPublished(selectedData) : false;
@@ -142,13 +148,18 @@ export function LanguageSelector({
       .replace(/[^a-z0-9\-_]/g, "")
       .replace(/^-+|-+$/g, "");
     if (!slug) return;
-    // Collision check against the UNFILTERED org list: the rows the
-    // user can't see (no verb rights) still own their names, and the
-    // worker will 403 a PUT against them. Client-side only — the
-    // worker's existence probe remains the enforcement.
-    if (takenNames.includes(slug)) {
+    // Collision check against the UNFILTERED org list, but only for
+    // names HIDDEN from this user: rows they hold no verb on still own
+    // their names, and the worker will 403 a PUT against them — without
+    // this, the create affordance hands an admin with an empty filtered
+    // list a bare "Forbidden". Names in the user's own (filtered) list
+    // pass through: a rights-holding shepherd re-creating their own
+    // language is the pre-existing PUT-over-existing re-scaffold flow,
+    // not a permission error (#256 rd-3). Client-side only — the
+    // worker's gate remains the enforcement.
+    if (takenNames.includes(slug) && !languages.some((l) => l.name === slug)) {
       setCreateError(
-        `A language named "${slug}" already exists in this org. Pick a different name, or ask its shepherd (or an admin) for access.`
+        `A language named "${slug}" already exists in this org, but you don't have access to it. Pick a different name, or ask a shepherd or admin for access.`
       );
       return;
     }
@@ -157,7 +168,7 @@ export function LanguageSelector({
     setNewLabel("");
     setShowCreate(false);
     setCreateError(null);
-  }, [newName, newLabel, onCreateLanguage, takenNames]);
+  }, [newName, newLabel, onCreateLanguage, takenNames, languages]);
 
   return (
     <div className="space-y-3">

--- a/src/lib/language-bootstrap-gate.ts
+++ b/src/lib/language-bootstrap-gate.ts
@@ -1,5 +1,6 @@
 import {
   effectiveLanguageEditRights,
+  hasAdminPowers,
   hasAnyRights,
   type LanguageRightsCarrier,
 } from "./permissions";
@@ -37,16 +38,23 @@ export function isCrossOrgTarget({
 }
 
 interface Args extends CrossOrgArgs {
-  caller: LanguageRightsCarrier | null | undefined;
+  caller:
+    | (LanguageRightsCarrier & { isAdmin?: boolean; isSuperAdmin?: boolean })
+    | null
+    | undefined;
 }
 
 // #247: true when the caller can create the FIRST language draft in
 // `targetOrg`. Mirrors the Languages page's `canCreate` gate:
 //   - Cross-org super-admin: bypasses per-row rights via worker's PR A
 //     carve-out (#166).
-//   - Everyone else (home-org, or same-org super-admin): needs some
-//     effective `language_edit_rights` — undefined counts as legacy
-//     full access, [] doesn't.
+//   - Same-org admins: always — the worker's bootstrap carve-out lets
+//     them create drafts that don't exist yet (and auto-grants both
+//     verbs). Added with the carve-out itself (#256 rd-2 F4: this gate
+//     had drifted from the page's canCreate, hiding the empty-drafts
+//     CTA from exactly the zero-rights-admin population #247 unblocks).
+//   - Everyone else: needs some effective `language_edit_rights` —
+//     undefined counts as legacy full access, [] doesn't.
 export function canBootstrapLanguage({
   caller,
   callerOrg,
@@ -63,5 +71,7 @@ export function canBootstrapLanguage({
   if (isCrossOrgTarget({ callerOrg, callerIsSuperAdmin, targetOrg })) {
     return true;
   }
-  return hasAnyRights(effectiveLanguageEditRights(caller));
+  return (
+    hasAdminPowers(caller) || hasAnyRights(effectiveLanguageEditRights(caller))
+  );
 }

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -66,6 +66,17 @@ export async function getLanguage(
   return data as unknown as Language;
 }
 
+// #247 — a PUT that created the language via the worker's admin
+// bootstrap carve-out comes back flagged (X-Bootstrap-Grant header):
+// the worker auto-granted the caller edit + publish on the new slug,
+// and the client mirrors that into its session user. An explicit wire
+// signal, NOT client-side inference — inferring the carve-out from the
+// local rights snapshot broke under session skew and published:true
+// shapes (#256 review rounds 2–3).
+export interface PutLanguageResult extends Language {
+  bootstrapGranted: boolean;
+}
+
 export async function putLanguage(
   name: string,
   body: {
@@ -75,7 +86,7 @@ export async function putLanguage(
   },
   signal?: AbortSignal,
   org?: string | null
-): Promise<Language> {
+): Promise<PutLanguageResult> {
   const res = await fetch(
     buildConfigUrl(`/api/config/languages/${encodeURIComponent(name)}`, org),
     {
@@ -94,14 +105,15 @@ export async function putLanguage(
     throw new Error(`Failed to save language (${res.status}): ${text}`);
   }
 
+  const bootstrapGranted = res.headers.get("X-Bootstrap-Grant") === "1";
   const data = (await res.json()) as Record<string, unknown>;
 
   // Worker wraps PUT response as { org, language, message }. Unwrap to
   // match getLanguage so callers consistently get a Language object.
   if ("language" in data && typeof data.language === "object") {
-    return data.language as Language;
+    return { ...(data.language as Language), bootstrapGranted };
   }
-  return data as unknown as Language;
+  return { ...(data as unknown as Language), bootstrapGranted };
 }
 
 export async function deleteLanguage(

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -91,35 +91,30 @@ export function effectiveLanguagePublishRights(
   return user.language_rights;
 }
 
-// #247 — mirror the worker's bootstrap auto-grant into the local session
-// user after a successful same-org language create, WITHOUT a wire signal.
-// The inference: creation demands edit rights on the slug, so a create
-// that succeeded while the user's effective edit rights did NOT cover it
-// can only have passed via the admin bootstrap carve-out — which is
-// exactly (and only) when the worker grants the creator both verbs. If
-// edit already covered the slug, the ordinary gate passed and the worker
-// granted nothing; mirroring anyway would invent local permissions (e.g.
-// publish for an edit-"*"/publish-[] admin) whose controls then 403
-// (#256 review round 2).
+// #247 — mirror the worker's bootstrap auto-grant (both verbs on `slug`)
+// into the local session user. Call ONLY when the worker signalled the
+// grant (X-Bootstrap-Grant on the create response → `bootstrapGranted`
+// on PutLanguageResult) — this helper deliberately performs no
+// inference about whether a grant occurred: every inference variant
+// broke under some rights shape (session skew after a mid-session
+// grant, published:true creates; #256 review rounds 2–3).
 //
-// Returns the updated user, or null when no grant occurred. Wildcard /
-// undefined (full-access) fields pass through untouched, matching the
-// server-side grant's no-op rule.
-export function applyLocalBootstrapGrant<T extends LanguageRightsCarrier>(
+// Materializes via the partner-aware effective* helpers so the local
+// result matches what the worker's grant wrote (worker/rights-migration
+// grantLanguageSlugToUser). Wildcard / undefined (full-access) fields
+// pass through untouched, matching the server-side grant's no-op rule.
+export function mirrorBootstrapGrant<T extends LanguageRightsCarrier>(
   user: T,
   slug: string
-): T | null {
-  const edit = effectiveLanguageEditRights(user);
-  if (hasRights(edit, slug)) return null;
-  const publish = effectiveLanguagePublishRights(user);
+): T {
   const withSlug = (rights: LanguageRights | undefined) =>
     rights === undefined || rights === "*" || rights.includes(slug)
       ? rights
       : [...rights, slug];
   return {
     ...user,
-    language_edit_rights: withSlug(edit),
-    language_publish_rights: withSlug(publish),
+    language_edit_rights: withSlug(effectiveLanguageEditRights(user)),
+    language_publish_rights: withSlug(effectiveLanguagePublishRights(user)),
   };
 }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -91,6 +91,38 @@ export function effectiveLanguagePublishRights(
   return user.language_rights;
 }
 
+// #247 — mirror the worker's bootstrap auto-grant into the local session
+// user after a successful same-org language create, WITHOUT a wire signal.
+// The inference: creation demands edit rights on the slug, so a create
+// that succeeded while the user's effective edit rights did NOT cover it
+// can only have passed via the admin bootstrap carve-out — which is
+// exactly (and only) when the worker grants the creator both verbs. If
+// edit already covered the slug, the ordinary gate passed and the worker
+// granted nothing; mirroring anyway would invent local permissions (e.g.
+// publish for an edit-"*"/publish-[] admin) whose controls then 403
+// (#256 review round 2).
+//
+// Returns the updated user, or null when no grant occurred. Wildcard /
+// undefined (full-access) fields pass through untouched, matching the
+// server-side grant's no-op rule.
+export function applyLocalBootstrapGrant<T extends LanguageRightsCarrier>(
+  user: T,
+  slug: string
+): T | null {
+  const edit = effectiveLanguageEditRights(user);
+  if (hasRights(edit, slug)) return null;
+  const publish = effectiveLanguagePublishRights(user);
+  const withSlug = (rights: LanguageRights | undefined) =>
+    rights === undefined || rights === "*" || rights.includes(slug)
+      ? rights
+      : [...rights, slug];
+  return {
+    ...user,
+    language_edit_rights: withSlug(edit),
+    language_publish_rights: withSlug(publish),
+  };
+}
+
 export function effectiveModeEditRights(
   user:
     | {

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1344,8 +1344,12 @@ describe("PUT gate — thrown engine GET propagates (rd-5 parity)", () => {
 interface SeedRightsUser {
   email: string;
   org: string;
+  isAdmin?: boolean;
   mode_edit_rights?: StoredUser["mode_edit_rights"];
   mode_publish_rights?: StoredUser["mode_publish_rights"];
+  language_rights?: StoredUser["language_rights"];
+  language_edit_rights?: StoredUser["language_edit_rights"];
+  language_publish_rights?: StoredUser["language_publish_rights"];
 }
 
 async function seedRightsUser(input: SeedRightsUser): Promise<void> {
@@ -1358,9 +1362,12 @@ async function seedRightsUser(input: SeedRightsUser): Promise<void> {
     // the seed cheap (no PBKDF2 per test).
     passwordHash: "x",
     salt: "x",
-    isAdmin: false,
+    isAdmin: input.isAdmin ?? false,
     mode_edit_rights: input.mode_edit_rights,
     mode_publish_rights: input.mode_publish_rights,
+    language_rights: input.language_rights,
+    language_edit_rights: input.language_edit_rights,
+    language_publish_rights: input.language_publish_rights,
   };
   await env.AUTH_KV.put(`user:${input.email}`, JSON.stringify(stored));
 }
@@ -2313,7 +2320,14 @@ describe("config authz — cross-org via ?org= (#166)", () => {
       "/api/config/languages/english"
     );
     expect(res.status).toBe(403);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    // One fetch: the #247 bootstrap carve-out's existence probe (the
+    // caller has admin powers and zero rights on this row). The spy's
+    // 200 reads as "exists", so the carve-out declines — the proxy PUT
+    // must never fire.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (fetchSpy.mock.calls[0]![1] as RequestInit | undefined)?.method
+    ).toBeUndefined();
   });
 
   it("super-admin with ?org=<own org> + matching language_rights → 200 (treated as same-org)", async () => {
@@ -2362,7 +2376,13 @@ describe("config authz — cross-org via ?org= (#166)", () => {
       "/api/config/languages/english"
     );
     expect(res.status).toBe(403);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    // Same-org admin + zero rights on the row → the #247 carve-out
+    // probes existence once; the spy's 200 reads as "exists" so the
+    // deny stands and the proxy PUT never fires.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (fetchSpy.mock.calls[0]![1] as RequestInit | undefined)?.method
+    ).toBeUndefined();
   });
 
   it("super-admin GET languages list with ?org=other → proxies to /orgs/other/languages", async () => {
@@ -2764,5 +2784,334 @@ describe("config authz — same-org ?org= (#247)", () => {
     expect(String(fetchSpy.mock.calls[0]![0])).toContain(
       "/api/v1/admin/orgs/ACME/languages"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #247 — language bootstrap create carve-out
+// ---------------------------------------------------------------------------
+//
+// A same-org admin with NO per-row language rights may CREATE a language
+// that doesn't exist yet; the worker auto-grants them both verbs on the
+// new slug before the engine call. Everything else about the PR #185
+// "no admin trump on languages" rule stays intact: existing rows,
+// DELETE, non-admins, and any ambiguous engine state all still 403.
+
+// First fetch = the gate's existence probe, second = the proxy PUT.
+function spyFetchBootstrap(
+  probe: () => Promise<Response>,
+  proxy: () => Promise<Response> = () =>
+    Promise.resolve(new Response("{}", { status: 200 }))
+) {
+  let call = 0;
+  return vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+    call++;
+    return call === 1 ? probe() : proxy();
+  });
+}
+
+function makeCreateRequest(name: string): Request {
+  return new Request(
+    `https://portal.example.test/api/config/languages/${name}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ document: "## Identity\n", published: false }),
+    }
+  );
+}
+
+const missing = () => Promise.resolve(new Response("", { status: 404 }));
+
+describe("#247 language bootstrap create", () => {
+  it("same-org admin with explicit empty rights + missing language → 200, creator granted both verbs", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    const fetchSpy = spyFetchBootstrap(missing);
+
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect((fetchSpy.mock.calls[1]![1] as RequestInit).method).toBe("PUT");
+
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual(["swahili"]);
+    expect(after.language_publish_rights).toEqual(["swahili"]);
+  });
+
+  it("grant materializes from restricted legacy language_rights", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_rights: ["en"],
+    });
+    const fetchSpy = spyFetchBootstrap(missing);
+
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_rights: ["en"],
+        // validateSession lazy-migrates legacy → verb fields on the
+        // session; mirror that here so the gate sees what it would in
+        // production.
+        language_edit_rights: ["en"],
+        language_publish_rights: ["en"],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual(["en", "swahili"]);
+    expect(after.language_publish_rights).toEqual(["en", "swahili"]);
+    expect(after.language_rights).toEqual(["en"]);
+  });
+
+  it("existing language → 403, no grant, no proxy (PR #185 rule intact)", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    const fetchSpy = spyFetchBootstrap(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ language: { document: "x" } }), {
+          status: 200,
+        })
+      )
+    );
+
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual([]);
+  });
+
+  it("existence probe 5xx → 403 (fail closed)", async () => {
+    const fetchSpy = spyFetchBootstrap(() =>
+      Promise.resolve(new Response("", { status: 500 }))
+    );
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("existence probe throws → 403 (fail closed)", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.reject(new Error("network down")));
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-admin with empty rights → 403 before any engine traffic", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        isAdmin: false,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("admin DELETE without rights → 403 (carve-out is PUT-only)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("DELETE", "/api/config/languages/swahili"),
+      env,
+      makeSession({
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("engine rejects the create with 4xx → grant compensated", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    const fetchSpy = spyFetchBootstrap(missing, () =>
+      Promise.resolve(new Response("bad name", { status: 400 }))
+    );
+
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual([]);
+    expect(after.language_publish_rights).toEqual([]);
+  });
+
+  it("engine 5xx on the create → grant kept (ambiguity never contracts)", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    spyFetchBootstrap(missing, () =>
+      Promise.resolve(new Response("", { status: 500 }))
+    );
+
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(500);
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual(["swahili"]);
+    expect(after.language_publish_rights).toEqual(["swahili"]);
+  });
+
+  it("stored user missing at grant time → 502, engine never called", async () => {
+    // No seed for this email — grant aborts the create.
+    const fetchSpy = spyFetchBootstrap(missing);
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "ghost@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(502);
+    // Only the existence probe fired; the proxy PUT never did.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("bootstrap create with published: true → allowed (creator holds both verbs)", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    const fetchSpy = spyFetchBootstrap(missing);
+
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/swahili", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "## Identity\n", published: true }),
+      }),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalid JSON body on the carve-out path → 400", async () => {
+    const fetchSpy = spyFetchBootstrap(missing);
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/swahili", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      }),
+      env,
+      makeSession({
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -3123,6 +3123,170 @@ describe("#247 language bootstrap create", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("zero-rights admin, EXISTING row, empty-diff body → 403, no proxy (#256 rd-2/rd-3 F0)", async () => {
+    // The widening both later review rounds confirmed: a body echoing
+    // the current state (or omitting fields) computes ZERO required
+    // verbs, and without the zeroRightsOnRow guard the gate returned
+    // ok — putting an engine write on a row PR #185 says a zero-rights
+    // admin must never touch. Main answered 403.
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    const currentDoc = "## Identity\n";
+    const fetchSpy = spyFetchBootstrap(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            language: { document: currentDoc, published: false },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/english", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        // Exactly equals the mocked current state → zero required verbs.
+        body: JSON.stringify({ document: currentDoc, published: false }),
+      }),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/english"
+    );
+    expect(res.status).toBe(403);
+    // Only the existence probe fired — the proxy PUT never did.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // And no grant was written.
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual([]);
+  });
+
+  it("zero-rights admin, MISSING row, empty body {} → still a bootstrap create with grant (not an ungoverned pass-through)", async () => {
+    // An empty body against a missing row also computes zero required
+    // verbs; the zeroRightsOnRow guard must route it through the
+    // carve-out (grant + flag), never the ordinary allow.
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    const fetchSpy = spyFetchBootstrap(missing);
+
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/swahili", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual(["swahili"]);
+    expect(after.language_publish_rights).toEqual(["swahili"]);
+  });
+
+  it("bootstrap create response carries X-Bootstrap-Grant: 1", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    spyFetchBootstrap(missing);
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
+  });
+
+  it("ORDINARY create (edit wildcard) → no header, no grant (#256 rd-3: the client mirror keys on this)", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: "*",
+      language_publish_rights: [],
+    });
+    const fetchSpy = spyFetchBootstrap(missing);
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: "*",
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const after = await readRightsUser("admin@acme.com");
+    // No grant: publish stays an explicit deny.
+    expect(after.language_edit_rights).toBe("*");
+    expect(after.language_publish_rights).toEqual([]);
+  });
+
+  it("engine 4xx on a bootstrap create → no X-Bootstrap-Grant header alongside the compensation", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    spyFetchBootstrap(missing, () =>
+      Promise.resolve(new Response("bad", { status: 400 }))
+    );
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: [],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(400);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
+  });
+
   it("mixed shape edit=[] + publish='*' → carve-out still reachable on a missing name (#256 review F2)", async () => {
     // The wildcard on one verb bypasses the zero-rights early-deny, so
     // the carve-out must live on the PUT diff's deny path — nested

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -2366,7 +2366,11 @@ describe("config authz — cross-org via ?org= (#166)", () => {
   it("no ?org= + non-super with restricted language_rights → still 403 (same-org gate intact)", async () => {
     const fetchSpy = spyFetch();
     const res = await handleConfig(
-      makeRequest("PUT", "/api/config/languages/english"),
+      new Request("https://portal.example.test/api/config/languages/english", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: "# English\n" }),
+      }),
       env,
       makeSession({
         org: "acme",
@@ -2938,21 +2942,24 @@ describe("#247 language bootstrap create", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("existence probe throws → 403 (fail closed)", async () => {
+  it("existence probe throws → request fails, no grant, no proxy (rd-5 parity)", async () => {
+    // Thrown fetch propagates on the PUT path, same as for rights-
+    // holding callers — still fail-closed: nothing is mutated.
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockImplementation(() => Promise.reject(new Error("network down")));
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(403);
+    await expect(
+      handleConfig(
+        makeCreateRequest("swahili"),
+        env,
+        makeSession({
+          isAdmin: true,
+          language_edit_rights: [],
+          language_publish_rights: [],
+        }),
+        "/api/config/languages/swahili"
+      )
+    ).rejects.toThrow("network down");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -3095,7 +3102,7 @@ describe("#247 language bootstrap create", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("invalid JSON body on the carve-out path → 400", async () => {
+  it("invalid JSON body on the carve-out path → 400 before any engine traffic", async () => {
     const fetchSpy = spyFetchBootstrap(missing);
     const res = await handleConfig(
       new Request("https://portal.example.test/api/config/languages/swahili", {
@@ -3112,6 +3119,76 @@ describe("#247 language bootstrap create", () => {
       "/api/config/languages/swahili"
     );
     expect(res.status).toBe(400);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // Body parse precedes the existence probe on the PUT path.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("mixed shape edit=[] + publish='*' → carve-out still reachable on a missing name (#256 review F2)", async () => {
+    // The wildcard on one verb bypasses the zero-rights early-deny, so
+    // the carve-out must live on the PUT diff's deny path — nested
+    // inside early-deny it never ran for this shape and the bootstrap
+    // deadlock persisted.
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_edit_rights: [],
+      language_publish_rights: "*",
+    });
+    const fetchSpy = spyFetchBootstrap(missing);
+
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_edit_rights: [],
+        language_publish_rights: "*",
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual(["swahili"]);
+    // The wildcard side needs no entry and must not be narrowed.
+    expect(after.language_publish_rights).toBe("*");
+  });
+
+  it("partner-deny shape (publish explicit, edit unset) → creator granted BOTH verbs, legacy never leaks (#256 review F1)", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_rights: ["x"],
+      language_publish_rights: ["x"],
+    });
+    const fetchSpy = spyFetchBootstrap(missing);
+
+    const res = await handleConfig(
+      makeCreateRequest("swahili"),
+      env,
+      // Session mirrors lazyMigrateLanguageRights: explicit publish,
+      // partner-denied edit ([]), legacy carried alongside.
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        language_rights: ["x"],
+        language_edit_rights: [],
+        language_publish_rights: ["x"],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const after = await readRightsUser("admin@acme.com");
+    // Edit was a deliberate deny: it materializes as [slug] only — the
+    // legacy "x" must NOT reappear (that would durably restore revoked
+    // access; the escalation face of review F1).
+    expect(after.language_edit_rights).toEqual(["swahili"]);
+    expect(after.language_publish_rights).toEqual(["x", "swahili"]);
   });
 });

--- a/tests/language-bootstrap-gate.test.ts
+++ b/tests/language-bootstrap-gate.test.ts
@@ -302,3 +302,55 @@ describe("isCrossOrgTarget", () => {
     ).toBe(false);
   });
 });
+
+// #256 rd-2 F4 — the gate must include the same-org admin trump the
+// Languages page's canCreate gained with the #247 worker carve-out;
+// without it the empty-drafts CTA hides from exactly the zero-rights
+// admins the carve-out unblocks.
+
+describe("canBootstrapLanguage — same-org admin trump (#247 carve-out)", () => {
+  it("same-org admin with explicit empty rights → true", () => {
+    expect(
+      canBootstrapLanguage({
+        caller: {
+          isAdmin: true,
+          language_edit_rights: [],
+          language_publish_rights: [],
+        },
+        callerOrg: "acme",
+        callerIsSuperAdmin: false,
+        targetOrg: "acme",
+      })
+    ).toBe(true);
+  });
+
+  it("same-org super-admin with explicit empty rights → true (admin powers, not the cross-org trump)", () => {
+    expect(
+      canBootstrapLanguage({
+        caller: {
+          isSuperAdmin: true,
+          language_edit_rights: [],
+          language_publish_rights: [],
+        },
+        callerOrg: "acme",
+        callerIsSuperAdmin: true,
+        targetOrg: "acme",
+      })
+    ).toBe(true);
+  });
+
+  it("non-admin with explicit empty rights → false (worker would 403 their create)", () => {
+    expect(
+      canBootstrapLanguage({
+        caller: {
+          isAdmin: false,
+          language_edit_rights: [],
+          language_publish_rights: [],
+        },
+        callerOrg: "acme",
+        callerIsSuperAdmin: false,
+        targetOrg: "acme",
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -48,7 +48,29 @@ describe("putLanguage", () => {
       label: "Arabic",
       document: "## Tone\n",
       published: false,
+      // #247 — no X-Bootstrap-Grant header on the mocked response.
+      bootstrapGranted: false,
     });
+  });
+
+  it("surfaces the worker's X-Bootstrap-Grant header as bootstrapGranted", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          org: "uw",
+          language: { name: "swahili", document: "## Tone\n" },
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Bootstrap-Grant": "1",
+          },
+        }
+      )
+    );
+    const result = await putLanguage("swahili", { document: "## Tone\n" });
+    expect(result.bootstrapGranted).toBe(true);
   });
 
   it("returns an already-unwrapped response unchanged (back-compat)", async () => {

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  applyLocalBootstrapGrant,
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
   effectiveModeEditRights,
@@ -393,5 +394,92 @@ describe("renameSlugInRights (#240 client mirror)", () => {
   it("wildcard and undefined pass through", () => {
     expect(renameSlugInRights("*", "spoken", "conv")).toBe("*");
     expect(renameSlugInRights(undefined, "spoken", "conv")).toBeUndefined();
+  });
+});
+
+// #247 / #256 review round 2 — local mirror of the worker's bootstrap
+// auto-grant. The null-vs-grant split is the whole point: mirroring
+// after an ORDINARY create (edit rights already covered the slug, so
+// the worker granted nothing) invents local permissions whose controls
+// then 403.
+
+describe("applyLocalBootstrapGrant", () => {
+  it("null when effective edit already covers the slug — ordinary create, worker granted nothing", async () => {
+    // The review-round-2 scenario: edit "*" passes the ordinary gate;
+    // publish [] must NOT gain the slug locally.
+    expect(
+      applyLocalBootstrapGrant(
+        { language_edit_rights: "*", language_publish_rights: [] },
+        "sw"
+      )
+    ).toBeNull();
+    // Legacy full-access user (all fields unset).
+    expect(applyLocalBootstrapGrant({}, "sw")).toBeNull();
+    // Explicit array already naming the slug.
+    expect(
+      applyLocalBootstrapGrant(
+        { language_edit_rights: ["sw"], language_publish_rights: [] },
+        "sw"
+      )
+    ).toBeNull();
+  });
+
+  it("mirrors both verbs after a carve-out create (explicit empty rights)", () => {
+    expect(
+      applyLocalBootstrapGrant(
+        { language_edit_rights: [], language_publish_rights: [] },
+        "sw"
+      )
+    ).toEqual({
+      language_edit_rights: ["sw"],
+      language_publish_rights: ["sw"],
+    });
+  });
+
+  it("split wildcard: edit [] + publish '*' → edit gains the slug, wildcard untouched", () => {
+    expect(
+      applyLocalBootstrapGrant(
+        { language_edit_rights: [], language_publish_rights: "*" },
+        "sw"
+      )
+    ).toEqual({ language_edit_rights: ["sw"], language_publish_rights: "*" });
+  });
+
+  it("partner-deny shape: publish explicit, edit unset → edit materializes [slug], not legacy", () => {
+    expect(
+      applyLocalBootstrapGrant(
+        { language_rights: ["x"], language_publish_rights: ["x"] },
+        "sw"
+      )
+    ).toEqual({
+      language_rights: ["x"],
+      language_edit_rights: ["sw"],
+      language_publish_rights: ["x", "sw"],
+    });
+  });
+
+  it("restricted legacy-only user → both verbs materialize legacy + slug (matches server grant)", () => {
+    expect(applyLocalBootstrapGrant({ language_rights: ["en"] }, "sw")).toEqual(
+      {
+        language_rights: ["en"],
+        language_edit_rights: ["en", "sw"],
+        language_publish_rights: ["en", "sw"],
+      }
+    );
+  });
+
+  it("preserves unrelated fields on the user object", () => {
+    const user = {
+      email: "a@acme.com",
+      isAdmin: true,
+      language_edit_rights: [] as string[],
+      language_publish_rights: [] as string[],
+    };
+    expect(applyLocalBootstrapGrant(user, "sw")).toMatchObject({
+      email: "a@acme.com",
+      isAdmin: true,
+    });
+    // Input is not mutated.
+    expect(user.language_edit_rights).toEqual([]);
   });
 });

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  applyLocalBootstrapGrant,
+  mirrorBootstrapGrant,
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
   effectiveModeEditRights,
@@ -397,37 +397,44 @@ describe("renameSlugInRights (#240 client mirror)", () => {
   });
 });
 
-// #247 / #256 review round 2 — local mirror of the worker's bootstrap
-// auto-grant. The null-vs-grant split is the whole point: mirroring
-// after an ORDINARY create (edit rights already covered the slug, so
-// the worker granted nothing) invents local permissions whose controls
-// then 403.
+// #247 / #256 rds 2-3 — local mirror of the worker's bootstrap
+// auto-grant, driven strictly by the worker's X-Bootstrap-Grant wire
+// signal (no client-side inference — every inference variant broke
+// under some rights shape: session skew, published:true creates).
+// These tests pin that the mirror reproduces exactly what the
+// server-side grant wrote for each shape.
 
-describe("applyLocalBootstrapGrant", () => {
-  it("null when effective edit already covers the slug — ordinary create, worker granted nothing", async () => {
-    // The review-round-2 scenario: edit "*" passes the ordinary gate;
-    // publish [] must NOT gain the slug locally.
+describe("mirrorBootstrapGrant", () => {
+  it("mirrors both verbs (explicit empty rights)", () => {
     expect(
-      applyLocalBootstrapGrant(
-        { language_edit_rights: "*", language_publish_rights: [] },
+      mirrorBootstrapGrant(
+        { language_edit_rights: [], language_publish_rights: [] },
         "sw"
       )
-    ).toBeNull();
-    // Legacy full-access user (all fields unset).
-    expect(applyLocalBootstrapGrant({}, "sw")).toBeNull();
-    // Explicit array already naming the slug.
-    expect(
-      applyLocalBootstrapGrant(
-        { language_edit_rights: ["sw"], language_publish_rights: [] },
-        "sw"
-      )
-    ).toBeNull();
+    ).toEqual({
+      language_edit_rights: ["sw"],
+      language_publish_rights: ["sw"],
+    });
   });
 
-  it("mirrors both verbs after a carve-out create (explicit empty rights)", () => {
+  it("full-access fields pass through untouched (server grant no-ops too)", () => {
     expect(
-      applyLocalBootstrapGrant(
-        { language_edit_rights: [], language_publish_rights: [] },
+      mirrorBootstrapGrant(
+        { language_edit_rights: "*", language_publish_rights: "*" },
+        "sw"
+      )
+    ).toEqual({ language_edit_rights: "*", language_publish_rights: "*" });
+    // Legacy full-access user (all fields unset) → stays unset.
+    expect(mirrorBootstrapGrant({}, "sw")).toEqual({
+      language_edit_rights: undefined,
+      language_publish_rights: undefined,
+    });
+  });
+
+  it("idempotent when a verb already names the slug", () => {
+    expect(
+      mirrorBootstrapGrant(
+        { language_edit_rights: ["sw"], language_publish_rights: [] },
         "sw"
       )
     ).toEqual({
@@ -438,7 +445,7 @@ describe("applyLocalBootstrapGrant", () => {
 
   it("split wildcard: edit [] + publish '*' → edit gains the slug, wildcard untouched", () => {
     expect(
-      applyLocalBootstrapGrant(
+      mirrorBootstrapGrant(
         { language_edit_rights: [], language_publish_rights: "*" },
         "sw"
       )
@@ -447,7 +454,7 @@ describe("applyLocalBootstrapGrant", () => {
 
   it("partner-deny shape: publish explicit, edit unset → edit materializes [slug], not legacy", () => {
     expect(
-      applyLocalBootstrapGrant(
+      mirrorBootstrapGrant(
         { language_rights: ["x"], language_publish_rights: ["x"] },
         "sw"
       )
@@ -459,27 +466,24 @@ describe("applyLocalBootstrapGrant", () => {
   });
 
   it("restricted legacy-only user → both verbs materialize legacy + slug (matches server grant)", () => {
-    expect(applyLocalBootstrapGrant({ language_rights: ["en"] }, "sw")).toEqual(
-      {
-        language_rights: ["en"],
-        language_edit_rights: ["en", "sw"],
-        language_publish_rights: ["en", "sw"],
-      }
-    );
+    expect(mirrorBootstrapGrant({ language_rights: ["en"] }, "sw")).toEqual({
+      language_rights: ["en"],
+      language_edit_rights: ["en", "sw"],
+      language_publish_rights: ["en", "sw"],
+    });
   });
 
-  it("preserves unrelated fields on the user object", () => {
+  it("preserves unrelated fields and does not mutate the input", () => {
     const user = {
       email: "a@acme.com",
       isAdmin: true,
       language_edit_rights: [] as string[],
       language_publish_rights: [] as string[],
     };
-    expect(applyLocalBootstrapGrant(user, "sw")).toMatchObject({
+    expect(mirrorBootstrapGrant(user, "sw")).toMatchObject({
       email: "a@acme.com",
       isAdmin: true,
     });
-    // Input is not mutated.
     expect(user.language_edit_rights).toEqual([]);
   });
 });

--- a/tests/rights-migration.test.ts
+++ b/tests/rights-migration.test.ts
@@ -12,7 +12,10 @@ import {
   contractOrgModeRights,
   expandOrgModeRights,
   expandRights,
+  grantLanguageSlugToUser,
+  grantSlug,
   removeSlugIfPartnerPresent,
+  revokeLanguageSlugFromUser,
 } from "../worker/rights-migration";
 import type { StoredUser } from "../worker/types";
 
@@ -96,7 +99,14 @@ async function seed(
   email: string,
   org: string,
   fields: Partial<
-    Pick<StoredUser, "mode_edit_rights" | "mode_publish_rights">
+    Pick<
+      StoredUser,
+      | "mode_edit_rights"
+      | "mode_publish_rights"
+      | "language_rights"
+      | "language_edit_rights"
+      | "language_publish_rights"
+    >
   > = {}
 ): Promise<string> {
   const key = `user:${email}`;
@@ -291,5 +301,105 @@ describe("contractOrgModeRights", () => {
         "b"
       )
     ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #247 — bootstrap auto-grant (single-user, both language verb fields)
+// ---------------------------------------------------------------------------
+
+describe("grantSlug", () => {
+  it("appends to an explicit array, ignoring the fallback", () => {
+    expect(grantSlug([], ["legacy"], "swahili")).toEqual(["swahili"]);
+    expect(grantSlug(["en"], undefined, "swahili")).toEqual(["en", "swahili"]);
+  });
+
+  it("materializes from the legacy fallback when the field is unset", () => {
+    // Mirrors worker/auth.ts lazy migration: explicit ?? legacy.
+    expect(grantSlug(undefined, ["en"], "swahili")).toEqual(["en", "swahili"]);
+    expect(grantSlug(undefined, [], "swahili")).toEqual(["swahili"]);
+  });
+
+  it("null when effective rights are already full (undefined / '*')", () => {
+    expect(grantSlug(undefined, undefined, "swahili")).toBeNull();
+    expect(grantSlug("*", [], "swahili")).toBeNull();
+    expect(grantSlug(undefined, "*", "swahili")).toBeNull();
+  });
+
+  it("null when the slug is already held (idempotent)", () => {
+    expect(grantSlug(["swahili"], undefined, "swahili")).toBeNull();
+    expect(grantSlug(undefined, ["swahili"], "swahili")).toBeNull();
+  });
+});
+
+describe("grantLanguageSlugToUser", () => {
+  it("grants both verb fields and returns the modified fields", async () => {
+    await seed("boot@acme.com", "acme", {
+      language_edit_rights: [],
+      language_publish_rights: [],
+    });
+    const fields = await grantLanguageSlugToUser(env, "boot@acme.com", "sw");
+    expect(fields).toEqual(["language_edit_rights", "language_publish_rights"]);
+    const after = await read("boot@acme.com");
+    expect(after.language_edit_rights).toEqual(["sw"]);
+    expect(after.language_publish_rights).toEqual(["sw"]);
+  });
+
+  it("materializes explicit fields from restricted legacy rights", async () => {
+    await seed("legacy@acme.com", "acme", { language_rights: ["en"] });
+    const fields = await grantLanguageSlugToUser(env, "legacy@acme.com", "sw");
+    expect(fields).toEqual(["language_edit_rights", "language_publish_rights"]);
+    const after = await read("legacy@acme.com");
+    expect(after.language_edit_rights).toEqual(["en", "sw"]);
+    expect(after.language_publish_rights).toEqual(["en", "sw"]);
+    // Legacy field itself is untouched — it stays the lazy-migration
+    // source of truth for anything else that still reads it.
+    expect(after.language_rights).toEqual(["en"]);
+  });
+
+  it("no-ops (and does not write) for full-access users", async () => {
+    await seed("full@acme.com", "acme", { language_edit_rights: "*" });
+    const fields = await grantLanguageSlugToUser(env, "full@acme.com", "sw");
+    // publish field is undefined with no legacy fallback → full access.
+    expect(fields).toEqual([]);
+    const after = await read("full@acme.com");
+    expect(after.language_edit_rights).toBe("*");
+    expect(after.language_publish_rights).toBeUndefined();
+  });
+
+  it("throws when the stored user is missing", async () => {
+    await expect(
+      grantLanguageSlugToUser(env, "ghost@acme.com", "sw")
+    ).rejects.toThrow(/no stored user/);
+  });
+});
+
+describe("revokeLanguageSlugFromUser", () => {
+  it("removes the slug from exactly the recorded fields", async () => {
+    await seed("rev@acme.com", "acme", {
+      language_edit_rights: ["en", "sw"],
+      language_publish_rights: ["sw"],
+    });
+    await revokeLanguageSlugFromUser(env, "rev@acme.com", "sw", [
+      "language_edit_rights",
+    ]);
+    const after = await read("rev@acme.com");
+    expect(after.language_edit_rights).toEqual(["en"]);
+    // Not recorded → untouched, even though it holds the slug.
+    expect(after.language_publish_rights).toEqual(["sw"]);
+  });
+
+  it("tolerates a vanished user and drifted fields", async () => {
+    await expect(
+      revokeLanguageSlugFromUser(env, "gone@acme.com", "sw", [
+        "language_edit_rights",
+      ])
+    ).resolves.toBeUndefined();
+
+    await seed("drift@acme.com", "acme", { language_edit_rights: "*" });
+    await revokeLanguageSlugFromUser(env, "drift@acme.com", "sw", [
+      "language_edit_rights",
+    ]);
+    expect((await read("drift@acme.com")).language_edit_rights).toBe("*");
   });
 });

--- a/tests/rights-migration.test.ts
+++ b/tests/rights-migration.test.ts
@@ -13,7 +13,6 @@ import {
   expandOrgModeRights,
   expandRights,
   grantLanguageSlugToUser,
-  grantSlug,
   removeSlugIfPartnerPresent,
   revokeLanguageSlugFromUser,
 } from "../worker/rights-migration";
@@ -308,30 +307,6 @@ describe("contractOrgModeRights", () => {
 // #247 — bootstrap auto-grant (single-user, both language verb fields)
 // ---------------------------------------------------------------------------
 
-describe("grantSlug", () => {
-  it("appends to an explicit array, ignoring the fallback", () => {
-    expect(grantSlug([], ["legacy"], "swahili")).toEqual(["swahili"]);
-    expect(grantSlug(["en"], undefined, "swahili")).toEqual(["en", "swahili"]);
-  });
-
-  it("materializes from the legacy fallback when the field is unset", () => {
-    // Mirrors worker/auth.ts lazy migration: explicit ?? legacy.
-    expect(grantSlug(undefined, ["en"], "swahili")).toEqual(["en", "swahili"]);
-    expect(grantSlug(undefined, [], "swahili")).toEqual(["swahili"]);
-  });
-
-  it("null when effective rights are already full (undefined / '*')", () => {
-    expect(grantSlug(undefined, undefined, "swahili")).toBeNull();
-    expect(grantSlug("*", [], "swahili")).toBeNull();
-    expect(grantSlug(undefined, "*", "swahili")).toBeNull();
-  });
-
-  it("null when the slug is already held (idempotent)", () => {
-    expect(grantSlug(["swahili"], undefined, "swahili")).toBeNull();
-    expect(grantSlug(undefined, ["swahili"], "swahili")).toBeNull();
-  });
-});
-
 describe("grantLanguageSlugToUser", () => {
   it("grants both verb fields and returns the modified fields", async () => {
     await seed("boot@acme.com", "acme", {
@@ -358,13 +333,67 @@ describe("grantLanguageSlugToUser", () => {
   });
 
   it("no-ops (and does not write) for full-access users", async () => {
-    await seed("full@acme.com", "acme", { language_edit_rights: "*" });
-    const fields = await grantLanguageSlugToUser(env, "full@acme.com", "sw");
-    // publish field is undefined with no legacy fallback → full access.
-    expect(fields).toEqual([]);
-    const after = await read("full@acme.com");
-    expect(after.language_edit_rights).toBe("*");
+    // Truly full = both wildcards, or both unset with no legacy (the
+    // pre-rights default). Neither needs a stored grant.
+    await seed("full@acme.com", "acme", {
+      language_edit_rights: "*",
+      language_publish_rights: "*",
+    });
+    expect(await grantLanguageSlugToUser(env, "full@acme.com", "sw")).toEqual(
+      []
+    );
+    expect((await read("full@acme.com")).language_edit_rights).toBe("*");
+
+    await seed("unset@acme.com", "acme");
+    expect(await grantLanguageSlugToUser(env, "unset@acme.com", "sw")).toEqual(
+      []
+    );
+    const after = await read("unset@acme.com");
+    expect(after.language_edit_rights).toBeUndefined();
     expect(after.language_publish_rights).toBeUndefined();
+  });
+
+  it("partner-aware: an unset field with an explicit partner is a DENY, so the grant materializes [slug] — not full access, not legacy (#256 review F1)", async () => {
+    // Under-grant face of the bug: publish explicit, edit unset. The
+    // naive `explicit ?? legacy` treated unset edit as full access and
+    // skipped the grant — while every session (worker/auth.ts
+    // lazyMigrateLanguageRights) saw edit=[] and locked the creator out
+    // of the draft they just made.
+    await seed("mixed@acme.com", "acme", {
+      language_publish_rights: ["es"],
+    });
+    const fields = await grantLanguageSlugToUser(env, "mixed@acme.com", "sw");
+    expect(fields).toEqual(["language_edit_rights", "language_publish_rights"]);
+    const after = await read("mixed@acme.com");
+    expect(after.language_edit_rights).toEqual(["sw"]);
+    expect(after.language_publish_rights).toEqual(["es", "sw"]);
+  });
+
+  it("partner-aware: legacy entries never materialize into a partner-denied field (#256 review F1, escalation face)", async () => {
+    // Over-grant face: publish explicit, edit unset, legacy holds "x".
+    // The partner-aware rule made edit a deliberate deny; the naive
+    // fallback would have written edit=["x","sw"], durably restoring
+    // access the rule had revoked.
+    await seed("esc@acme.com", "acme", {
+      language_rights: ["x"],
+      language_publish_rights: ["x"],
+    });
+    await grantLanguageSlugToUser(env, "esc@acme.com", "sw");
+    const after = await read("esc@acme.com");
+    expect(after.language_edit_rights).toEqual(["sw"]);
+    expect(after.language_publish_rights).toEqual(["x", "sw"]);
+  });
+
+  it("partner-aware: a one-sided wildcard leaves that side untouched and grants the denied side", async () => {
+    await seed("wild@acme.com", "acme", {
+      language_edit_rights: [],
+      language_publish_rights: "*",
+    });
+    const fields = await grantLanguageSlugToUser(env, "wild@acme.com", "sw");
+    expect(fields).toEqual(["language_edit_rights"]);
+    const after = await read("wild@acme.com");
+    expect(after.language_edit_rights).toEqual(["sw"]);
+    expect(after.language_publish_rights).toBe("*");
   });
 
   it("throws when the stored user is missing", async () => {

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -163,7 +163,11 @@ export async function validateSession(
 
 // Shared between validateSession and handleLogin so the session shape is
 // identical whether the session is freshly minted or rehydrated from KV.
-function lazyMigrateLanguageRights(user: StoredUser): {
+// Exported for the #247 bootstrap auto-grant (worker/rights-migration.ts),
+// which must materialize explicit verb fields under EXACTLY this rule — a
+// third hand-rolled copy of the partner-aware fallback is how the original
+// #256 review bug happened.
+export function lazyMigrateLanguageRights(user: StoredUser): {
   language_edit_rights: LanguageRights | undefined;
   language_publish_rights: LanguageRights | undefined;
 } {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -3,6 +3,9 @@ import { errorResponse, isPathShapedOrg } from "./helpers";
 import {
   contractOrgModeRights,
   expandOrgModeRights,
+  grantLanguageSlugToUser,
+  revokeLanguageSlugFromUser,
+  type LanguageVerbRightsField,
   type MigrationRecord,
 } from "./rights-migration";
 import type { LanguageRights, SessionData } from "./types";
@@ -293,7 +296,17 @@ function computeRequiredVerbsForPut(
 //   4. Early-deny — if the caller has zero rights on this row across
 //      both verbs, reject before consuming the body. Keeps bodyless
 //      probes (DELETE, GET-with-method-override, malformed PUTs) on
-//      the 403 path rather than a downstream 400.
+//      the 403 path rather than a downstream 400. One carve-out (#247):
+//      a same-org admin's language PUT is allowed through IF the engine
+//      confirms the target doesn't exist yet — pure creation. Without
+//      it, an org whose users all hold explicit (non-"*") language
+//      rights can never create its FIRST draft: rights can only name
+//      drafts that exist, and creating a draft requires rights — a
+//      deadlock. The carve-out fails CLOSED (found/error/thrown state
+//      lookup → 403) and never applies to DELETE or existing rows, so
+//      the PR #185 "admin doesn't trump per-row languages" rule holds
+//      for everything that already exists. The caller pairs it with an
+//      auto-grant of both verbs to the creator (rights-migration.ts).
 //   5. DELETE → requires BOTH edit + publish on the row. Deletion is
 //      strictly more destructive than either alone.
 //   6. PUT → diff body vs current and require the union of verbs the
@@ -307,7 +320,10 @@ async function gateConfigMutation(
   kind: ResourceKind,
   name: string,
   crossOrg: boolean
-): Promise<{ ok: true; parsedBody?: ResourceShape } | { error: Response }> {
+): Promise<
+  | { ok: true; parsedBody?: ResourceShape; adminBootstrapCreate?: boolean }
+  | { error: Response }
+> {
   if (crossOrg) return { ok: true };
 
   // Admin trumps PER-MODE rights only. Pre-#181, modes were admin-only
@@ -342,6 +358,36 @@ async function gateConfigMutation(
     !hasRights(rightsFor(session, kind, "edit"), name) &&
     !hasRights(rightsFor(session, kind, "publish"), name)
   ) {
+    // #247 bootstrap carve-out — see the gate's doc comment (check 4).
+    // Ordering note: the state lookup runs only on the path that would
+    // otherwise 403, so rights-holding callers never pay the extra
+    // engine GET. TOCTOU: a same-name create landing between this
+    // "missing" read and the engine PUT means one admin's scaffold
+    // overwrites the other's seconds-old scaffold — same-org, admin-
+    // only, and bounded to brand-new drafts; accepted.
+    if (
+      kind === "language" &&
+      request.method === "PUT" &&
+      hasAdminPowers(session)
+    ) {
+      let state: ResourceState;
+      try {
+        state = await fetchResourceState(env, kind, org, name);
+      } catch {
+        // Thrown fetch / malformed 2xx body — ambiguous, fail closed
+        // (same mapping as preflightMode).
+        state = { status: "error" };
+      }
+      if (state.status === "missing") {
+        let body: ResourceShape;
+        try {
+          body = (await request.json()) as ResourceShape;
+        } catch {
+          return { error: errorResponse("Invalid JSON", 400) };
+        }
+        return { ok: true, parsedBody: body, adminBootstrapCreate: true };
+      }
+    }
     return { error: errorResponse("Forbidden", 403) };
   }
 
@@ -838,13 +884,52 @@ export async function handleConfig(
         resolved.crossOrg
       );
       if ("error" in gate) return gate.error;
-      return proxyToEngine(
+      // #247 bootstrap create — grant the creator both verbs on the new
+      // slug BEFORE the engine call (#240 expand-first model: a failure
+      // after the grant leaves an inert entry for a slug that doesn't
+      // exist, never a lockout). Grant failure aborts the create — the
+      // engine hasn't been touched, and creating a draft the creator
+      // can't see would re-manifest the very bug this fixes.
+      let grantedFields: LanguageVerbRightsField[] = [];
+      if (gate.adminBootstrapCreate) {
+        try {
+          grantedFields = await grantLanguageSlugToUser(
+            env,
+            session.email,
+            languageName
+          );
+        } catch (err) {
+          console.error(
+            `bootstrap create: rights grant failed for ${session.email} ("${languageName}")`,
+            err
+          );
+          return errorResponse("Failed to grant creator rights", 502);
+        }
+      }
+      const engineRes = await proxyToEngine(
         request,
         env,
         `/api/v1/admin/orgs/${encodedOrg}/languages/${encodeURIComponent(languageName)}`,
         ["GET", "PUT", "DELETE"],
         gate.parsedBody
       );
+      // Compensate ONLY on a definitive engine rejection (4xx). A 5xx
+      // or transport failure is ambiguous — the create may have landed —
+      // so the grant superset is kept (same rule as the #240 rename
+      // compensation: ambiguity never contracts rights).
+      if (
+        grantedFields.length > 0 &&
+        engineRes.status >= 400 &&
+        engineRes.status < 500
+      ) {
+        await revokeLanguageSlugFromUser(
+          env,
+          session.email,
+          languageName,
+          grantedFields
+        );
+      }
+      return engineRes;
     }
     return proxyToEngine(
       request,

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -294,7 +294,13 @@ function computeRequiredVerbsForPut(
 //      or existing rows, so the PR #185 "admin doesn't trump per-row
 //      languages" rule holds for everything that already exists. The
 //      caller pairs it with an auto-grant of both verbs to the creator
-//      (rights-migration.ts).
+//      (rights-migration.ts). Failure-surface note for the exempted
+//      shape (zero-rights same-org admin): malformed JSON answers 400
+//      and an engine outage during the probe propagates as a request
+//      failure, where main answered a bodyless 403 — both are still
+//      fail-closed (no mutation), and the caller is a same-org admin
+//      to whom the row's existence is already visible via the ungated
+//      GET; accepted.
 async function gateConfigMutation(
   request: Request,
   env: Env,
@@ -382,19 +388,34 @@ async function gateConfigMutation(
     // the diff but can never widen admin creation onto an existing row.
     const state = await fetchResourceState(env, kind, org, name);
     const current = state.status === "found" ? state.mode : null;
+    // Zero rights on the row can only reach this point via the
+    // adminLanguageCreatePath exemption (the early-deny catches everyone
+    // else). Such callers must NEVER take the ordinary allow below: an
+    // empty diff (body echoing current state, or omitting fields)
+    // computes zero required verbs, which on main was unreachable for
+    // them — letting it through would put an engine write on a row the
+    // PR #185 rule says they can't touch (#256 rd-2 F0). Their only
+    // allowed outcome is the bootstrap carve-out; it also tags an
+    // empty-diff PUT against a MISSING row as a bootstrap create, so
+    // the creator auto-grant can never be skipped on a creation.
+    const zeroRightsOnRow =
+      !hasRights(rightsFor(session, kind, "edit"), name) &&
+      !hasRights(rightsFor(session, kind, "publish"), name);
     const denied = computeRequiredVerbsForPut(body, current).some(
       (verb) => !hasRights(rightsFor(session, kind, verb), name)
     );
-    if (!denied) return { ok: true, parsedBody: body };
-    // #247 bootstrap carve-out — see the gate's doc comment (check 6).
-    // TOCTOU: a same-name create landing between the "missing" read and
-    // the engine PUT means one admin's scaffold overwrites the other's
-    // seconds-old scaffold — same-org, admin-only, and bounded to
-    // brand-new drafts; accepted.
-    if (adminLanguageCreatePath && state.status === "missing") {
-      return { ok: true, parsedBody: body, adminBootstrapCreate: true };
+    if (denied || zeroRightsOnRow) {
+      // #247 bootstrap carve-out — see the gate's doc comment (check 6).
+      // TOCTOU: a same-name create landing between the "missing" read
+      // and the engine PUT means one admin's scaffold overwrites the
+      // other's seconds-old scaffold — same-org, admin-only, and
+      // bounded to brand-new drafts; accepted.
+      if (adminLanguageCreatePath && state.status === "missing") {
+        return { ok: true, parsedBody: body, adminBootstrapCreate: true };
+      }
+      return { error: errorResponse("Forbidden", 403) };
     }
-    return { error: errorResponse("Forbidden", 403) };
+    return { ok: true, parsedBody: body };
   }
 
   return { ok: true };
@@ -904,6 +925,16 @@ export async function handleConfig(
           languageName,
           grantedFields
         );
+      }
+      // Tell the client the bootstrap grant happened so it can mirror
+      // the new rights into its session user without refetching /me
+      // (KV read-after-write) and without inferring the carve-out from
+      // its own rights snapshot — every inference variant broke under
+      // some shape (session skew, published:true creates; #256 rd-3).
+      if (gate.adminBootstrapCreate && engineRes.ok) {
+        const flagged = new Response(engineRes.body, engineRes);
+        flagged.headers.set("X-Bootstrap-Grant", "1");
+        return flagged;
       }
       return engineRes;
     }

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -133,33 +133,10 @@ interface ResourceShape {
   published?: boolean;
 }
 
-async function fetchCurrentResource(
-  env: Env,
-  kind: ResourceKind,
-  org: string,
-  name: string
-): Promise<ResourceShape | null> {
-  // Any non-found RESPONSE → null. 404 means the resource doesn't
-  // exist yet (creation); other non-2xx statuses (auth, engine 5xx)
-  // are DELIBERATELY collapsed to null too, so the PUT gate falls
-  // through to creation semantics — which demand at minimum edit on
-  // any editorial field and publish on `published: true`, stricter
-  // than the diff path would have produced.
-  //
-  // A THROWN fetch or malformed 2xx body is NOT collapsed: it
-  // propagates and fails the request, exactly as on main (rd-5
-  // review; pinned by test). Do not add a catch here or in
-  // fetchResourceState — swallowing throws widens the creation
-  // fallback and lets an edit-only shepherd unpublish a live mode
-  // during an engine blip.
-  const state = await fetchResourceState(env, kind, org, name);
-  return state.status === "found" ? state.mode : null;
-}
-
 // Tri-state resource lookup — the single copy of the engine GET +
-// envelope unwrap (rd-4 review: preflightMode and fetchCurrentResource
-// had drifted into near-duplicates of it). Callers layer their own
-// error semantics on top.
+// envelope unwrap (rd-4 review: the preflights and the PUT gate's
+// current-state read had drifted into near-duplicates of it). Callers
+// layer their own error semantics on top.
 //
 // Deliberately does NOT catch: a thrown fetch (network) or a malformed
 // 2xx body (json parse) PROPAGATES. The PUT gate has always let those
@@ -203,10 +180,10 @@ async function fetchResourceState(
   return { status: "found", mode };
 }
 
-// Preflight lookup for the rename arm. Unlike fetchCurrentResource
-// (whose null-on-any-error is deliberately lax — the PUT gate falls
-// through to stricter creation semantics), the preflights are SECURITY
-// checks and must fail CLOSED: a transient engine 5xx during the
+// Preflight lookup for the rename arm. Unlike the PUT gate's current-
+// state read (whose error-collapses-to-null is deliberately lax — the
+// gate falls through to stricter creation semantics), the preflights
+// are SECURITY checks and must fail CLOSED: a transient engine 5xx during the
 // collision check must abort the rename, not read as "slug is free"
 // and reopen the escalation window it guards (rd-3 review). A found
 // mode whose payload lacks a string `name` is treated as an error for
@@ -296,22 +273,28 @@ function computeRequiredVerbsForPut(
 //   4. Early-deny — if the caller has zero rights on this row across
 //      both verbs, reject before consuming the body. Keeps bodyless
 //      probes (DELETE, GET-with-method-override, malformed PUTs) on
-//      the 403 path rather than a downstream 400. One carve-out (#247):
-//      a same-org admin's language PUT is allowed through IF the engine
-//      confirms the target doesn't exist yet — pure creation. Without
-//      it, an org whose users all hold explicit (non-"*") language
-//      rights can never create its FIRST draft: rights can only name
-//      drafts that exist, and creating a draft requires rights — a
-//      deadlock. The carve-out fails CLOSED (found/error/thrown state
-//      lookup → 403) and never applies to DELETE or existing rows, so
-//      the PR #185 "admin doesn't trump per-row languages" rule holds
-//      for everything that already exists. The caller pairs it with an
-//      auto-grant of both verbs to the creator (rights-migration.ts).
+//      the 403 path rather than a downstream 400. Same-org-admin
+//      language PUTs are exempted — they fall through to check 6,
+//      whose #247 carve-out must see them.
 //   5. DELETE → requires BOTH edit + publish on the row. Deletion is
 //      strictly more destructive than either alone.
 //   6. PUT → diff body vs current and require the union of verbs the
 //      diff implies (`edit` if any editorial field changed, `publish`
-//      if the published flag flipped).
+//      if the published flag flipped). When the diff denies, one
+//      carve-out (#247): a same-org admin's language PUT is allowed IF
+//      the engine CONFIRMED the target doesn't exist — pure creation.
+//      Without it, an org whose users all hold explicit (non-"*")
+//      language rights can never create its FIRST draft: rights can
+//      only name drafts that exist, and creating a draft requires
+//      rights — a deadlock. The carve-out sits on the deny path of the
+//      diff (not inside check 4) so mixed shapes like edit=[] +
+//      publish="*" — which pass the zero-rights screen on one verb yet
+//      still fail creation's edit demand — reach it too. It fails
+//      CLOSED (found or probe-error → 403) and never applies to DELETE
+//      or existing rows, so the PR #185 "admin doesn't trump per-row
+//      languages" rule holds for everything that already exists. The
+//      caller pairs it with an auto-grant of both verbs to the creator
+//      (rights-migration.ts).
 async function gateConfigMutation(
   request: Request,
   env: Env,
@@ -349,45 +332,26 @@ async function gateConfigMutation(
     return { error: errorResponse("Forbidden", 403) };
   }
 
+  // #247 — the shape eligible for the bootstrap carve-out in the PUT
+  // path below. Computed once: it also exempts these requests from the
+  // early-deny, which would otherwise 403 the zero-rights-admin case
+  // before the creation probe could run.
+  const adminLanguageCreatePath =
+    kind === "language" && request.method === "PUT" && hasAdminPowers(session);
+
   // Early-deny: if the caller has zero rights on this row across both
   // verbs, no PUT diff can let them through. Rejecting before reading
   // the body keeps the gate side-effect-free in the impossible case and
   // preserves the pre-#181 same-org "restricted shepherd → 403 on any
-  // unauthorized row" behavior even for bodyless probes.
+  // unauthorized row" behavior even for bodyless probes. Same-org-admin
+  // language PUTs fall through instead — for them the PUT diff CAN
+  // allow (creation via the #247 carve-out), at the cost of a body
+  // parse + existence probe on what may still end as a 403.
   if (
+    !adminLanguageCreatePath &&
     !hasRights(rightsFor(session, kind, "edit"), name) &&
     !hasRights(rightsFor(session, kind, "publish"), name)
   ) {
-    // #247 bootstrap carve-out — see the gate's doc comment (check 4).
-    // Ordering note: the state lookup runs only on the path that would
-    // otherwise 403, so rights-holding callers never pay the extra
-    // engine GET. TOCTOU: a same-name create landing between this
-    // "missing" read and the engine PUT means one admin's scaffold
-    // overwrites the other's seconds-old scaffold — same-org, admin-
-    // only, and bounded to brand-new drafts; accepted.
-    if (
-      kind === "language" &&
-      request.method === "PUT" &&
-      hasAdminPowers(session)
-    ) {
-      let state: ResourceState;
-      try {
-        state = await fetchResourceState(env, kind, org, name);
-      } catch {
-        // Thrown fetch / malformed 2xx body — ambiguous, fail closed
-        // (same mapping as preflightMode).
-        state = { status: "error" };
-      }
-      if (state.status === "missing") {
-        let body: ResourceShape;
-        try {
-          body = (await request.json()) as ResourceShape;
-        } catch {
-          return { error: errorResponse("Invalid JSON", 400) };
-        }
-        return { ok: true, parsedBody: body, adminBootstrapCreate: true };
-      }
-    }
     return { error: errorResponse("Forbidden", 403) };
   }
 
@@ -408,17 +372,29 @@ async function gateConfigMutation(
     } catch {
       return { error: errorResponse("Invalid JSON", 400) };
     }
-    // `fetchCurrentResource` returns null for any engine non-2xx
-    // (including 5xx / network errors) — the gate then treats the PUT
-    // as a creation, which is conservative (every editorial field
-    // present demands edit; published: true demands publish).
-    const current = await fetchCurrentResource(env, kind, org, name);
-    for (const verb of computeRequiredVerbsForPut(body, current)) {
-      if (!hasRights(rightsFor(session, kind, verb), name)) {
-        return { error: errorResponse("Forbidden", 403) };
-      }
+    // Tri-state lookup. A thrown fetch or malformed 2xx body PROPAGATES
+    // and fails the request, exactly as on main (rd-5 review; pinned by
+    // test) — do not add a catch here. An "error" status collapses to
+    // null for the verb diff, treating the PUT as a creation, which is
+    // conservative (every editorial field present demands edit;
+    // published: true demands publish). The #247 carve-out is stricter:
+    // it requires a CONFIRMED "missing", so an engine blip can tighten
+    // the diff but can never widen admin creation onto an existing row.
+    const state = await fetchResourceState(env, kind, org, name);
+    const current = state.status === "found" ? state.mode : null;
+    const denied = computeRequiredVerbsForPut(body, current).some(
+      (verb) => !hasRights(rightsFor(session, kind, verb), name)
+    );
+    if (!denied) return { ok: true, parsedBody: body };
+    // #247 bootstrap carve-out — see the gate's doc comment (check 6).
+    // TOCTOU: a same-name create landing between the "missing" read and
+    // the engine PUT means one admin's scaffold overwrites the other's
+    // seconds-old scaffold — same-org, admin-only, and bounded to
+    // brand-new drafts; accepted.
+    if (adminLanguageCreatePath && state.status === "missing") {
+      return { ok: true, parsedBody: body, adminBootstrapCreate: true };
     }
-    return { ok: true, parsedBody: body };
+    return { error: errorResponse("Forbidden", 403) };
   }
 
   return { ok: true };

--- a/worker/rights-migration.ts
+++ b/worker/rights-migration.ts
@@ -1,3 +1,4 @@
+import { lazyMigrateLanguageRights } from "./auth";
 import type { Env } from "./helpers";
 import { listKvKeys } from "./helpers";
 import type { LanguageRights, StoredUser } from "./types";
@@ -84,26 +85,6 @@ export function expandRights(
   return [...rights, to];
 }
 
-// #247 bootstrap auto-grant transform — add `slug` to one verb field.
-// `explicit` is the field's stored value; `legacyFallback` is the
-// user's legacy `language_rights`, consulted only when the field is
-// unset (mirroring the lazy-migration rule in worker/auth.ts). When
-// the grant fires against a fallback-derived array, the explicit field
-// is materialized with the fallback's entries plus the new slug — the
-// same materialization validateSession performs at read time.
-// Returns the new array, or null when no write is needed (effective
-// rights are full — undefined/"*" — or already include the slug).
-export function grantSlug(
-  explicit: LanguageRights | undefined,
-  legacyFallback: LanguageRights | undefined,
-  slug: string
-): string[] | null {
-  const effective = explicit ?? legacyFallback;
-  if (effective === undefined || effective === "*") return null;
-  if (effective.includes(slug)) return null;
-  return [...effective, slug];
-}
-
 // #247 — grant the creator both language verbs on a just-bootstrapped
 // slug. Follows the #240 expand-first model: the caller invokes this
 // BEFORE the engine create, so a crash between grant and create leaves
@@ -112,6 +93,25 @@ export function grantSlug(
 // inherit is the admin who was allowed to create it anyway. Throws on
 // read/write failure — the caller must abort the create (nothing has
 // touched the engine yet).
+//
+// The grant operates on the user's EFFECTIVE rights per the canonical
+// partner-aware rule (lazyMigrateLanguageRights, worker/auth.ts): the
+// legacy `language_rights` fallback applies only when BOTH verb fields
+// are unset; an explicit partner makes the unset field a deliberate
+// deny ([]), which the grant materializes as [slug] — never as legacy
+// entries. Getting this wrong in either direction is an authz bug: the
+// naive per-field `explicit ?? legacy` fallback both under-grants (an
+// unset-partner field reads as "full", so no grant is written while
+// every session sees [] — the creator is locked out of the draft they
+// just made) and over-grants (legacy entries materialize into a
+// partner-denied field, durably restoring access the rule had revoked).
+//
+// Concurrency: this is a whole-record read-modify-write over KV, which
+// has no CAS — two writes racing the same user record are last-write-
+// wins, the same acceptance as the #240 org-wide migration. The window
+// here is one admin's own record during their own create click; a lost
+// grant re-manifests as the (recoverable) read-only-draft symptom and
+// any admin can re-grant via the Users dialog now that the draft exists.
 //
 // Returns the fields actually modified, so definitive-failure
 // compensation operates only on what this grant touched and can never
@@ -127,13 +127,14 @@ export async function grantLanguageSlugToUser(
   if (!user) {
     throw new Error(`bootstrap grant: no stored user for ${key}`);
   }
+  const effective = lazyMigrateLanguageRights(user);
   const changed: LanguageVerbRightsField[] = [];
   for (const field of LANGUAGE_VERB_RIGHTS_FIELDS) {
-    const next = grantSlug(user[field], user.language_rights, slug);
-    if (next !== null) {
-      user[field] = next;
-      changed.push(field);
-    }
+    const rights = effective[field];
+    if (rights === undefined || rights === "*") continue;
+    if (rights.includes(slug)) continue;
+    user[field] = [...rights, slug];
+    changed.push(field);
   }
   if (changed.length > 0) {
     await env.AUTH_KV.put(key, JSON.stringify(user));

--- a/worker/rights-migration.ts
+++ b/worker/rights-migration.ts
@@ -48,14 +48,22 @@ export const MODE_RIGHTS_FIELDS = [
   "mode_publish_rights",
 ] as const satisfies readonly (keyof StoredUser)[];
 
-// A future language rename would add the three language fields here
-// (including the legacy `language_rights` bit, whose undefined-means-
-// full semantics differ from modes — the expandRights passthrough is
-// correct for it, but the consumer must decide how "*"-equivalent
-// legacy users interact with per-slug migration). Deliberately not
-// pre-declared: no consumer exists yet, and an unused constant would
-// assert semantics nobody has validated.
+// A future language rename would add the legacy `language_rights` bit
+// here too (its undefined-means-full semantics differ from modes — the
+// expandRights passthrough is correct for it, but the consumer must
+// decide how "*"-equivalent legacy users interact with per-slug
+// migration). The two VERB fields below are declared because the #247
+// bootstrap auto-grant consumes them; the legacy field stays
+// undeclared until a rename consumer validates its semantics.
 export type RightsField = (typeof MODE_RIGHTS_FIELDS)[number];
+
+export const LANGUAGE_VERB_RIGHTS_FIELDS = [
+  "language_edit_rights",
+  "language_publish_rights",
+] as const satisfies readonly (keyof StoredUser)[];
+
+export type LanguageVerbRightsField =
+  (typeof LANGUAGE_VERB_RIGHTS_FIELDS)[number];
 
 // Add `to` wherever `from` is held. `"*"` and `undefined` pass through
 // untouched — wildcard resolves at gate time and needs no entry; for
@@ -74,6 +82,96 @@ export function expandRights(
   if (!rights.includes(from)) return null;
   if (rights.includes(to)) return null;
   return [...rights, to];
+}
+
+// #247 bootstrap auto-grant transform — add `slug` to one verb field.
+// `explicit` is the field's stored value; `legacyFallback` is the
+// user's legacy `language_rights`, consulted only when the field is
+// unset (mirroring the lazy-migration rule in worker/auth.ts). When
+// the grant fires against a fallback-derived array, the explicit field
+// is materialized with the fallback's entries plus the new slug — the
+// same materialization validateSession performs at read time.
+// Returns the new array, or null when no write is needed (effective
+// rights are full — undefined/"*" — or already include the slug).
+export function grantSlug(
+  explicit: LanguageRights | undefined,
+  legacyFallback: LanguageRights | undefined,
+  slug: string
+): string[] | null {
+  const effective = explicit ?? legacyFallback;
+  if (effective === undefined || effective === "*") return null;
+  if (effective.includes(slug)) return null;
+  return [...effective, slug];
+}
+
+// #247 — grant the creator both language verbs on a just-bootstrapped
+// slug. Follows the #240 expand-first model: the caller invokes this
+// BEFORE the engine create, so a crash between grant and create leaves
+// the user with an entry for a slug that doesn't exist — inert, and in
+// this case the "accidental shepherd" a future same-slug language would
+// inherit is the admin who was allowed to create it anyway. Throws on
+// read/write failure — the caller must abort the create (nothing has
+// touched the engine yet).
+//
+// Returns the fields actually modified, so definitive-failure
+// compensation operates only on what this grant touched and can never
+// strip a pre-existing entry (per-field recording, same rationale as
+// MigrationRecord).
+export async function grantLanguageSlugToUser(
+  env: Env,
+  email: string,
+  slug: string
+): Promise<LanguageVerbRightsField[]> {
+  const key = `user:${email}`;
+  const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
+  if (!user) {
+    throw new Error(`bootstrap grant: no stored user for ${key}`);
+  }
+  const changed: LanguageVerbRightsField[] = [];
+  for (const field of LANGUAGE_VERB_RIGHTS_FIELDS) {
+    const next = grantSlug(user[field], user.language_rights, slug);
+    if (next !== null) {
+      user[field] = next;
+      changed.push(field);
+    }
+  }
+  if (changed.length > 0) {
+    await env.AUTH_KV.put(key, JSON.stringify(user));
+  }
+  return changed;
+}
+
+// #247 — compensate a bootstrap grant after a DEFINITIVE engine
+// rejection of the create (4xx). Best-effort by design, like
+// contractOrgModeRights: a failed removal leaves a harmless inert
+// entry (logged). Operates only on the fields the grant recorded.
+export async function revokeLanguageSlugFromUser(
+  env: Env,
+  email: string,
+  slug: string,
+  fields: LanguageVerbRightsField[]
+): Promise<void> {
+  const key = `user:${email}`;
+  try {
+    const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
+    if (!user) return;
+    let dirty = false;
+    for (const field of fields) {
+      const rights = user[field];
+      if (rights !== undefined && rights !== "*" && rights.includes(slug)) {
+        user[field] = rights.filter((s) => s !== slug);
+        dirty = true;
+      }
+    }
+    if (dirty) {
+      await env.AUTH_KV.put(key, JSON.stringify(user));
+    }
+  } catch (err) {
+    console.error(
+      `rights-migration: bootstrap grant compensation failed for ${key} (slug "${slug}") — stale entry remains`,
+      err
+    );
+  }
 }
 
 // Remove `remove` — but ONLY when `keep` is present in the same array.


### PR DESCRIPTION
## Summary

Fixes the #247 reopen (Elsy's 2026-07-08 staging re-test): a same-org **admin** can now create the first language draft in an org that has none, breaking the rights↔drafts bootstrap deadlock.

**Root cause** (full analysis on the issue): an org whose users all hold explicit (non-`"*"`) language rights could never create its FIRST draft — rights can only name drafts that already exist, and creating a draft required rights. Saving "Specific Languages" with nothing tickable writes explicit `[]`, and languages deliberately carry no admin trump (PR #185), so every layer locked the admin out: sidebar entry disabled, Create affordance hidden, worker 403 on the PUT.

## Changes

**Worker**
- `gateConfigMutation` gains a **create-only carve-out**: a same-org admin's language PUT passes IF the engine confirms the target doesn't exist yet. Found / probe-error / thrown-probe all **fail closed** to the existing 403. DELETE, existing rows, and non-admins are untouched — the PR #185 "no admin trump on languages" rule holds for everything that already exists.
- **Creator auto-grant**: before the engine call, the creator gets edit + publish on the new slug (`grantLanguageSlugToUser`, following the #240 expand-first atomicity model — a failure after the grant leaves an inert entry, never a lockout). Compensation (`revokeLanguageSlugFromUser`) runs only on a definitive engine 4xx; 5xx/transport ambiguity keeps the superset, same rule as the #240 rename compensation.
- New primitives live in `worker/rights-migration.ts` beside the #240 ones; `grantSlug` materializes explicit verb fields from restricted legacy `language_rights` exactly like `validateSession`'s lazy migration.

**UI**
- Languages sidebar entry enables for admins (`activity-bar.tsx`), mirroring why Modes already worked in Elsy's comparison.
- Languages page: `hasAccess`/`canCreate` include admins; per-row edit/publish/delete gates on existing drafts unchanged.
- After a create, the page refetches `/api/auth/me` so the server-side auto-grant is immediately visible to the list filter and edit gates (otherwise the just-created draft would render read-only or vanish until reload).

## Behavior notes

- Admin PUTs that still end in 403 now cost one extra engine GET (the existence probe) — probe runs only on the path that would otherwise deny, so rights-holding callers pay nothing.
- TOCTOU between probe and create: two admins racing the same brand-new name means one scaffold overwrites the other's seconds-old scaffold — same-org, admin-only, bounded to brand-new drafts; accepted and documented inline.
- This deliberately does NOT prejudge #249 (visibility/sharing design): no change to who can see or edit existing drafts.

## Tests

512 → 534: gate carve-out matrix (missing/found/5xx/thrown probe, non-admin, DELETE, published:true create, invalid JSON), grant/compensate KV effects (engine 4xx compensates, 5xx keeps, missing stored user aborts with 502 before the engine is touched), pure-helper coverage for `grantSlug`/revoke, and two pre-existing "403 with zero fetches" assertions updated for the admin-path existence probe.

Tracks #247 (leaving it open for Elsy's staging re-verify).
