### PR TITLE
feat(#257): un-gate mode clone/retire for shepherds — rename-parity gates + cloner auto-grant

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -19,6 +19,7 @@ import {
   hasAdminPowers,
   hasAnyRights,
   hasRights,
+  mirrorModeGrant,
 } from "@/lib/permissions";
 import { useUiStore } from "@/lib/ui-store";
 import { OrgContextSelector } from "@/components/org-context-selector";
@@ -120,16 +121,26 @@ export function ModesPage() {
   // canEditSelected here (both resolve modeEditRights to "*") but stay
   // explicit to keep the gate's intent readable.
   const canRenameSelected = isAdmin || isCrossOrg || canEditSelected;
-  // Clone rides the same gate as rename today (#241 PR B). The clone
-  // has no rights pre-assigned, so a non-admin cloning would land on a
-  // mode they can't edit. Kept as a separate boolean so the gate can
-  // loosen independently once rights-migration lands (#240).
-  const canCloneSelected = isAdmin || isCrossOrg;
-  // Retire rides the same gate (#241 PR C). Deleting a mode + widening
-  // the target's alias set are org-wide config changes at the same
-  // trust bar as rename. Loosen independently when rights-migration
-  // (#240) exists.
-  const canRetireSelected = isAdmin || isCrossOrg;
+  // Clone opens to shepherds with EDIT rights on the source (#257) —
+  // rename parity. The worker auto-grants the cloner both verbs on the
+  // new slug (X-Bootstrap-Grant), so the clone no longer lands on a
+  // mode its creator can't edit; handleCloneMode mirrors that grant
+  // into the session user.
+  const canCloneSelected = isAdmin || isCrossOrg || canEditSelected;
+  // Retire opens to shepherds at DELETE parity on the source (#257):
+  // edit + publish, same as canDeleteSelected — retire is strictly more
+  // destructive than delete. The worker additionally requires EDIT on
+  // the CANONICAL forward target (its alias set is being widened);
+  // the retire dialog mirrors that by filtering target options through
+  // canEditModeName below.
+  const canRetireSelected = isAdmin || isCrossOrg || canDeleteSelected;
+  // Per-row edit predicate for the retire dialog's target list.
+  // modeEditRights already resolves to "*" for admin/cross-org, so a
+  // plain hasRights read mirrors the worker's target gate.
+  const canEditModeName = useCallback(
+    (name: string) => hasRights(modeEditRights, name),
+    [modeEditRights]
+  );
 
   // Local document draft (auto-save target).
   //
@@ -433,9 +444,23 @@ export function ModesPage() {
       // picks discard-or-cancel). Uses data.name so an engine slug
       // canonicalization is picked up too. Belt-and-suspenders for
       // Frank F1 on #241 PR B.
+      //
+      // #257 — a shepherd clone comes back with bootstrapGranted: the
+      // worker granted this user both verbs on the new slug, but the
+      // auth store still holds pre-grant rights and the per-row gates
+      // + dropdown filter read from it. Mirror the grant synchronously
+      // (same pattern and rationale as the #240 rename mirror below:
+      // /me re-reads eventually-consistent KV and could clobber the
+      // patch with the pre-grant snapshot). Keyed on the newName we
+      // sent — that is exactly what the worker granted; data.name is
+      // used only for selection.
+      if (data.bootstrapGranted) {
+        const current = useAuthStore.getState().user;
+        if (current) setUser(mirrorModeGrant(current, newName.trim()));
+      }
       handleSelectMode(data.name);
     },
-    [cloneMode, handleSelectMode]
+    [cloneMode, handleSelectMode, setUser]
   );
 
   const handleRetireMode = useCallback(
@@ -544,6 +569,7 @@ export function ModesPage() {
               onRenameMode={handleRenameMode}
               onCloneMode={handleCloneMode}
               onRetireMode={handleRetireMode}
+              canEditTargetMode={canEditModeName}
               isCreating={saveMode.isPending}
               isDeleting={deleteMode.isPending}
               isRenaming={renameMode.isPending}

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -6,6 +6,7 @@ import { useBlocker } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
+import { CloneCollisionError, type CloneModeResult } from "@/lib/config-api";
 import {
   buildModeExportContent,
   buildModeExportFilename,
@@ -426,11 +427,31 @@ export function ModesPage() {
       // review comment: the engine never sees a bare `""` that could
       // be interpreted as either "user cleared" or "unset".
       const trimmedLabel = newLabel.trim();
-      const data = await cloneMode.mutateAsync({
-        name,
-        newName,
-        newLabel: trimmedLabel ? trimmedLabel : undefined,
-      });
+      let data: CloneModeResult;
+      try {
+        data = await cloneMode.mutateAsync({
+          name,
+          newName,
+          newLabel: trimmedLabel ? trimmedLabel : undefined,
+        });
+      } catch (err) {
+        // #258 rd-2 P2 — a collision carrying granted verbs means a
+        // prior attempt's engine create committed while its response
+        // was lost: the auto-grant was kept, and the colliding mode is
+        // OURS but invisible to the stale session snapshot. Mirror the
+        // header's verbs (server truth) before rethrowing so the mode
+        // surfaces in the selector; the dialog still shows the
+        // collision message.
+        if (err instanceof CloneCollisionError && err.grantedVerbs) {
+          const current = useAuthStore.getState().user;
+          if (current) {
+            setUser(
+              mirrorModeGrant(current, newName.trim(), err.grantedVerbs.publish)
+            );
+          }
+        }
+        throw err;
+      }
       // Route through handleSelectMode (not raw setSelectedMode) so
       // the switch-guard fires if the source draft dirtied while the
       // modal was open. The Clone button is disabled up-front by
@@ -454,22 +475,19 @@ export function ModesPage() {
       // patch with the pre-grant snapshot). Keyed on the newName we
       // sent — that is exactly what the worker granted; data.name is
       // used only for selection.
-      if (data.bootstrapGranted) {
+      if (data.grantedVerbs) {
         const current = useAuthStore.getState().user;
-        // includePublish mirrors the worker's rule: the grant carries
-        // publish only when the cloner holds publish on the SOURCE.
+        // The header names the verbs the caller now holds on the new
+        // slug — mirror exactly those (server truth; replaces the
+        // client-side source-rights recomputation, #258 rd-2).
         if (current)
           setUser(
-            mirrorModeGrant(
-              current,
-              newName.trim(),
-              hasRights(modePublishRights, name)
-            )
+            mirrorModeGrant(current, newName.trim(), data.grantedVerbs.publish)
           );
       }
       handleSelectMode(data.name);
     },
-    [cloneMode, handleSelectMode, setUser, modePublishRights]
+    [cloneMode, handleSelectMode, setUser]
   );
 
   const handleRetireMode = useCallback(

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -456,11 +456,20 @@ export function ModesPage() {
       // used only for selection.
       if (data.bootstrapGranted) {
         const current = useAuthStore.getState().user;
-        if (current) setUser(mirrorModeGrant(current, newName.trim()));
+        // includePublish mirrors the worker's rule: the grant carries
+        // publish only when the cloner holds publish on the SOURCE.
+        if (current)
+          setUser(
+            mirrorModeGrant(
+              current,
+              newName.trim(),
+              hasRights(modePublishRights, name)
+            )
+          );
       }
       handleSelectMode(data.name);
     },
-    [cloneMode, handleSelectMode, setUser]
+    [cloneMode, handleSelectMode, setUser, modePublishRights]
   );
 
   const handleRetireMode = useCallback(

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -107,6 +107,13 @@ interface ModeSelectorProps {
       route through `handleSelectMode` in modes.tsx defends the race
       window when focus escapes the modal. */
   retireDisabledReason: string | null;
+  /** Per-row edit predicate for the retire dialog's "Forward to" list
+      (#257). The worker requires EDIT rights on the CANONICAL forward
+      target (retire widens its alias array), so the dialog must not
+      offer targets the caller can't edit — a shepherd picking one
+      would just get a worker 403 after confirming. Admin/cross-org
+      callers resolve to "*" upstream and see every target. */
+  canEditTargetMode: (name: string) => boolean;
 }
 
 function isPublished(mode: Pick<PromptMode, "published">): boolean {
@@ -153,6 +160,7 @@ export function ModeSelector({
   renameDisabledReason,
   cloneDisabledReason,
   retireDisabledReason,
+  canEditTargetMode,
 }: ModeSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -692,7 +700,11 @@ export function ModeSelector({
                       </SelectTrigger>
                       <SelectContent>
                         {modes
-                          .filter((m) => m.name !== selectedMode)
+                          .filter(
+                            (m) =>
+                              m.name !== selectedMode &&
+                              canEditTargetMode(m.name)
+                          )
                           .map((m) => (
                             <SelectItem key={m.name} value={m.name}>
                               <span className="flex items-center gap-2">
@@ -712,10 +724,15 @@ export function ModeSelector({
                           ))}
                       </SelectContent>
                     </Select>
-                    {modes.filter((m) => m.name !== selectedMode).length ===
-                      0 && (
+                    {modes.filter(
+                      (m) =>
+                        m.name !== selectedMode && canEditTargetMode(m.name)
+                    ).length === 0 && (
                       <p className="text-muted-foreground text-xs">
-                        No other modes exist to forward to. Create one first.
+                        {modes.filter((m) => m.name !== selectedMode).length ===
+                        0
+                          ? "No other modes exist to forward to. Create one first."
+                          : "No forward targets you can edit. Retiring requires edit access on the target mode — ask an admin."}
                       </p>
                     )}
                   </div>

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { faLayerGroup } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -277,7 +277,10 @@ export function ModeSelector({
     );
   }, [onRenameMode, renameValue, selectedMode]);
 
-  const modes = modesData?.modes ?? [];
+  // Memoized: eligibleRetireTargets depends on this, and the `?? []`
+  // fallback would otherwise mint a fresh array identity every render
+  // (react-hooks/exhaustive-deps).
+  const modes = useMemo(() => modesData?.modes ?? [], [modesData]);
   const selectedModeData = modes.find((m) => m.name === selectedMode) ?? null;
   const selectedIsPublished = selectedModeData
     ? isPublished(selectedModeData)
@@ -287,6 +290,16 @@ export function ModeSelector({
   // orphan the user's selection.
   const visibleModes = modes.filter(
     (m) => showDrafts || isPublished(m) || m.name === selectedMode
+  );
+
+  // #257 — the retire dialog's eligible forward targets: everything
+  // except the mode being retired, restricted to modes the caller can
+  // EDIT (the worker's target gate). Single source for both the option
+  // list and the empty-state check.
+  const eligibleRetireTargets = useMemo(
+    () =>
+      modes.filter((m) => m.name !== selectedMode && canEditTargetMode(m.name)),
+    [modes, selectedMode, canEditTargetMode]
   );
 
   const handleCreate = useCallback(() => {
@@ -699,35 +712,26 @@ export function ModeSelector({
                         <SelectValue placeholder="Pick a target mode" />
                       </SelectTrigger>
                       <SelectContent>
-                        {modes
-                          .filter(
-                            (m) =>
-                              m.name !== selectedMode &&
-                              canEditTargetMode(m.name)
-                          )
-                          .map((m) => (
-                            <SelectItem key={m.name} value={m.name}>
-                              <span className="flex items-center gap-2">
-                                <span className="truncate">
-                                  {m.label || m.name}
-                                </span>
-                                {!isPublished(m) && (
-                                  <Badge
-                                    variant="outline"
-                                    className="px-1.5 py-0 text-[10px]"
-                                  >
-                                    Draft
-                                  </Badge>
-                                )}
+                        {eligibleRetireTargets.map((m) => (
+                          <SelectItem key={m.name} value={m.name}>
+                            <span className="flex items-center gap-2">
+                              <span className="truncate">
+                                {m.label || m.name}
                               </span>
-                            </SelectItem>
-                          ))}
+                              {!isPublished(m) && (
+                                <Badge
+                                  variant="outline"
+                                  className="px-1.5 py-0 text-[10px]"
+                                >
+                                  Draft
+                                </Badge>
+                              )}
+                            </span>
+                          </SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
-                    {modes.filter(
-                      (m) =>
-                        m.name !== selectedMode && canEditTargetMode(m.name)
-                    ).length === 0 && (
+                    {eligibleRetireTargets.length === 0 && (
                       <p className="text-muted-foreground text-xs">
                         {modes.filter((m) => m.name !== selectedMode).length ===
                         0

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -217,6 +217,19 @@ export function useCloneMode(org?: string | null) {
       void qc.invalidateQueries({ queryKey: keys.modes(key) });
       void qc.invalidateQueries({ queryKey: keys.mode(data.name, key) });
     },
+    onError: (error) => {
+      // #258 rd-2 P2 — a collision carrying granted verbs means a prior
+      // attempt's engine create COMMITTED while its response was lost:
+      // the colliding mode exists server-side but this client's list
+      // cache predates it. Refetch so the reconciled rights (mirrored
+      // by the page) have a list entry to surface.
+      if (
+        error instanceof configApi.CloneCollisionError &&
+        error.grantedVerbs
+      ) {
+        void qc.invalidateQueries({ queryKey: keys.modes(key) });
+      }
+    },
   });
 }
 

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -246,12 +246,42 @@ export async function renameMode(
 // reconciliation §4).
 //
 // #257 — a clone performed by a non-admin shepherd comes back flagged
-// (X-Bootstrap-Grant header): the worker auto-granted the cloner
-// edit + publish on the new slug, and the client mirrors that into its
-// session user. An explicit wire signal, NOT client-side inference —
-// same rationale as the #247 language-create grant (#256 rds 2–3).
+// (X-Bootstrap-Grant header) with the VERBS the caller now holds on the
+// new slug (e.g. "edit" or "edit,publish"); the client mirrors exactly
+// those into its session user. An explicit wire signal, NOT client-side
+// inference — same rationale as the #247 language-create grant (#256
+// rds 2–3; the verb list replaced a client-side recomputation in #258
+// rd-2).
+export interface CloneGrantedVerbs {
+  edit: boolean;
+  publish: boolean;
+}
+
 export interface CloneModeResult extends PromptMode {
-  bootstrapGranted: boolean;
+  grantedVerbs: CloneGrantedVerbs | null;
+}
+
+// A 409 slug collision. When a prior clone attempt COMMITTED on the
+// engine but its response was lost, the kept auto-grant makes the
+// retry collide here — `grantedVerbs` (from the same header, attached
+// to the 409) carries the rights the caller's live session holds on
+// the colliding slug so the UI can reconcile instead of stranding an
+// invisible, uneditable mode (#258 rd-2 P2).
+export class CloneCollisionError extends Error {
+  constructor(
+    message: string,
+    readonly grantedVerbs: CloneGrantedVerbs | null
+  ) {
+    super(message);
+    this.name = "CloneCollisionError";
+  }
+}
+
+function parseGrantedVerbs(res: Response): CloneGrantedVerbs | null {
+  const header = res.headers.get("X-Bootstrap-Grant");
+  if (!header) return null;
+  const verbs = header.split(",");
+  return { edit: verbs.includes("edit"), publish: verbs.includes("publish") };
 }
 
 export async function cloneMode(
@@ -271,15 +301,16 @@ export async function cloneMode(
   );
 
   if (!res.ok) {
-    throw new Error(
-      `Failed to clone mode (${res.status}): ${await readModeOpError(res)}`
-    );
+    const message = `Failed to clone mode (${res.status}): ${await readModeOpError(res)}`;
+    if (res.status === 409) {
+      throw new CloneCollisionError(message, parseGrantedVerbs(res));
+    }
+    throw new Error(message);
   }
 
-  const bootstrapGranted = res.headers.get("X-Bootstrap-Grant") === "1";
   return {
     ...unwrapModeResponse((await res.json()) as Record<string, unknown>),
-    bootstrapGranted,
+    grantedVerbs: parseGrantedVerbs(res),
   };
 }
 

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -244,12 +244,22 @@ export async function renameMode(
 // clone lands as a draft. Rejects with 409 if the new slug collides with any
 // existing mode's canonical name OR alias in the org (Ian's #232
 // reconciliation §4).
+//
+// #257 — a clone performed by a non-admin shepherd comes back flagged
+// (X-Bootstrap-Grant header): the worker auto-granted the cloner
+// edit + publish on the new slug, and the client mirrors that into its
+// session user. An explicit wire signal, NOT client-side inference —
+// same rationale as the #247 language-create grant (#256 rds 2–3).
+export interface CloneModeResult extends PromptMode {
+  bootstrapGranted: boolean;
+}
+
 export async function cloneMode(
   name: string,
   body: { newName: string; newLabel?: string },
   signal?: AbortSignal,
   org?: string | null
-): Promise<PromptMode> {
+): Promise<CloneModeResult> {
   const res = await fetch(
     buildConfigUrl(`/api/config/modes/${encodeURIComponent(name)}/_clone`, org),
     {
@@ -266,7 +276,11 @@ export async function cloneMode(
     );
   }
 
-  return unwrapModeResponse((await res.json()) as Record<string, unknown>);
+  const bootstrapGranted = res.headers.get("X-Bootstrap-Grant") === "1";
+  return {
+    ...unwrapModeResponse((await res.json()) as Record<string, unknown>),
+    bootstrapGranted,
+  };
 }
 
 // Retire the source mode and forward users onto `forwardTo` via the

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -118,20 +118,24 @@ export function mirrorBootstrapGrant<T extends LanguageRightsCarrier>(
   };
 }
 
-// #257 — mirror the worker's clone auto-grant (both MODE verbs on
-// `slug`) into the local session user. Call ONLY when the worker
-// signalled the grant (X-Bootstrap-Grant on the clone response →
-// `bootstrapGranted` on CloneModeResult) — no client-side inference,
-// same rationale as mirrorBootstrapGrant above. Mode semantics: no
-// legacy fallback; `undefined` means "no access" for non-admins, so an
-// unset field materializes as [slug] (matching the server-side grant).
-// Wildcards pass through untouched.
+// #257 — mirror the worker's clone auto-grant into the local session
+// user. Call ONLY when the worker signalled the grant (X-Bootstrap-
+// Grant on the clone response → `bootstrapGranted` on CloneModeResult)
+// — no client-side inference, same rationale as mirrorBootstrapGrant
+// above. The worker grants the verbs the cloner holds on the SOURCE
+// mode (edit always; publish only if held there — #258 rd-1: an
+// unconditional both-verbs grant handed publish to edit-only
+// shepherds), so the caller passes `includePublish` computed from its
+// own source-mode rights. Mode semantics: no legacy fallback;
+// `undefined` means "no access" for non-admins, so an unset field
+// materializes as [slug] (matching the server-side grant). Wildcards
+// pass through untouched.
 export function mirrorModeGrant<
   T extends {
     mode_edit_rights?: LanguageRights;
     mode_publish_rights?: LanguageRights;
   },
->(user: T, slug: string): T {
+>(user: T, slug: string, includePublish: boolean): T {
   const withSlug = (rights: LanguageRights | undefined) =>
     rights === "*" || (rights !== undefined && rights.includes(slug))
       ? rights
@@ -139,7 +143,9 @@ export function mirrorModeGrant<
   return {
     ...user,
     mode_edit_rights: withSlug(user.mode_edit_rights),
-    mode_publish_rights: withSlug(user.mode_publish_rights),
+    mode_publish_rights: includePublish
+      ? withSlug(user.mode_publish_rights)
+      : user.mode_publish_rights,
   };
 }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -118,6 +118,31 @@ export function mirrorBootstrapGrant<T extends LanguageRightsCarrier>(
   };
 }
 
+// #257 — mirror the worker's clone auto-grant (both MODE verbs on
+// `slug`) into the local session user. Call ONLY when the worker
+// signalled the grant (X-Bootstrap-Grant on the clone response →
+// `bootstrapGranted` on CloneModeResult) — no client-side inference,
+// same rationale as mirrorBootstrapGrant above. Mode semantics: no
+// legacy fallback; `undefined` means "no access" for non-admins, so an
+// unset field materializes as [slug] (matching the server-side grant).
+// Wildcards pass through untouched.
+export function mirrorModeGrant<
+  T extends {
+    mode_edit_rights?: LanguageRights;
+    mode_publish_rights?: LanguageRights;
+  },
+>(user: T, slug: string): T {
+  const withSlug = (rights: LanguageRights | undefined) =>
+    rights === "*" || (rights !== undefined && rights.includes(slug))
+      ? rights
+      : [...(rights ?? []), slug];
+  return {
+    ...user,
+    mode_edit_rights: withSlug(user.mode_edit_rights),
+    mode_publish_rights: withSlug(user.mode_publish_rights),
+  };
+}
+
 export function effectiveModeEditRights(
   user:
     | {

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   clearUserMode,
+  CloneCollisionError,
   cloneMode,
   deleteMode,
   deleteUserMemory,
@@ -446,18 +447,67 @@ describe("cloneMode", () => {
     expect(spy.mock.calls[0]![0]).toBe("/api/config/modes/kids%20mode/_clone");
   });
 
-  it("surfaces the engine's JSON `{ error }` message on a slug collision", async () => {
+  it("surfaces the engine's JSON `{ error }` message on a slug collision, as a CloneCollisionError", async () => {
     // Engine returns 409 for a collision against another mode's name OR
     // alias. Dialog shows this inline; the message must be the engine
     // string, not the raw JSON blob.
     mockFetchOnce(409, {
       error: 'Slug "conversation" already belongs to another mode in this org',
     });
-    await expect(
-      cloneMode("spoken", { newName: "conversation" })
-    ).rejects.toThrow(
+    const err = await cloneMode("spoken", { newName: "conversation" }).then(
+      () => null,
+      (e: unknown) => e
+    );
+    expect(err).toBeInstanceOf(CloneCollisionError);
+    expect((err as CloneCollisionError).message).toMatch(
       /Failed to clone mode \(409\): Slug "conversation" already belongs/
     );
+    // Bare 409 (no header) → no verbs to reconcile.
+    expect((err as CloneCollisionError).grantedVerbs).toBeNull();
+  });
+
+  it("parses X-Bootstrap-Grant verb lists on success (#257/#258)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ mode: { name: "new", document: "" } }), {
+        status: 200,
+        headers: { "X-Bootstrap-Grant": "edit,publish" },
+      })
+    );
+    const result = await cloneMode("spoken", { newName: "new" });
+    expect(result.grantedVerbs).toEqual({ edit: true, publish: true });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ mode: { name: "new2", document: "" } }), {
+        status: 200,
+        headers: { "X-Bootstrap-Grant": "edit" },
+      })
+    );
+    const editOnly = await cloneMode("spoken", { newName: "new2" });
+    expect(editOnly.grantedVerbs).toEqual({ edit: true, publish: false });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ mode: { name: "new3", document: "" } }))
+    );
+    const admin = await cloneMode("spoken", { newName: "new3" });
+    expect(admin.grantedVerbs).toBeNull();
+  });
+
+  it("ambiguous-commit reconciliation: a 409 carrying held verbs surfaces them on the CloneCollisionError (#258 rd-2 P2)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "exists" }), {
+        status: 409,
+        headers: { "X-Bootstrap-Grant": "edit" },
+      })
+    );
+    const err = await cloneMode("spoken", { newName: "mine" }).then(
+      () => null,
+      (e: unknown) => e
+    );
+    expect(err).toBeInstanceOf(CloneCollisionError);
+    expect((err as CloneCollisionError).grantedVerbs).toEqual({
+      edit: true,
+      publish: false,
+    });
   });
 
   it("falls back to raw text when the error body isn't JSON", async () => {

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1841,7 +1841,8 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
       "/api/config/modes/spoken/_clone"
     );
     expect(res.status).toBe(200);
-    expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
+    // Verb-list header: edit only — publish was withheld on the source.
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("edit");
     // Collision preflight GET + proxy POST.
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect((fetchSpy.mock.calls[1]![1] as RequestInit).method).toBe("POST");
@@ -1872,6 +1873,7 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
       "/api/config/modes/spoken/_clone"
     );
     expect(res.status).toBe(200);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("edit,publish");
     const after = await readRightsUser("shepherd@acme.com");
     expect(after.mode_edit_rights).toEqual(["spoken", "spoken-v2"]);
     expect(after.mode_publish_rights).toEqual(["spoken", "spoken-v2"]);
@@ -1896,11 +1898,51 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
       "/api/config/modes/spoken/_clone"
     );
     expect(res.status).toBe(409);
+    // No rights on the colliding slug → bare 409, no header.
+    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
     // Preflight only — no grant, no engine POST, no escalation window.
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const after = await readRightsUser("shepherd@acme.com");
     expect(after.mode_edit_rights).toEqual(["spoken"]);
     expect(after.mode_publish_rights).toEqual(["spoken"]);
+  });
+
+  it("ambiguous-commit reconciliation: engine committed on a lost response, retry collides → 409 CARRIES the held verbs (#258 rd-2 P2)", async () => {
+    // Attempt 1: grant written, engine created the mode, response lost
+    // (worker returned 502, grant kept). The retry's live session
+    // carries the kept grant; the collision preflight now finds the
+    // mode. The 409 must name the caller's held verbs so the client
+    // can mirror and surface the interrupted clone.
+    const fetchSpy = spyFetchCloneEngine("found");
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken", "spoken-v2"],
+        mode_publish_rights: ["spoken", "spoken-v2"],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(409);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("edit,publish");
+    // Preflight only — no engine POST.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ambiguous-commit reconciliation, edit-only variant → 409 carries "edit"', async () => {
+    const fetchSpy = spyFetchCloneEngine("found");
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken", "spoken-v2"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(409);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("edit");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("collision preflight engine error → 502 fail closed, no grant, no POST", async () => {
@@ -1950,9 +1992,10 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
       "/api/config/modes/spoken/_clone"
     );
     // NOTE: preflight is mocked "missing" — the ambiguous first attempt
-    // never created the mode.
+    // never created the mode. (The created-but-response-lost variant is
+    // covered by the ambiguous-commit reconciliation tests above.)
     expect(res.status).toBe(200);
-    expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("edit,publish");
   }, 10000);
 
   it("engine POST throws after the grant → 502 retry contract, grant kept (#258 rd-1)", async () => {

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1735,12 +1735,13 @@ describe("#240 rename rights migration", () => {
 // ---------------------------------------------------------------------------
 //
 // Clone creates a new mode (draft, distinct slug + optional label) via the
-// engine `_clone` op. The BFF proxies POST + `{ newName, newLabel? }` to
-// the engine, admin-gated on the same basis as _rename: per-user
-// mode_edit_rights / mode_publish_rights are slug-scoped, and the clone's
-// fresh slug has no rights pre-assigned, so a non-admin cloner would land
-// on a mode they can't edit. Matched before the generic `modes/{name}` arm
-// for the same regex-ordering reason as _rename.
+// engine `_clone` op. #257 opened it to shepherds at rename parity (EDIT
+// on the source slug); non-admin same-org cloners are auto-granted both
+// verbs on the new slug before the engine call (expand-first), with
+// compensation only on a definitive engine 4xx and an X-Bootstrap-Grant
+// response header so the client can mirror the grant. Matched before the
+// generic `modes/{name}` arm for the same regex-ordering reason as
+// _rename.
 
 function makeCloneRequest(name: string, body: object): Request {
   return new Request(
@@ -1794,21 +1795,183 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("non-admin with BOTH edit+publish on the source row → 403 (clone is admin-only, same reasoning as rename)", async () => {
-    // Clone's new slug carries no per-user rights, so a shepherd cloning
-    // would produce a mode they can't edit. Gating this to admins/cross-
-    // org avoids that trap; loosen when rights-migration exists (#240).
+  it("shepherd with EDIT on the source → 200, cloner auto-granted both verbs, X-Bootstrap-Grant set (#257)", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: [],
+    });
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeCloneRequest("spoken", { newName: "spoken-v2" }),
       env,
       makeSession({
+        email: "shepherd@acme.com",
         mode_edit_rights: ["spoken"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
+    // Clone has NO preflights — one fetch, the proxy POST.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("POST");
+
+    const after = await readRightsUser("shepherd@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken", "spoken-v2"]);
+    expect(after.mode_publish_rights).toEqual(["spoken-v2"]);
+  });
+
+  it("publish-only shepherd on the source → 403, no grant, no proxy (cloning is edit-side)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        mode_edit_rights: [],
         mode_publish_rights: ["spoken"],
       }),
       "/api/config/modes/spoken/_clone"
     );
     expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("engine rejects the clone with 409 → grant compensated, no header", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: [],
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+      Promise.resolve(new Response("slug taken", { status: 409 }))
+    );
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "shepherd@acme.com",
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(409);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
+    const after = await readRightsUser("shepherd@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken"]);
+    expect(after.mode_publish_rights).toEqual([]);
+  });
+
+  it("engine 5xx on the clone → grant kept (ambiguity never contracts), no header", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: [],
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+      Promise.resolve(new Response("", { status: 500 }))
+    );
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "shepherd@acme.com",
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(500);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
+    const after = await readRightsUser("shepherd@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken", "spoken-v2"]);
+  });
+
+  it("admin clone → NO grant and no header (mode admin trump covers)", async () => {
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      mode_edit_rights: [],
+      mode_publish_rights: [],
+    });
+    spyFetch();
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "admin@acme.com",
+        isAdmin: true,
+        mode_edit_rights: [],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.mode_edit_rights).toEqual([]);
+    expect(after.mode_publish_rights).toEqual([]);
+  });
+
+  it("stored user missing at grant time → 502, engine never called", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "ghost@acme.com",
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(502);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("missing newName → 400; invalid JSON → 400; non-POST → 405 — all before any engine traffic", async () => {
+    const fetchSpy = spyFetch();
+    const noName = await handleConfig(
+      makeCloneRequest("spoken", {}),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(noName.status).toBe(400);
+
+    const badJson = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_clone",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{nope",
+        }
+      ),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(badJson.status).toBe(400);
+
+    const wrongMethod = await handleConfig(
+      new Request(
+        "https://portal.example.test/api/config/modes/spoken/_clone",
+        {
+          method: "GET",
+        }
+      ),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(wrongMethod.status).toBe(405);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -1868,10 +2031,41 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
 // Retire moves the source mode's canonical slug (+ its own aliases) onto the
 // target mode's aliases array, then deletes the source. Users assigned to
 // the source (or resolving via one of its previous aliases) silently
-// resolve to the target. Same admin/cross-org gate as _rename and _clone —
-// deleting a mode is an org-wide config change at the same trust bar as
-// today's PUT/DELETE modes. Regex is segment-anchored so a duplicated
+// resolve to the target. #257 opened it to shepherds at DELETE-parity-
+// plus: edit+publish on the source AND edit on the CANONICAL forward
+// target, with two fail-closed preflights (canonical source addressing;
+// target resolved to canonical before the rights check) so stale aliases
+// can't capture or launder either side. Admin/cross-org callers keep the
+// preflight-free fast path. Regex is segment-anchored so a duplicated
 // suffix falls through to the generic arm and 405s at the BFF.
+
+// URL-routing engine mock for the shepherd retire path: preflight GETs
+// answered per-slug, the proxy POST answered 200. `slugStates` maps a
+// slug to a found-name, "missing", or "error".
+function spyFetchRetireEngine(
+  slugStates: Record<string, string | "missing" | "error">
+) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const method = (init as RequestInit | undefined)?.method ?? "GET";
+    if (method === "POST") {
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }
+    const url = String(input);
+    const slug = decodeURIComponent(url.split("/modes/")[1] ?? "");
+    const state = slugStates[slug];
+    if (state === undefined || state === "missing") {
+      return Promise.resolve(new Response("", { status: 404 }));
+    }
+    if (state === "error") {
+      return Promise.resolve(new Response("", { status: 500 }));
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ mode: { name: state, document: "x" } }), {
+        status: 200,
+      })
+    );
+  });
+}
 
 function makeRetireRequest(name: string, body: object): Request {
   return new Request(
@@ -1925,22 +2119,199 @@ describe("config authz — #241 PR C mode retire (_retire)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("non-admin with BOTH edit+publish on the source row → 403 (retire is admin-only)", async () => {
-    // Same reasoning as rename/clone: retire deletes a mode + widens the
-    // target's alias set (org-wide change), and the target's rights
-    // aren't necessarily aligned with the source's — a shepherd who
-    // could edit the source might have no rights on the target.
+  it("shepherd with edit+publish on source AND edit on target → 200 via preflights (#257)", async () => {
+    const fetchSpy = spyFetchRetireEngine({
+      spoken: "spoken",
+      conversation: "conversation",
+    });
+    const res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken", "conversation"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(200);
+    // Two preflight GETs + the proxy POST.
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(
+      (fetchSpy.mock.calls[2]![1] as RequestInit | undefined)?.method
+    ).toBe("POST");
+  });
+
+  it("shepherd edit-only on source (no publish) → 403 before any engine traffic (#257: DELETE parity)", async () => {
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRetireRequest("spoken", { forwardTo: "conversation" }),
       env,
       makeSession({
         mode_edit_rights: ["spoken", "conversation"],
-        mode_publish_rights: ["spoken", "conversation"],
+        mode_publish_rights: [],
       }),
       "/api/config/modes/spoken/_retire"
     );
     expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("shepherd lacking edit on the forward target → 403 after preflights, no proxy (#257)", async () => {
+    const fetchSpy = spyFetchRetireEngine({
+      spoken: "spoken",
+      conversation: "conversation",
+    });
+    const res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(403);
+    // Preflights ran, proxy POST did not.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("alias-addressed source → 409, no proxy (stale-alias capture blocked, #257)", async () => {
+    // Shepherd holds rights on the stale alias slug; the engine would
+    // resolve it to the canonical mode and retire THAT. The canonical
+    // preflight refuses.
+    const fetchSpy = spyFetchRetireEngine({
+      "old-alias": "spoken",
+      conversation: "conversation",
+    });
+    const res = await handleConfig(
+      makeRetireRequest("old-alias", { forwardTo: "conversation" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["old-alias", "conversation"],
+        mode_publish_rights: ["old-alias"],
+      }),
+      "/api/config/modes/old-alias/_retire"
+    );
+    expect(res.status).toBe(409);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwardTo alias resolving to an unauthorized canonical target → 403 (alias laundering blocked, #257)", async () => {
+    // Shepherd holds edit on the alias STRING but not on the canonical
+    // mode it resolves to; the rights check keys on the canonical name.
+    const fetchSpy = spyFetchRetireEngine({
+      spoken: "spoken",
+      "target-alias": "conversation",
+    });
+    const res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "target-alias" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken", "target-alias"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("shepherd preflight failure modes: source missing → 404, target missing → 404, engine error → 502 (fail closed)", async () => {
+    const sourceMissing = spyFetchRetireEngine({
+      conversation: "conversation",
+    });
+    let res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken", "conversation"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(404);
+    sourceMissing.mockRestore();
+
+    const targetMissing = spyFetchRetireEngine({ spoken: "spoken" });
+    res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken", "conversation"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(404);
+    targetMissing.mockRestore();
+
+    spyFetchRetireEngine({ spoken: "error", conversation: "conversation" });
+    res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken", "conversation"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(502);
+  });
+
+  it("admin retire skips the preflights (single proxy fetch, unchanged fast path)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_retire"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("missing forwardTo → 400; invalid JSON → 400; non-POST → 405", async () => {
+    const fetchSpy = spyFetch();
+    expect(
+      (
+        await handleConfig(
+          makeRetireRequest("spoken", {}),
+          env,
+          makeSession({ isAdmin: true }),
+          "/api/config/modes/spoken/_retire"
+        )
+      ).status
+    ).toBe(400);
+    expect(
+      (
+        await handleConfig(
+          new Request(
+            "https://portal.example.test/api/config/modes/spoken/_retire",
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: "{nope",
+            }
+          ),
+          env,
+          makeSession({ isAdmin: true }),
+          "/api/config/modes/spoken/_retire"
+        )
+      ).status
+    ).toBe(400);
+    expect(
+      (
+        await handleConfig(
+          new Request(
+            "https://portal.example.test/api/config/modes/spoken/_retire",
+            { method: "GET" }
+          ),
+          env,
+          makeSession({ isAdmin: true }),
+          "/api/config/modes/spoken/_retire"
+        )
+      ).status
+    ).toBe(405);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -1754,6 +1754,33 @@ function makeCloneRequest(name: string, body: object): Request {
   );
 }
 
+// Routed engine mock for the shepherd clone path: the collision
+// preflight GET is answered per `preflight` ("missing" | "found" |
+// "error"), the proxy POST per `post`.
+function spyFetchCloneEngine(
+  preflight: "missing" | "found" | "error",
+  post: { status: number } | "throw" = { status: 200 }
+) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+    const method = (init as RequestInit | undefined)?.method ?? "GET";
+    if (method === "POST") {
+      if (post === "throw") return Promise.reject(new Error("engine down"));
+      return Promise.resolve(new Response("{}", { status: post.status }));
+    }
+    if (preflight === "found") {
+      return Promise.resolve(
+        new Response(JSON.stringify({ mode: { name: "spoken-v2" } }), {
+          status: 200,
+        })
+      );
+    }
+    if (preflight === "error") {
+      return Promise.resolve(new Response("", { status: 500 }));
+    }
+    return Promise.resolve(new Response("", { status: 404 }));
+  });
+}
+
 describe("config authz — #241 PR B mode clone (_clone)", () => {
   it("admin → proxies POST to engine _clone path", async () => {
     const fetchSpy = spyFetch();
@@ -1795,14 +1822,14 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("shepherd with EDIT on the source → 200, cloner auto-granted both verbs, X-Bootstrap-Grant set (#257)", async () => {
+  it("edit-only shepherd → 200, granted EDIT ONLY on the new slug (no publish widening, #258 rd-1), header set", async () => {
     await seedRightsUser({
       email: "shepherd@acme.com",
       org: "acme",
       mode_edit_rights: ["spoken"],
       mode_publish_rights: [],
     });
-    const fetchSpy = spyFetch();
+    const fetchSpy = spyFetchCloneEngine("missing");
     const res = await handleConfig(
       makeCloneRequest("spoken", { newName: "spoken-v2" }),
       env,
@@ -1815,13 +1842,140 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
     );
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
-    // Clone has NO preflights — one fetch, the proxy POST.
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("POST");
+    // Collision preflight GET + proxy POST.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect((fetchSpy.mock.calls[1]![1] as RequestInit).method).toBe("POST");
 
     const after = await readRightsUser("shepherd@acme.com");
     expect(after.mode_edit_rights).toEqual(["spoken", "spoken-v2"]);
-    expect(after.mode_publish_rights).toEqual(["spoken-v2"]);
+    // Publish was explicitly withheld on the source — the clone must
+    // not widen it.
+    expect(after.mode_publish_rights).toEqual([]);
+  });
+
+  it("edit+publish shepherd on the source → granted BOTH verbs on the new slug", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: ["spoken"],
+    });
+    spyFetchCloneEngine("missing");
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "shepherd@acme.com",
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(200);
+    const after = await readRightsUser("shepherd@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken", "spoken-v2"]);
+    expect(after.mode_publish_rights).toEqual(["spoken", "spoken-v2"]);
+  });
+
+  it("newName collides with an existing mode/alias → 409 with NO grant written and no engine POST (#258 rd-1 P1)", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: ["spoken"],
+    });
+    const fetchSpy = spyFetchCloneEngine("found");
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "shepherd@acme.com",
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(409);
+    // Preflight only — no grant, no engine POST, no escalation window.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const after = await readRightsUser("shepherd@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken"]);
+    expect(after.mode_publish_rights).toEqual(["spoken"]);
+  });
+
+  it("collision preflight engine error → 502 fail closed, no grant, no POST", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: [],
+    });
+    const fetchSpy = spyFetchCloneEngine("error");
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "shepherd@acme.com",
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (await readRightsUser("shepherd@acme.com")).mode_edit_rights
+    ).toEqual(["spoken"]);
+  });
+
+  it("retry after an ambiguous first attempt (grant already in KV) → header STILL set (#258 rd-1)", async () => {
+    // First attempt granted and the engine 5xx'd; the slug is already
+    // in both fields, so this request's grant writes nothing — the
+    // client must still be told to mirror.
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken", "spoken-v2"],
+      mode_publish_rights: ["spoken", "spoken-v2"],
+    });
+    spyFetchCloneEngine("missing");
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "shepherd@acme.com",
+        mode_edit_rights: ["spoken", "spoken-v2"],
+        mode_publish_rights: ["spoken", "spoken-v2"],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    // NOTE: preflight is mocked "missing" — the ambiguous first attempt
+    // never created the mode.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
+  }, 10000);
+
+  it("engine POST throws after the grant → 502 retry contract, grant kept (#258 rd-1)", async () => {
+    await seedRightsUser({
+      email: "shepherd@acme.com",
+      org: "acme",
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: [],
+    });
+    spyFetchCloneEngine("missing", "throw");
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "spoken-v2" }),
+      env,
+      makeSession({
+        email: "shepherd@acme.com",
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(502);
+    const after = await readRightsUser("shepherd@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken", "spoken-v2"]);
   });
 
   it("publish-only shepherd on the source → 403, no grant, no proxy (cloning is edit-side)", async () => {
@@ -1839,16 +1993,14 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("engine rejects the clone with 409 → grant compensated, no header", async () => {
+  it("TOCTOU race — preflight missing but engine 409s the create → grant compensated, no header", async () => {
     await seedRightsUser({
       email: "shepherd@acme.com",
       org: "acme",
       mode_edit_rights: ["spoken"],
       mode_publish_rights: [],
     });
-    vi.spyOn(globalThis, "fetch").mockImplementation(() =>
-      Promise.resolve(new Response("slug taken", { status: 409 }))
-    );
+    spyFetchCloneEngine("missing", { status: 409 });
     const res = await handleConfig(
       makeCloneRequest("spoken", { newName: "spoken-v2" }),
       env,
@@ -1873,9 +2025,7 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
       mode_edit_rights: ["spoken"],
       mode_publish_rights: [],
     });
-    vi.spyOn(globalThis, "fetch").mockImplementation(() =>
-      Promise.resolve(new Response("", { status: 500 }))
-    );
+    spyFetchCloneEngine("missing", { status: 500 });
     const res = await handleConfig(
       makeCloneRequest("spoken", { newName: "spoken-v2" }),
       env,
@@ -1919,8 +2069,8 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
     expect(after.mode_publish_rights).toEqual([]);
   });
 
-  it("stored user missing at grant time → 502, engine never called", async () => {
-    const fetchSpy = spyFetch();
+  it("stored user missing at grant time → 502, engine POST never fires", async () => {
+    const fetchSpy = spyFetchCloneEngine("missing");
     const res = await handleConfig(
       makeCloneRequest("spoken", { newName: "spoken-v2" }),
       env,
@@ -1932,7 +2082,23 @@ describe("config authz — #241 PR B mode clone (_clone)", () => {
       "/api/config/modes/spoken/_clone"
     );
     expect(res.status).toBe(502);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    // Only the collision preflight ran.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("padded newName → engine receives the TRIMMED value the grant used (#258 rd-1)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeCloneRequest("spoken", { newName: "  spoken-v2  " }),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken/_clone"
+    );
+    expect(res.status).toBe(200);
+    const sent = JSON.parse(
+      String((fetchSpy.mock.calls[0]![1] as RequestInit).body)
+    ) as { newName: string };
+    expect(sent.newName).toBe("spoken-v2");
   });
 
   it("missing newName → 400; invalid JSON → 400; non-POST → 405 — all before any engine traffic", async () => {
@@ -2258,16 +2424,20 @@ describe("config authz — #241 PR C mode retire (_retire)", () => {
     expect(res.status).toBe(502);
   });
 
-  it("admin retire skips the preflights (single proxy fetch, unchanged fast path)", async () => {
+  it("admin retire skips the preflights (single proxy fetch, unchanged fast path) and forwards trimmed forwardTo", async () => {
     const fetchSpy = spyFetch();
     const res = await handleConfig(
-      makeRetireRequest("spoken", { forwardTo: "conversation" }),
+      makeRetireRequest("spoken", { forwardTo: "  conversation  " }),
       env,
       makeSession({ isAdmin: true }),
       "/api/config/modes/spoken/_retire"
     );
     expect(res.status).toBe(200);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(
+      String((fetchSpy.mock.calls[0]![1] as RequestInit).body)
+    ) as { forwardTo: string };
+    expect(sent.forwardTo).toBe("conversation");
   });
 
   it("missing forwardTo → 400; invalid JSON → 400; non-POST → 405", async () => {

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -494,10 +494,25 @@ describe("mirrorBootstrapGrant", () => {
 // mirrorBootstrapGrant above for the history).
 
 describe("mirrorModeGrant", () => {
-  it("adds the slug to both verb fields, materializing unset fields as [slug]", () => {
-    expect(mirrorModeGrant({ mode_edit_rights: ["spoken"] }, "sw")).toEqual({
+  it("adds the slug to both verb fields when includePublish, materializing unset fields as [slug]", () => {
+    expect(
+      mirrorModeGrant({ mode_edit_rights: ["spoken"] }, "sw", true)
+    ).toEqual({
       mode_edit_rights: ["spoken", "sw"],
       mode_publish_rights: ["sw"],
+    });
+  });
+
+  it("edit-only mirror: publish untouched when includePublish is false (#258 rd-1)", () => {
+    expect(
+      mirrorModeGrant(
+        { mode_edit_rights: ["spoken"], mode_publish_rights: [] },
+        "sw",
+        false
+      )
+    ).toEqual({
+      mode_edit_rights: ["spoken", "sw"],
+      mode_publish_rights: [],
     });
   });
 
@@ -505,7 +520,8 @@ describe("mirrorModeGrant", () => {
     expect(
       mirrorModeGrant(
         { mode_edit_rights: "*", mode_publish_rights: ["sw"] },
-        "sw"
+        "sw",
+        true
       )
     ).toEqual({ mode_edit_rights: "*", mode_publish_rights: ["sw"] });
   });
@@ -515,7 +531,9 @@ describe("mirrorModeGrant", () => {
       email: "a@acme.com",
       mode_edit_rights: ["spoken"] as string[],
     };
-    expect(mirrorModeGrant(user, "sw")).toMatchObject({ email: "a@acme.com" });
+    expect(mirrorModeGrant(user, "sw", true)).toMatchObject({
+      email: "a@acme.com",
+    });
     expect(user.mode_edit_rights).toEqual(["spoken"]);
   });
 });

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   mirrorBootstrapGrant,
+  mirrorModeGrant,
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
   effectiveModeEditRights,
@@ -485,5 +486,36 @@ describe("mirrorBootstrapGrant", () => {
       isAdmin: true,
     });
     expect(user.language_edit_rights).toEqual([]);
+  });
+});
+
+// #257 — local mirror of the worker's clone auto-grant, driven strictly
+// by the X-Bootstrap-Grant wire signal (no inference — see
+// mirrorBootstrapGrant above for the history).
+
+describe("mirrorModeGrant", () => {
+  it("adds the slug to both verb fields, materializing unset fields as [slug]", () => {
+    expect(mirrorModeGrant({ mode_edit_rights: ["spoken"] }, "sw")).toEqual({
+      mode_edit_rights: ["spoken", "sw"],
+      mode_publish_rights: ["sw"],
+    });
+  });
+
+  it("wildcards pass through untouched; held slugs are idempotent", () => {
+    expect(
+      mirrorModeGrant(
+        { mode_edit_rights: "*", mode_publish_rights: ["sw"] },
+        "sw"
+      )
+    ).toEqual({ mode_edit_rights: "*", mode_publish_rights: ["sw"] });
+  });
+
+  it("preserves unrelated fields and does not mutate the input", () => {
+    const user = {
+      email: "a@acme.com",
+      mode_edit_rights: ["spoken"] as string[],
+    };
+    expect(mirrorModeGrant(user, "sw")).toMatchObject({ email: "a@acme.com" });
+    expect(user.mode_edit_rights).toEqual(["spoken"]);
   });
 });

--- a/tests/rights-migration.test.ts
+++ b/tests/rights-migration.test.ts
@@ -449,7 +449,10 @@ describe("grantModeSlugToUser", () => {
       mode_edit_rights: ["spoken"],
       mode_publish_rights: [],
     });
-    const fields = await grantModeSlugToUser(env, "cloner@acme.com", "sw");
+    const fields = await grantModeSlugToUser(env, "cloner@acme.com", "sw", [
+      "mode_edit_rights",
+      "mode_publish_rights",
+    ]);
     expect(fields).toEqual(["mode_edit_rights", "mode_publish_rights"]);
     const after = await read("cloner@acme.com");
     expect(after.mode_edit_rights).toEqual(["spoken", "sw"]);
@@ -458,9 +461,26 @@ describe("grantModeSlugToUser", () => {
 
   it("materializes an UNSET field as [slug] (no-access, not full-access)", async () => {
     await seed("unset@acme.com", "acme", { mode_edit_rights: ["spoken"] });
-    await grantModeSlugToUser(env, "unset@acme.com", "sw");
+    await grantModeSlugToUser(env, "unset@acme.com", "sw", [
+      "mode_edit_rights",
+      "mode_publish_rights",
+    ]);
     const after = await read("unset@acme.com");
     expect(after.mode_publish_rights).toEqual(["sw"]);
+  });
+
+  it("grants ONLY the requested fields — edit-only cloners never gain publish (#258 rd-1)", async () => {
+    await seed("editonly@acme.com", "acme", {
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: [],
+    });
+    const fields = await grantModeSlugToUser(env, "editonly@acme.com", "sw", [
+      "mode_edit_rights",
+    ]);
+    expect(fields).toEqual(["mode_edit_rights"]);
+    const after = await read("editonly@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken", "sw"]);
+    expect(after.mode_publish_rights).toEqual([]);
   });
 
   it("wildcards pass through untouched; already-held slugs are idempotent", async () => {
@@ -468,7 +488,10 @@ describe("grantModeSlugToUser", () => {
       mode_edit_rights: "*",
       mode_publish_rights: ["sw"],
     });
-    const fields = await grantModeSlugToUser(env, "wild@acme.com", "sw");
+    const fields = await grantModeSlugToUser(env, "wild@acme.com", "sw", [
+      "mode_edit_rights",
+      "mode_publish_rights",
+    ]);
     expect(fields).toEqual([]);
     const after = await read("wild@acme.com");
     expect(after.mode_edit_rights).toBe("*");
@@ -477,7 +500,7 @@ describe("grantModeSlugToUser", () => {
 
   it("throws when the stored user is missing", async () => {
     await expect(
-      grantModeSlugToUser(env, "ghost@acme.com", "sw")
+      grantModeSlugToUser(env, "ghost@acme.com", "sw", ["mode_edit_rights"])
     ).rejects.toThrow(/no stored user/);
   });
 });

--- a/tests/rights-migration.test.ts
+++ b/tests/rights-migration.test.ts
@@ -13,8 +13,10 @@ import {
   expandOrgModeRights,
   expandRights,
   grantLanguageSlugToUser,
+  grantModeSlugToUser,
   removeSlugIfPartnerPresent,
   revokeLanguageSlugFromUser,
+  revokeModeSlugFromUser,
 } from "../worker/rights-migration";
 import type { StoredUser } from "../worker/types";
 
@@ -430,5 +432,80 @@ describe("revokeLanguageSlugFromUser", () => {
       "language_edit_rights",
     ]);
     expect((await read("drift@acme.com")).language_edit_rights).toBe("*");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #257 — clone auto-grant (single-user, both MODE verb fields)
+// ---------------------------------------------------------------------------
+//
+// Mode semantics, not language semantics: no legacy fallback, and an
+// unset field means "no access" for non-admins — so it materializes as
+// [slug] instead of consulting anything.
+
+describe("grantModeSlugToUser", () => {
+  it("grants both verb fields and returns the modified fields", async () => {
+    await seed("cloner@acme.com", "acme", {
+      mode_edit_rights: ["spoken"],
+      mode_publish_rights: [],
+    });
+    const fields = await grantModeSlugToUser(env, "cloner@acme.com", "sw");
+    expect(fields).toEqual(["mode_edit_rights", "mode_publish_rights"]);
+    const after = await read("cloner@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken", "sw"]);
+    expect(after.mode_publish_rights).toEqual(["sw"]);
+  });
+
+  it("materializes an UNSET field as [slug] (no-access, not full-access)", async () => {
+    await seed("unset@acme.com", "acme", { mode_edit_rights: ["spoken"] });
+    await grantModeSlugToUser(env, "unset@acme.com", "sw");
+    const after = await read("unset@acme.com");
+    expect(after.mode_publish_rights).toEqual(["sw"]);
+  });
+
+  it("wildcards pass through untouched; already-held slugs are idempotent", async () => {
+    await seed("wild@acme.com", "acme", {
+      mode_edit_rights: "*",
+      mode_publish_rights: ["sw"],
+    });
+    const fields = await grantModeSlugToUser(env, "wild@acme.com", "sw");
+    expect(fields).toEqual([]);
+    const after = await read("wild@acme.com");
+    expect(after.mode_edit_rights).toBe("*");
+    expect(after.mode_publish_rights).toEqual(["sw"]);
+  });
+
+  it("throws when the stored user is missing", async () => {
+    await expect(
+      grantModeSlugToUser(env, "ghost@acme.com", "sw")
+    ).rejects.toThrow(/no stored user/);
+  });
+});
+
+describe("revokeModeSlugFromUser", () => {
+  it("removes the slug from exactly the recorded fields", async () => {
+    await seed("rev-mode@acme.com", "acme", {
+      mode_edit_rights: ["spoken", "sw"],
+      mode_publish_rights: ["sw"],
+    });
+    await revokeModeSlugFromUser(env, "rev-mode@acme.com", "sw", [
+      "mode_edit_rights",
+    ]);
+    const after = await read("rev-mode@acme.com");
+    expect(after.mode_edit_rights).toEqual(["spoken"]);
+    // Not recorded → untouched.
+    expect(after.mode_publish_rights).toEqual(["sw"]);
+  });
+
+  it("tolerates a vanished user and drifted fields", async () => {
+    await expect(
+      revokeModeSlugFromUser(env, "gone@acme.com", "sw", ["mode_edit_rights"])
+    ).resolves.toBeUndefined();
+
+    await seed("drift-mode@acme.com", "acme", { mode_edit_rights: "*" });
+    await revokeModeSlugFromUser(env, "drift-mode@acme.com", "sw", [
+      "mode_edit_rights",
+    ]);
+    expect((await read("drift-mode@acme.com")).mode_edit_rights).toBe("*");
   });
 });

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -850,6 +850,11 @@ export async function handleConfig(
     }
 
     const isShepherdClone = !resolved.crossOrg && !hasAdminPowers(session);
+    // Whether the cloner holds PUBLISH on the source — drives both the
+    // grant shape and the response header's verb list.
+    const sourcePublishHeld =
+      isShepherdClone &&
+      hasRights(rightsFor(session, "mode", "publish"), modeName);
     let grantedFields: RightsField[] = [];
     if (isShepherdClone) {
       // P1 preflight — see the arm comment. Runs only on the shepherd
@@ -863,17 +868,35 @@ export async function handleConfig(
         );
       }
       if (collision.status === "found") {
-        return errorResponse(
+        const conflict = errorResponse(
           `A mode named "${newName}" already exists (as a mode or alias)`,
           409
         );
+        // Ambiguous-commit reconciliation (#258 rd-2 P2): if a prior
+        // attempt's engine create COMMITTED but its response was lost,
+        // the grant was kept (ambiguity never contracts) and the retry
+        // lands here — without a signal, the session could never learn
+        // the rights it already holds and the interrupted clone stays
+        // invisible until re-login. The live session is re-hydrated
+        // from KV per request, so it already carries any kept grant:
+        // surface the caller's ACTUAL verbs on the colliding slug on
+        // the 409. This never invents rights — it names exactly what
+        // the session holds; a caller with no rights on the slug gets
+        // the bare 409.
+        if (hasRights(rightsFor(session, "mode", "edit"), newName)) {
+          const verbs = ["edit"];
+          if (hasRights(rightsFor(session, "mode", "publish"), newName)) {
+            verbs.push("publish");
+          }
+          const flagged = new Response(conflict.body, conflict);
+          flagged.headers.set("X-Bootstrap-Grant", verbs.join(","));
+          return flagged;
+        }
+        return conflict;
       }
       // Grant exactly the verbs held on the SOURCE slug (edit is
       // guaranteed by the gate above; publish only if held there).
-      const grantFields: RightsField[] = hasRights(
-        rightsFor(session, "mode", "publish"),
-        modeName
-      )
+      const grantFields: RightsField[] = sourcePublishHeld
         ? ["mode_edit_rights", "mode_publish_rights"]
         : ["mode_edit_rights"];
       try {
@@ -925,10 +948,21 @@ export async function handleConfig(
     // Keyed on the OUTCOME (shepherd + engine 2xx), not on whether THIS
     // request's grant wrote anything — a retry after an ambiguous first
     // attempt finds the grant already in KV (grantedFields []) and must
-    // still tell the client to mirror (#258 rd-1).
+    // still tell the client to mirror (#258 rd-1). The value names the
+    // verbs the caller now holds on the new slug: the ones this grant
+    // ensured, plus publish if the pre-grant session already carried it
+    // there — precise, so the client mirrors truth instead of
+    // recomputing it (#258 rd-2).
     if (isShepherdClone && engineRes.ok) {
+      const verbs = ["edit"];
+      if (
+        sourcePublishHeld ||
+        hasRights(rightsFor(session, "mode", "publish"), newName)
+      ) {
+        verbs.push("publish");
+      }
       const flagged = new Response(engineRes.body, engineRes);
-      flagged.headers.set("X-Bootstrap-Grant", "1");
+      flagged.headers.set("X-Bootstrap-Grant", verbs.join(","));
       return flagged;
     }
     return engineRes;

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -4,9 +4,12 @@ import {
   contractOrgModeRights,
   expandOrgModeRights,
   grantLanguageSlugToUser,
+  grantModeSlugToUser,
   revokeLanguageSlugFromUser,
+  revokeModeSlugFromUser,
   type LanguageVerbRightsField,
   type MigrationRecord,
+  type RightsField,
 } from "./rights-migration";
 import type { LanguageRights, SessionData } from "./types";
 
@@ -776,31 +779,96 @@ export async function handleConfig(
     return engineRes;
   }
 
-  // /api/config/modes/{name}/_clone → POST. Admin/cross-org ONLY —
-  // deliberately STRICTER than _rename, which #240 opened to edit-
-  // rights shepherds. The engine creates a new mode with the new slug +
-  // optional label; content is copied verbatim from the source. Rights
-  // don't migrate — mode_edit_rights / mode_publish_rights are slug-
-  // scoped and no shepherd holds rights on the fresh slug yet, so a
-  // non-admin cloning would land on a mode they can't edit. Opening
-  // this needs a cloner-auto-grant decision (rights-migration.ts
-  // primitives are ready; product call pending). Matched above the
-  // catch-all for the same regex-ordering reason as _rename.
-  // `[^/]+` for the same reason as _rename above.
+  // /api/config/modes/{name}/_clone → POST. Opened to shepherds (#257):
+  // rename-parity gate — admins and cross-org super-admins pass as
+  // before; non-admin shepherds pass with EDIT rights on the source
+  // slug (publish-only stays denied; cloning is an edit-side action).
+  // The engine creates a new mode with the new slug + optional label;
+  // content is copied verbatim from the source.
+  //
+  // Cloner auto-grant (#257): mode_edit_rights / mode_publish_rights
+  // are slug-scoped and no shepherd holds rights on the fresh slug, so
+  // a non-admin clone would otherwise land on a mode its own creator
+  // can't edit. Non-admin same-org cloners are granted both verbs on
+  // the new slug BEFORE the engine call (#240 expand-first model: a
+  // failure after the grant leaves an inert entry, never a lockout);
+  // compensation runs only on a definitive engine 4xx (e.g. the slug-
+  // collision 409) — ambiguity keeps the superset. Admin/cross-org
+  // callers need no grant (mode admin trump). Successful grants are
+  // signalled via X-Bootstrap-Grant so the client mirrors the rights
+  // without a /me refetch or inference (#256 rds 2–3 rationale).
+  //
+  // No canonical-slug preflight, deliberately: the engine resolves an
+  // alias-addressed source, but clone neither mutates the source nor
+  // keys any rights on it — the grant attaches to the FRESH slug, and
+  // mode content is already readable by any session via the ungated
+  // GET — so alias addressing isn't capturable here (contrast _rename
+  // and _retire). Matched above the catch-all for the same regex-
+  // ordering reason as _rename; `[^/]+` likewise.
   const modeCloneMatch = pathname.match(
     /^\/api\/config\/modes\/([^/]+)\/_clone$/
   );
   if (modeCloneMatch?.[1]) {
     const modeName = decodeURIComponent(modeCloneMatch[1]);
-    if (!resolved.crossOrg && !hasAdminPowers(session)) {
+    if (
+      !resolved.crossOrg &&
+      !hasAdminPowers(session) &&
+      !hasRights(rightsFor(session, "mode", "edit"), modeName)
+    ) {
       return errorResponse("Forbidden", 403);
     }
-    return proxyToEngine(
+    // Method check before the body read — see the _rename arm.
+    if (request.method !== "POST") {
+      return errorResponse("Method not allowed", 405);
+    }
+    // The grant needs `newName` before the engine call, so this arm
+    // consumes the body (one-shot stream) and passes the parsed copy
+    // through proxyToEngine, mirroring _rename.
+    let cloneBody: { newName?: unknown } | null;
+    try {
+      cloneBody = (await request.json()) as { newName?: unknown } | null;
+    } catch {
+      return errorResponse("Invalid JSON", 400);
+    }
+    const newName =
+      typeof cloneBody?.newName === "string" ? cloneBody.newName.trim() : "";
+    if (!newName) {
+      return errorResponse("Missing newName", 400);
+    }
+
+    const isShepherdClone = !resolved.crossOrg && !hasAdminPowers(session);
+    let grantedFields: RightsField[] = [];
+    if (isShepherdClone) {
+      try {
+        grantedFields = await grantModeSlugToUser(env, session.email, newName);
+      } catch (err) {
+        console.error(
+          `clone: rights grant failed for ${session.email} ("${newName}")`,
+          err
+        );
+        return errorResponse("Failed to grant cloner rights", 502);
+      }
+    }
+    const engineRes = await proxyToEngine(
       request,
       env,
       `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}/_clone`,
-      ["POST"]
+      ["POST"],
+      cloneBody
     );
+    if (
+      grantedFields.length > 0 &&
+      engineRes.status >= 400 &&
+      engineRes.status < 500
+    ) {
+      await revokeModeSlugFromUser(env, session.email, newName, grantedFields);
+    }
+    if (isShepherdClone && grantedFields.length > 0 && engineRes.ok) {
+      const flagged = new Response(engineRes.body, engineRes);
+      flagged.headers.set("X-Bootstrap-Grant", "1");
+      return flagged;
+    }
+    return engineRes;
   }
 
   // /api/config/modes/{name}/_retire → POST. Retires the source mode
@@ -810,26 +878,101 @@ export async function handleConfig(
   // silently resolve to the target — the "bring FIA Coach users over
   // silently" flow from Ian's #232 plan §3.
   //
-  // Admin/cross-org ONLY — deliberately STRICTER than _rename, which
-  // #240 opened to edit-rights shepherds. Retire deletes a mode +
-  // widens the target's alias set, both org-wide config changes;
-  // whether the retired mode's shepherds should inherit rights on the
-  // forward target is an open product call (rights-migration.ts
-  // primitives are ready). `[^/]+` for the same reason as _rename and
-  // _clone above.
+  // Opened to shepherds (#257) at DELETE-parity-plus: admins and
+  // cross-org super-admins pass as before; a non-admin shepherd needs
+  // EDIT + PUBLISH on the source (retire is strictly more destructive
+  // than DELETE, which already demands both) AND EDIT on the CANONICAL
+  // forward target (retire widens the target's alias array — an edit
+  // of the target).
+  //
+  // Two fail-closed preflights for the shepherd path, mirroring the
+  // #240 rename arm: (1) the addressed source slug must be the mode's
+  // canonical name — the engine resolves aliases, so without this a
+  // shepherd holding rights only on a STALE ALIAS could retire the
+  // aliased-to mode out from under its real shepherds; (2) `forwardTo`
+  // resolves to its canonical name and the shepherd's edit rights are
+  // checked against THAT, so an alias can't launder the target rights
+  // check. Both run AFTER the coarse source-rights gate, so a
+  // no-rights caller can't probe mode existence through them.
+  //
+  // Non-goal (v1, documented in #257): rights inheritance. Shepherds
+  // of the retired mode do NOT gain rights on the forward target;
+  // their entries for the retired slug go inert, exactly as with a
+  // DELETE today. `[^/]+` for the same reason as _rename and _clone.
   const modeRetireMatch = pathname.match(
     /^\/api\/config\/modes\/([^/]+)\/_retire$/
   );
   if (modeRetireMatch?.[1]) {
     const modeName = decodeURIComponent(modeRetireMatch[1]);
-    if (!resolved.crossOrg && !hasAdminPowers(session)) {
+    const isShepherdRetire = !resolved.crossOrg && !hasAdminPowers(session);
+    if (
+      isShepherdRetire &&
+      (!hasRights(rightsFor(session, "mode", "edit"), modeName) ||
+        !hasRights(rightsFor(session, "mode", "publish"), modeName))
+    ) {
       return errorResponse("Forbidden", 403);
     }
+    // Method check before the body read — see the _rename arm.
+    if (request.method !== "POST") {
+      return errorResponse("Method not allowed", 405);
+    }
+    let retireBody: { forwardTo?: unknown } | null;
+    try {
+      retireBody = (await request.json()) as { forwardTo?: unknown } | null;
+    } catch {
+      return errorResponse("Invalid JSON", 400);
+    }
+    const forwardTo =
+      typeof retireBody?.forwardTo === "string"
+        ? retireBody.forwardTo.trim()
+        : "";
+    if (!forwardTo) {
+      return errorResponse("Missing forwardTo", 400);
+    }
+
+    if (isShepherdRetire) {
+      // Both engine GETs run in parallel (independent lookups),
+      // evaluated source-first so a flaky target GET can't mask a
+      // definitive source answer (rd-5 rename review, same rule).
+      const [source, target] = await Promise.all([
+        preflightMode(env, resolved.org, modeName),
+        preflightMode(env, resolved.org, forwardTo),
+      ]);
+      if (source.status === "error") {
+        return errorResponse(
+          "Engine unreachable; retire not attempted. Retry the retire.",
+          502
+        );
+      }
+      if (source.status === "missing") {
+        return errorResponse("Mode not found", 404);
+      }
+      if (source.mode.name !== modeName) {
+        return errorResponse(
+          `"${modeName}" is an alias of "${source.mode.name}" — retire the mode via its canonical slug`,
+          409
+        );
+      }
+      if (target.status === "error") {
+        return errorResponse(
+          "Engine unreachable; retire not attempted. Retry the retire.",
+          502
+        );
+      }
+      if (target.status === "missing") {
+        return errorResponse("Forward target not found", 404);
+      }
+      if (!hasRights(rightsFor(session, "mode", "edit"), target.mode.name)) {
+        return errorResponse("Forbidden", 403);
+      }
+    }
+
     return proxyToEngine(
       request,
       env,
       `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}/_retire`,
-      ["POST"]
+      ["POST"],
+      retireBody
     );
   }
 

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -789,22 +789,35 @@ export async function handleConfig(
   // Cloner auto-grant (#257): mode_edit_rights / mode_publish_rights
   // are slug-scoped and no shepherd holds rights on the fresh slug, so
   // a non-admin clone would otherwise land on a mode its own creator
-  // can't edit. Non-admin same-org cloners are granted both verbs on
-  // the new slug BEFORE the engine call (#240 expand-first model: a
-  // failure after the grant leaves an inert entry, never a lockout);
-  // compensation runs only on a definitive engine 4xx (e.g. the slug-
-  // collision 409) — ambiguity keeps the superset. Admin/cross-org
-  // callers need no grant (mode admin trump). Successful grants are
-  // signalled via X-Bootstrap-Grant so the client mirrors the rights
-  // without a /me refetch or inference (#256 rds 2–3 rationale).
+  // can't edit. Non-admin same-org cloners are granted, on the new
+  // slug, exactly the verbs they hold on the SOURCE (edit always — the
+  // gate requires it; publish only if they hold it there), BEFORE the
+  // engine call (#240 expand-first model). Compensation runs only on a
+  // definitive engine 4xx — ambiguity keeps the superset. Admin/cross-
+  // org callers need no grant (mode admin trump). Shepherd clones that
+  // succeed are signalled via X-Bootstrap-Grant — keyed on the OUTCOME
+  // (shepherd + engine 2xx), not on whether this request's grant wrote
+  // anything, so a retry after an ambiguous first attempt (grant
+  // already in KV) still tells the client to mirror (#258 rd-1).
   //
-  // No canonical-slug preflight, deliberately: the engine resolves an
-  // alias-addressed source, but clone neither mutates the source nor
-  // keys any rights on it — the grant attaches to the FRESH slug, and
-  // mode content is already readable by any session via the ungated
-  // GET — so alias addressing isn't capturable here (contrast _rename
-  // and _retire). Matched above the catch-all for the same regex-
-  // ordering reason as _rename; `[^/]+` likewise.
+  // Collision preflight (#258 rd-1 P1, same threat as the rename arm's
+  // preflight 2): the grant MUST NOT run until the engine confirms
+  // `newName` is unused — the engine GET resolves canonical names AND
+  // aliases, so a found result 409s before any rights mutation.
+  // Without this, a shepherd could "clone onto" a live mode's slug and
+  // hold real KV rights on it for the grant→409→compensate window —
+  // permanently, if compensation's best-effort write failed. The
+  // preflight fails CLOSED (engine error → 502, nothing mutated); the
+  // engine's own 409 remains the backstop for the TOCTOU race between
+  // preflight and create, with compensation covering that path.
+  //
+  // No canonical-slug preflight on the SOURCE, deliberately: the
+  // engine resolves an alias-addressed source, but clone neither
+  // mutates the source nor keys any rights on it — the grant attaches
+  // to the FRESH slug, and mode content is already readable by any
+  // session via the ungated GET — so alias addressing isn't capturable
+  // here (contrast _rename and _retire). Matched above the catch-all
+  // for the same regex-ordering reason as _rename; `[^/]+` likewise.
   const modeCloneMatch = pathname.match(
     /^\/api\/config\/modes\/([^/]+)\/_clone$/
   );
@@ -839,8 +852,37 @@ export async function handleConfig(
     const isShepherdClone = !resolved.crossOrg && !hasAdminPowers(session);
     let grantedFields: RightsField[] = [];
     if (isShepherdClone) {
+      // P1 preflight — see the arm comment. Runs only on the shepherd
+      // path; admin clones keep the preflight-free fast path (no grant
+      // to protect, and the engine's 409 already handles collisions).
+      const collision = await preflightMode(env, resolved.org, newName);
+      if (collision.status === "error") {
+        return errorResponse(
+          "Engine unreachable; clone not attempted. Retry the clone.",
+          502
+        );
+      }
+      if (collision.status === "found") {
+        return errorResponse(
+          `A mode named "${newName}" already exists (as a mode or alias)`,
+          409
+        );
+      }
+      // Grant exactly the verbs held on the SOURCE slug (edit is
+      // guaranteed by the gate above; publish only if held there).
+      const grantFields: RightsField[] = hasRights(
+        rightsFor(session, "mode", "publish"),
+        modeName
+      )
+        ? ["mode_edit_rights", "mode_publish_rights"]
+        : ["mode_edit_rights"];
       try {
-        grantedFields = await grantModeSlugToUser(env, session.email, newName);
+        grantedFields = await grantModeSlugToUser(
+          env,
+          session.email,
+          newName,
+          grantFields
+        );
       } catch (err) {
         console.error(
           `clone: rights grant failed for ${session.email} ("${newName}")`,
@@ -849,13 +891,30 @@ export async function handleConfig(
         return errorResponse("Failed to grant cloner rights", 502);
       }
     }
-    const engineRes = await proxyToEngine(
-      request,
-      env,
-      `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}/_clone`,
-      ["POST"],
-      cloneBody
-    );
+    // Wrapped so a thrown engine fetch after the grant surfaces as the
+    // 502-retry contract instead of an unhandled 500 (#258 rd-1); the
+    // grant is kept — ambiguity never contracts rights.
+    let engineRes: Response;
+    try {
+      engineRes = await proxyToEngine(
+        request,
+        env,
+        `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}/_clone`,
+        ["POST"],
+        // Forward the TRIMMED newName — the same value the grant used
+        // (rename-arm Frank rd-1 P2 parity; #258 rd-1).
+        { ...cloneBody, newName }
+      );
+    } catch (err) {
+      console.error(
+        `clone: engine call failed after grant for ${session.email} ("${newName}")`,
+        err
+      );
+      return errorResponse(
+        "Engine unreachable; the clone may not have been created. Retry the clone.",
+        502
+      );
+    }
     if (
       grantedFields.length > 0 &&
       engineRes.status >= 400 &&
@@ -863,7 +922,11 @@ export async function handleConfig(
     ) {
       await revokeModeSlugFromUser(env, session.email, newName, grantedFields);
     }
-    if (isShepherdClone && grantedFields.length > 0 && engineRes.ok) {
+    // Keyed on the OUTCOME (shepherd + engine 2xx), not on whether THIS
+    // request's grant wrote anything — a retry after an ambiguous first
+    // attempt finds the grant already in KV (grantedFields []) and must
+    // still tell the client to mirror (#258 rd-1).
+    if (isShepherdClone && engineRes.ok) {
       const flagged = new Response(engineRes.body, engineRes);
       flagged.headers.set("X-Bootstrap-Grant", "1");
       return flagged;
@@ -972,7 +1035,9 @@ export async function handleConfig(
       env,
       `/api/v1/admin/orgs/${encodedOrg}/modes/${encodeURIComponent(modeName)}/_retire`,
       ["POST"],
-      retireBody
+      // Forward the TRIMMED forwardTo — the value the preflights
+      // authorized (#258 rd-1; rename-arm parity).
+      { forwardTo }
     );
   }
 

--- a/worker/rights-migration.ts
+++ b/worker/rights-migration.ts
@@ -175,6 +175,72 @@ export async function revokeLanguageSlugFromUser(
   }
 }
 
+// #257 — clone auto-grant: give a single user both MODE verbs on a
+// just-cloned slug. Sibling of grantLanguageSlugToUser (#247) with mode
+// semantics instead of language semantics: modes have NO legacy-rights
+// fallback and `undefined` means "no access" for non-admins (the
+// pre-#181 admin-only baseline), so an unset field simply materializes
+// as [slug] — there is no partner-aware or legacy rule to consult.
+// Wildcards pass through untouched. Same expand-first contract as the
+// language grant: call BEFORE the engine op; throws abort the clone;
+// the returned field list scopes definitive-failure compensation so a
+// pre-existing entry can never be stripped.
+export async function grantModeSlugToUser(
+  env: Env,
+  email: string,
+  slug: string
+): Promise<RightsField[]> {
+  const key = `user:${email}`;
+  const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
+  if (!user) {
+    throw new Error(`clone grant: no stored user for ${key}`);
+  }
+  const changed: RightsField[] = [];
+  for (const field of MODE_RIGHTS_FIELDS) {
+    const rights = user[field];
+    if (rights === "*") continue;
+    if (rights !== undefined && rights.includes(slug)) continue;
+    user[field] = [...(rights ?? []), slug];
+    changed.push(field);
+  }
+  if (changed.length > 0) {
+    await env.AUTH_KV.put(key, JSON.stringify(user));
+  }
+  return changed;
+}
+
+// #257 — compensate a clone grant after a DEFINITIVE engine rejection
+// (4xx, e.g. the slug-collision 409). Best-effort, recorded-fields-only,
+// same contract as revokeLanguageSlugFromUser.
+export async function revokeModeSlugFromUser(
+  env: Env,
+  email: string,
+  slug: string,
+  fields: RightsField[]
+): Promise<void> {
+  const key = `user:${email}`;
+  try {
+    const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
+    if (!user) return;
+    let dirty = false;
+    for (const field of fields) {
+      const rights = user[field];
+      if (rights !== undefined && rights !== "*" && rights.includes(slug)) {
+        user[field] = rights.filter((s) => s !== slug);
+        dirty = true;
+      }
+    }
+    if (dirty) {
+      await env.AUTH_KV.put(key, JSON.stringify(user));
+    }
+  } catch (err) {
+    console.error(
+      `rights-migration: clone grant compensation failed for ${key} (slug "${slug}") — stale entry remains`,
+      err
+    );
+  }
+}
+
 // Remove `remove` — but ONLY when `keep` is present in the same array.
 // This single guard is what makes contract and compensate safe to run
 // against any intermediate state: the removal can never take away a

--- a/worker/rights-migration.ts
+++ b/worker/rights-migration.ts
@@ -175,7 +175,7 @@ export async function revokeLanguageSlugFromUser(
   }
 }
 
-// #257 — clone auto-grant: give a single user both MODE verbs on a
+// #257 — clone auto-grant: give a single user MODE verbs on a
 // just-cloned slug. Sibling of grantLanguageSlugToUser (#247) with mode
 // semantics instead of language semantics: modes have NO legacy-rights
 // fallback and `undefined` means "no access" for non-admins (the
@@ -185,10 +185,17 @@ export async function revokeLanguageSlugFromUser(
 // language grant: call BEFORE the engine op; throws abort the clone;
 // the returned field list scopes definitive-failure compensation so a
 // pre-existing entry can never be stripped.
+//
+// `fields` names the verbs to grant — the caller passes the verbs the
+// cloner holds on the SOURCE mode, so cloning preserves the shepherd's
+// capability profile instead of widening it (#258 review rd-1: the
+// unconditional both-verbs grant handed publish rights to edit-only
+// shepherds, a capability their admin had explicitly withheld).
 export async function grantModeSlugToUser(
   env: Env,
   email: string,
-  slug: string
+  slug: string,
+  fields: readonly RightsField[]
 ): Promise<RightsField[]> {
   const key = `user:${email}`;
   const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
@@ -196,7 +203,7 @@ export async function grantModeSlugToUser(
     throw new Error(`clone grant: no stored user for ${key}`);
   }
   const changed: RightsField[] = [];
-  for (const field of MODE_RIGHTS_FIELDS) {
+  for (const field of fields) {
     const rights = user[field];
     if (rights === "*") continue;
     if (rights !== undefined && rights.includes(slug)) continue;


### PR DESCRIPTION
## Summary

Closes #257 — opens the #241 clone and retire-and-forward operations to non-admin shepherds, completing the follow-up both gates shipped with ("loosen once rights-migration (#240) lands"). #240 supplied the primitives pattern; #256 supplied the auto-grant + wire-signal pattern; this PR composes them.

## Worker

**Clone — rename parity + cloner auto-grant.**
- `_clone` passes shepherds with **EDIT rights on the source slug** (publish-only stays denied — cloning is an edit-side action), exactly the #240 rename gate.
- Non-admin same-org cloners are auto-granted edit + publish on the new slug **before** the engine call (#240 expand-first model: worst case is an inert entry, never a lockout), via new `grantModeSlugToUser` / `revokeModeSlugFromUser` primitives — mode semantics (no legacy fallback; unset materializes as `[slug]`). Compensation only on a definitive engine 4xx (e.g. the slug-collision 409); ambiguity keeps the superset. Successful grants are signalled via `X-Bootstrap-Grant` (the #256 wire-signal pattern — no client inference).
- **No canonical-slug preflight, deliberately**: clone neither mutates the source nor keys rights on it, and mode content is already readable by any session via the ungated GET — alias addressing isn't capturable here (contrast `_rename`/`_retire`).

**Retire — DELETE parity plus target-edit, canonical preflights.**
- Shepherds need **edit + publish on the source** (retire is strictly more destructive than DELETE, which already demands both) **and EDIT on the CANONICAL forward target** (retire widens the target's alias array — an edit of the target).
- Two fail-closed preflights mirror the #240 rename arm: (1) alias-addressed sources are refused with a canonical-slug 409 — otherwise a shepherd holding rights on a **stale alias** could retire the aliased-to mode out from under its real shepherds; (2) `forwardTo` is resolved to its canonical name before the rights check, so an alias can't launder the target gate. Source-first evaluation, engine errors → 502 before any mutation.
- Admin/cross-org callers keep the preflight-free fast path (pinned by test).
- **v1 non-goal (documented in #257)**: rights inheritance — the retired mode's other shepherds do NOT gain rights on the target; their entries go inert exactly as with a DELETE today.

## Client

- `canCloneSelected` / `canRetireSelected` mirror the worker gates (`modes.tsx`).
- The retire dialog **filters forward targets to modes the caller can edit** (new `canEditTargetMode` predicate) with honest empty-state copy — a shepherd can no longer pick a target the worker will 403.
- A shepherd clone mirrors the granted rights into the session user synchronously via `mirrorModeGrant`, keyed strictly on the wire signal and reading the store at callback time — same pattern and eventual-consistency rationale as the #240 rename mirror and #256.

## Tests

551 → 573: shepherd clone grant/compensation/header matrix (incl. engine 409 compensates / 5xx keeps / ghost-user 502-before-engine), retire preflight matrix (canonical-source 409, forwardTo alias-laundering 403, missing→404 / error→502 fail-closed, target-edit deny after preflights), admin fast paths pinned, malformed-body/method guards, plus unit coverage for the new primitives and the client mirror.
