### PR TITLE
feat(#260): slug visibility + display-name sync prompt at rename (option 4)

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -12,6 +12,8 @@ import {
   buildModeExportFilename,
 } from "@/lib/mode-export";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
+import { humanizeModeSlug, slugifyModeName } from "@/lib/mode-slug";
+import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import {
   effectiveModeEditRights,
   renameSlugInRights,
@@ -35,6 +37,7 @@ import {
   useSaveMode,
 } from "@/hooks/use-prompt-config";
 import type { MarkdownHeading } from "@/types/markdown";
+import type { PromptMode } from "@/types/prompt-override";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -46,6 +49,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   MarkdownEditor,
   type MarkdownEditorHandle,
@@ -308,6 +313,14 @@ export function ModesPage() {
     value: string | null;
   } | null>(null);
 
+  // #260 — post-rename display-name sync prompt. Holds the rename
+  // response (server truth for label/description/document/published) so
+  // the follow-up label PUT never depends on refetch timing. Null =
+  // no prompt showing.
+  const [labelSync, setLabelSync] = useState<PromptMode | null>(null);
+  const [labelSyncValue, setLabelSyncValue] = useState("");
+  const [labelSyncError, setLabelSyncError] = useState<string | null>(null);
+
   const handleSelectMode = useCallback(
     (next: string | null) => {
       if (next === selectedMode) return;
@@ -505,7 +518,7 @@ export function ModesPage() {
 
   const handleRenameMode = useCallback(
     async (name: string, newName: string) => {
-      await renameMode.mutateAsync({ name, newName });
+      const renamed = await renameMode.mutateAsync({ name, newName });
       // #240: the worker migrated this user's stored mode_*_rights to
       // the new slug, but the Zustand auth store still holds the login-
       // time snapshot with the OLD slug — the per-row rights guard and
@@ -547,9 +560,54 @@ export function ModesPage() {
       // snapshot and clobber the exact patch above (rd-4 review). The
       // local patch mirrors the worker's migration; the next full page
       // load reconciles any residual drift.
+
+      // #260 — rename only touches the slug, so a mode with a display
+      // label looks unchanged in the label-only dropdown afterwards
+      // (the confusion behind Elsy's #232 staging report). Offer to
+      // bring the label along. Skipped when there is no label (the
+      // display already follows the slug) or when the label already
+      // slugifies to the new slug (nothing has drifted).
+      if (renamed.label && slugifyModeName(renamed.label) !== renamed.name) {
+        setLabelSyncValue(humanizeModeSlug(renamed.name));
+        setLabelSyncError(null);
+        setLabelSync(renamed);
+      }
     },
     [renameMode, selectedMode, setSelectedMode, setUser]
   );
+
+  // #260 — confirm handler for the display-name sync prompt. The PUT
+  // body comes from the rename response held in `labelSync`: the worker
+  // contract has no partial update (every PUT carries the full
+  // document), and the response is server truth that cannot be dirtied
+  // while the modal is open. Same inline-error/manual-close dialog
+  // contract as the selector's destructive confirms (#102).
+  const handleConfirmLabelSync = useCallback(() => {
+    if (!labelSync) return;
+    const nextLabel = labelSyncValue.trim();
+    if (!nextLabel) {
+      setLabelSyncError("Enter a display name, or keep the current one.");
+      return;
+    }
+    return runConfirmedAction(
+      () =>
+        saveMode.mutateAsync({
+          name: labelSync.name,
+          body: {
+            label: nextLabel,
+            description: labelSync.description,
+            document: labelSync.document,
+            published: labelSync.published ?? false,
+          },
+        }),
+      setLabelSyncError,
+      () => {
+        setLabelSync(null);
+        setLabelSyncValue("");
+      },
+      "Failed to update the display name."
+    );
+  }, [labelSync, labelSyncValue, saveMode]);
 
   const handleJumpToLine = useCallback((line: number) => {
     editorRef.current?.jumpToLine(line);
@@ -800,6 +858,68 @@ export function ModesPage() {
             >
               Discard and switch
             </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* #260 — post-rename display-name sync prompt (option 4 from the
+          #232 verification thread). Opens after a successful rename when
+          the mode's label no longer matches its slug. */}
+      <AlertDialog
+        open={labelSync !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setLabelSync(null);
+            setLabelSyncValue("");
+            setLabelSyncError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Update the display name too?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The slug is now{" "}
+              <span className="text-foreground font-mono font-medium">
+                {labelSync?.name}
+              </span>
+              , but this mode still shows as{" "}
+              <span className="text-foreground font-medium">
+                &ldquo;{labelSync?.label}&rdquo;
+              </span>{" "}
+              in the mode list. Update the display name so the rename is visible
+              there, or keep the current one.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-1.5">
+            <Label htmlFor="mode-label-sync" className="text-xs">
+              Display name
+            </Label>
+            <Input
+              id="mode-label-sync"
+              value={labelSyncValue}
+              onChange={(e) => setLabelSyncValue(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+          {labelSyncError && (
+            <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+              {labelSyncError}
+            </p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saveMode.isPending}>
+              Keep current name
+            </AlertDialogCancel>
+            {/* Plain Button — AlertDialogAction auto-closes before an
+                error could render inline (#102); close happens in
+                handleConfirmLabelSync on success. */}
+            <Button
+              onClick={handleConfirmLabelSync}
+              disabled={saveMode.isPending || !labelSyncValue.trim()}
+            >
+              {saveMode.isPending ? "Updating…" : "Update name"}
+            </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/mode-selector.tsx
+++ b/src/components/mode-selector.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { pickCloneDefaultSlug } from "@/lib/mode-clone-defaults";
+import { slugifyModeName as slugify } from "@/lib/mode-slug";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import type { OrgModes, PromptMode } from "@/types/prompt-override";
 import {
@@ -118,19 +119,6 @@ interface ModeSelectorProps {
 
 function isPublished(mode: Pick<PromptMode, "published">): boolean {
   return mode.published === true;
-}
-
-// Canonical mode-slug normalization, shared by the create and rename
-// flows: lowercase, spaces → hyphens, drop anything outside
-// [a-z0-9-_], trim leading/trailing hyphens. The engine validates the
-// result again server-side.
-function slugify(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, "-")
-    .replace(/[^a-z0-9\-_]/g, "")
-    .replace(/^-+|-+$/g, "");
 }
 
 export function ModeSelector({
@@ -338,16 +326,30 @@ export function ModeSelector({
               ) : (
                 visibleModes.map((m) => (
                   <SelectItem key={m.name} value={m.name}>
-                    <span className="flex items-center gap-2">
-                      <span className="truncate">{m.label || m.name}</span>
-                      {!isPublished(m) && (
-                        <Badge
-                          variant="outline"
-                          className="px-1.5 py-0 text-[10px]"
-                        >
-                          Draft
-                        </Badge>
-                      )}
+                    <span className="flex min-w-0 flex-col items-start gap-0.5">
+                      <span className="flex items-center gap-2">
+                        <span className="truncate">{m.label || m.name}</span>
+                        {!isPublished(m) && (
+                          <Badge
+                            variant="outline"
+                            className="px-1.5 py-0 text-[10px]"
+                          >
+                            Draft
+                          </Badge>
+                        )}
+                      </span>
+                      {/* Slug subtitle (#260) — rename only touches the
+                          slug, so a reslug is invisible in a label-only
+                          list. Shown only when a label masks the slug.
+                          Radix mirrors ItemText children into the
+                          trigger's SelectValue; the descendant variant
+                          hides the subtitle there so the w-52 trigger
+                          stays a single line. */}
+                      {m.label && m.label !== m.name ? (
+                        <span className="text-muted-foreground truncate font-mono text-[10px] [[data-slot=select-value]_&]:hidden">
+                          {m.name}
+                        </span>
+                      ) : null}
                     </span>
                   </SelectItem>
                 ))
@@ -385,6 +387,22 @@ export function ModeSelector({
             >
               {selectedIsPublished ? "Published" : "Draft"}
             </Badge>
+
+            {/* Canonical slug (#260) — the dropdown trigger shows the
+                label, so when a label exists the slug has no home in the
+                header without this. Omitted when the label IS the slug
+                (the trigger already shows it). Sits before the alias
+                badges so the strip reads "current slug, then previous
+                slugs". */}
+            {selectedModeData.label &&
+            selectedModeData.label !== selectedMode ? (
+              <span
+                className="text-muted-foreground shrink-0 font-mono text-xs"
+                title={`Canonical slug — users select this mode by typing #${selectedMode}.`}
+              >
+                {selectedMode}
+              </span>
+            ) : null}
 
             {/* Alias badges (#232 / #241). A mode answers to its previous
                 slug(s) after rename, or to its merged-in slug(s) after a

--- a/src/lib/mode-slug.ts
+++ b/src/lib/mode-slug.ts
@@ -1,0 +1,25 @@
+// Canonical mode-slug normalization, shared by the create and rename
+// flows (moved out of mode-selector for #260 so the modes page can
+// compare labels against slugs): lowercase, spaces → hyphens, drop
+// anything outside [a-z0-9-_], trim leading/trailing hyphens. The
+// engine validates the result again server-side.
+export function slugifyModeName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9\-_]/g, "")
+    .replace(/^-+|-+$/g, "");
+}
+
+// Best-effort display name suggested from a slug (#260): the post-rename
+// "update display name to match?" prompt prefills with this. Word
+// casing is lossy for acronyms ("fia" → "Fia"), which is why the prompt
+// renders it in an editable input rather than applying it silently.
+export function humanizeModeSlug(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/tests/mode-slug.test.ts
+++ b/tests/mode-slug.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { humanizeModeSlug, slugifyModeName } from "../src/lib/mode-slug";
+
+describe("slugifyModeName", () => {
+  it("lowercases and swaps interior whitespace runs for single hyphens", () => {
+    expect(slugifyModeName("FIA Coach")).toBe("fia-coach");
+    expect(slugifyModeName("kids   mode")).toBe("kids-mode");
+  });
+
+  it("drops characters outside [a-z0-9-_]", () => {
+    expect(slugifyModeName("kids' mode!")).toBe("kids-mode");
+    expect(slugifyModeName("café_mode")).toBe("caf_mode");
+  });
+
+  it("trims leading/trailing hyphens left by stripped characters", () => {
+    expect(slugifyModeName("--edge--")).toBe("edge");
+    expect(slugifyModeName(" (draft) ")).toBe("draft");
+  });
+
+  it("preserves existing hyphens and underscores", () => {
+    expect(slugifyModeName("fia-drafting")).toBe("fia-drafting");
+    expect(slugifyModeName("fia_drafting")).toBe("fia_drafting");
+  });
+
+  it("returns empty string when nothing survives", () => {
+    expect(slugifyModeName("")).toBe("");
+    expect(slugifyModeName("   ")).toBe("");
+    expect(slugifyModeName("!!!")).toBe("");
+  });
+});
+
+describe("humanizeModeSlug", () => {
+  it("splits on hyphens and title-cases each word", () => {
+    expect(humanizeModeSlug("fia-drafting")).toBe("Fia Drafting");
+  });
+
+  it("splits on underscores too", () => {
+    expect(humanizeModeSlug("kids_mode")).toBe("Kids Mode");
+  });
+
+  it("collapses separator runs without emitting empty words", () => {
+    expect(humanizeModeSlug("a--b__c")).toBe("A B C");
+  });
+
+  it("handles a single word", () => {
+    expect(humanizeModeSlug("conversation")).toBe("Conversation");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(humanizeModeSlug("")).toBe("");
+  });
+
+  it("round-trips with slugify for simple display names", () => {
+    // The prompt's skip condition relies on this: a label whose slugified
+    // form equals the new slug means there is no drift to fix.
+    expect(slugifyModeName(humanizeModeSlug("fia-drafting"))).toBe(
+      "fia-drafting"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements #260 — the option-4 visibility follow-up Elsy picked in the #232 verification thread. Rename only touches a mode's **slug** while the dropdown shows **labels**, so a reslug looked like nothing changed. Three surfaces close that gap:

1. **Slug subtitle in the mode dropdown** — each item shows its mono slug beneath the label, only when a label masks it (no label ⇒ the slug already is the display text). Radix mirrors `ItemText` children into the closed trigger's `SelectValue`, so the subtitle carries a `[[data-slot=select-value]_&]:hidden` ancestor variant to keep the w-52 trigger single-line — verified the rule lands in the built CSS.
2. **Canonical slug in the header strip** — mono text next to the Published/Draft badge, before the `also:` alias badges, so the strip reads "current slug, then previous slugs". Same show-condition as the subtitle.
3. **Post-rename display-name sync prompt** — after a successful rename of a labeled mode, a dialog offers to update the label, prefilled with a humanized slug (`fia-drafting` → "Fia Drafting" — lossy for acronyms, hence an editable input rather than a silent apply). Skipped when there's no label or the label already slugifies to the new slug (no drift to fix).

## Design notes

- The sync PUT's body comes from the **rename response** held in state — server truth for label/description/document/published. The worker PUT contract has no partial update, and using the response avoids any dependence on refetch timing; the modal blocks editing while open, so the document can't be dirtied under it.
- The dialog follows the #102 contract: plain `Button` confirm (not `AlertDialogAction`), inline error rendering, manual close on success only.
- `slugify` moves from `mode-selector.tsx` to `src/lib/mode-slug.ts` (joined by `humanizeModeSlug`) so the page can compare labels against slugs without importing from a component. 12 unit tests cover both helpers, including the `slugify(humanize(x)) === x` round-trip the skip condition relies on.

## Scope boxes from #260

- [x] Slug subtitle in the mode dropdown
- [x] Slug line in the header strip
- [x] "Update the display name to match?" prompt at rename time

Non-goals honored: no chat-side changes, no change to slug-only rename semantics.

## Testing

- `npm test`: 596/596 passing (12 new in `tests/mode-slug.test.ts`)
- `npm run lint` / `typecheck` / `build`: clean
- Built CSS inspected to confirm the trigger-hide rule: `[data-slot=select-value] .\[\[data-slot\=select-value\]_\&\]\:hidden{display:none}`

Refs #260 (implements all three scope boxes; leaving closure to verification on the dev deploy)