### PR TITLE
feat(#230): read-only Resources panel over the aggregated worker endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-markdown": "^10.1.0",
-        "react-router": "^7.6.2",
+        "react-router": "^8.3.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.3.5",
@@ -6873,6 +6873,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6881,6 +6882,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -11360,24 +11367,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-markdown": {
@@ -11465,20 +11472,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
-      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -11849,12 +11855,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",
-    "react-router": "^7.6.2",
+    "react-router": "^8.3.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.5",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -20,6 +20,7 @@ import { LanguagesPage } from "@/app/pages/languages";
 import { LoginPage } from "@/app/pages/login";
 import { ManualConfigPage } from "@/app/pages/manual-config";
 import { ModesPage } from "@/app/pages/modes";
+import { ResourcesPage } from "@/app/pages/resources";
 
 const queryClient = new QueryClient();
 
@@ -65,6 +66,7 @@ const router = createBrowserRouter([
             ),
           },
           { path: "languages", element: <LanguagesPage /> },
+          { path: "resources", element: <ResourcesPage /> },
           {
             path: "admin/users",
             element: (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -98,6 +98,9 @@
      which document they're editing. */
   --brand-modes: oklch(0.71 0.108 226);
   --brand-languages: oklch(0.78 0.054 195);
+  /* Archive amber for Resources (#230) — the panel is a library inventory,
+     so its accent reads as paper/parchment against the blue/teal editors. */
+  --brand-resources: oklch(0.75 0.115 80);
 }
 
 .dark {
@@ -151,6 +154,7 @@
 
   --brand-modes: oklch(0.74 0.13 225);
   --brand-languages: oklch(0.8 0.07 195);
+  --brand-resources: oklch(0.8 0.13 80);
 }
 
 @layer base {

--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -3,6 +3,7 @@ import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ChevronRight, ExternalLink, RotateCw } from "lucide-react";
 
+import { safeResourceHref } from "@/lib/resource-href";
 import { subjectLabel } from "@/lib/resource-subjects";
 import { useUiStore } from "@/lib/ui-store";
 import { cn } from "@/lib/utils";
@@ -69,6 +70,9 @@ function ServerChip({
 }
 
 function ResourceRow({ item }: { item: ResourceItem }) {
+  // Scheme-guarded: item.url is third-party MCP server output relayed by
+  // the worker — see lib/resource-href.ts.
+  const href = safeResourceHref(item.url);
   const meta = [
     item.organization,
     item.version && `v${item.version}`,
@@ -92,9 +96,9 @@ function ResourceRow({ item }: { item: ResourceItem }) {
           {meta.join(" · ")}
         </span>
       )}
-      {item.url && (
+      {href && (
         <a
-          href={item.url}
+          href={href}
           target="_blank"
           rel="noreferrer"
           className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline underline-offset-2"
@@ -213,7 +217,17 @@ export function ResourcesPage() {
                 ))}
               </div>
 
-              {noneListable ? (
+              {servers.length === 0 ? (
+                <div className="bg-card rounded-xl border px-6 py-10 text-center">
+                  <p className="text-foreground text-sm font-medium">
+                    No servers are connected for this org
+                  </p>
+                  <p className="text-muted-foreground mx-auto mt-2 max-w-md text-xs leading-relaxed">
+                    Resource listings come from the org&rsquo;s MCP servers, and
+                    none are configured yet.
+                  </p>
+                </div>
+              ) : noneListable ? (
                 <div className="bg-card rounded-xl border px-6 py-10 text-center">
                   <p className="text-foreground text-sm font-medium">
                     This org&rsquo;s servers don&rsquo;t support resource

--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -1,0 +1,310 @@
+import { useMemo, useState } from "react";
+import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { ChevronRight, ExternalLink, RotateCw } from "lucide-react";
+
+import { subjectLabel } from "@/lib/resource-subjects";
+import { useUiStore } from "@/lib/ui-store";
+import { cn } from "@/lib/utils";
+import { OrgContextSelector } from "@/components/org-context-selector";
+import { PageHeader } from "@/components/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useResources } from "@/hooks/use-resources";
+import type { ResourceItem, ResourceServerReport } from "@/types/resources";
+
+// Server chips render the `servers[]` status block honestly (#230 / worker
+// #257): `ok` and `unsupported` and `error` are distinct states, never
+// conflated — "this server has no listing tool" (FIA) is not a failure,
+// and a transient failure is not a capability gap.
+function ServerChip({
+  server,
+  onRetry,
+  isRetrying,
+}: {
+  server: ResourceServerReport;
+  onRetry: () => void;
+  isRetrying: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs",
+        server.status === "error"
+          ? "border-destructive/40 text-destructive"
+          : "border-border text-muted-foreground"
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "size-1.5 rounded-full",
+          server.status === "ok" && "bg-emerald-500",
+          server.status === "unsupported" && "bg-muted-foreground/40",
+          server.status === "error" && "bg-destructive"
+        )}
+      />
+      <span className="text-foreground/80 font-medium">
+        {server.serverName}
+      </span>
+      {server.status === "unsupported" && <span>no resource listing</span>}
+      {server.status === "error" && (
+        <>
+          <span title={server.error}>failed to respond</span>
+          <button
+            type="button"
+            className="hover:text-foreground inline-flex items-center gap-1 underline underline-offset-2"
+            onClick={onRetry}
+            disabled={isRetrying}
+          >
+            <RotateCw className="size-3" />
+            Retry
+          </button>
+        </>
+      )}
+    </span>
+  );
+}
+
+function ResourceRow({ item }: { item: ResourceItem }) {
+  const meta = [
+    item.organization,
+    item.version && `v${item.version}`,
+    item.articleCount !== undefined &&
+      `${String(item.articleCount)} article${item.articleCount === 1 ? "" : "s"}`,
+  ].filter(Boolean);
+
+  return (
+    <li className="flex flex-wrap items-baseline gap-x-2 gap-y-1 py-2">
+      <span className="text-foreground text-sm font-medium">
+        {item.label || item.name}
+      </span>
+      {item.label && (
+        <code className="text-muted-foreground text-[11px]">{item.name}</code>
+      )}
+      <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+        {item.serverId}
+      </Badge>
+      {meta.length > 0 && (
+        <span className="text-muted-foreground text-xs">
+          {meta.join(" · ")}
+        </span>
+      )}
+      {item.url && (
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline underline-offset-2"
+        >
+          Source
+          <ExternalLink className="size-3" />
+        </a>
+      )}
+    </li>
+  );
+}
+
+export function ResourcesPage() {
+  const contextOrg = useUiStore((s) => s.contextOrg);
+
+  // The endpoint takes an IETF-style content-language code ("en", "sw",
+  // "es-419") — deliberately NOT the org's tuning-language slugs, which are
+  // free-form names like "indonesian" and aren't valid here. Hence a code
+  // input rather than a language dropdown.
+  const [languageInput, setLanguageInput] = useState("en");
+  const [language, setLanguage] = useState("en");
+
+  const resources = useResources(language, contextOrg);
+  const data = resources.data;
+
+  const subjects = useMemo(() => Object.entries(data?.resources ?? {}), [data]);
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
+  const toggle = (slug: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  };
+
+  const servers = data?.servers ?? [];
+  const noneListable =
+    servers.length > 0 && servers.every((s) => s.status !== "ok");
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const next = languageInput.trim();
+    if (next) setLanguage(next);
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <PageHeader
+        variant="resources"
+        title="Resources"
+        subtitle="Everything BT Servant can draw on for answers, grouped by category and resolved per language across your org's connected servers."
+      />
+
+      <div className="bg-card flex flex-wrap items-end gap-3 border-b p-4 sm:p-6">
+        <OrgContextSelector />
+        <form className="flex items-end gap-2" onSubmit={submit}>
+          <div className="space-y-1.5">
+            <Label htmlFor="resources-language" className="text-xs">
+              Content language
+            </Label>
+            <Input
+              id="resources-language"
+              value={languageInput}
+              onChange={(e) => setLanguageInput(e.target.value)}
+              placeholder="en"
+              className="h-8 w-32 text-sm"
+              aria-describedby="resources-language-hint"
+            />
+          </div>
+          <Button
+            type="submit"
+            size="sm"
+            disabled={!languageInput.trim() || resources.isFetching}
+          >
+            Load
+          </Button>
+          <p
+            id="resources-language-hint"
+            className="text-muted-foreground pb-1.5 text-xs"
+          >
+            IETF code — en, sw, es-419
+          </p>
+        </form>
+      </div>
+
+      <div className="config-grid-bg min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
+        <div className="mx-auto max-w-3xl space-y-4">
+          {resources.error && (
+            <div
+              className="bg-destructive/10 text-destructive border-destructive rounded-lg border-l-2 px-4 py-3 text-sm"
+              role="alert"
+            >
+              {resources.error.message}
+            </div>
+          )}
+
+          {resources.isLoading ? (
+            <div className="text-muted-foreground flex flex-col items-center justify-center gap-3 py-16">
+              <FontAwesomeIcon
+                icon={faSpinnerThird}
+                className="size-5 animate-spin"
+              />
+              <p className="text-sm">Loading resources...</p>
+            </div>
+          ) : data ? (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                {servers.map((server) => (
+                  <ServerChip
+                    key={server.serverId}
+                    server={server}
+                    onRetry={() => void resources.refetch()}
+                    isRetrying={resources.isFetching}
+                  />
+                ))}
+              </div>
+
+              {noneListable ? (
+                <div className="bg-card rounded-xl border px-6 py-10 text-center">
+                  <p className="text-foreground text-sm font-medium">
+                    This org&rsquo;s servers don&rsquo;t support resource
+                    listing
+                  </p>
+                  <p className="text-muted-foreground mx-auto mt-2 max-w-md text-xs leading-relaxed">
+                    None of the connected servers expose a resource catalog, so
+                    there&rsquo;s nothing to browse here. They can still answer
+                    questions — this only affects the inventory view.
+                  </p>
+                </div>
+              ) : subjects.length === 0 ? (
+                <div className="bg-card rounded-xl border px-6 py-10 text-center">
+                  <p className="text-foreground text-sm font-medium">
+                    No resources found for &ldquo;{data.language}&rdquo;
+                  </p>
+                  <p className="text-muted-foreground mx-auto mt-2 max-w-md text-xs leading-relaxed">
+                    The connected servers responded but listed nothing for this
+                    language. Try another language code.
+                  </p>
+                </div>
+              ) : (
+                <ul className="space-y-2">
+                  {subjects.map(([slug, items]) => {
+                    const isOpen = expanded.has(slug);
+                    const serverIds = [
+                      ...new Set(items.map((i) => i.serverId)),
+                    ];
+                    return (
+                      <li
+                        key={slug}
+                        className={cn(
+                          "bg-card overflow-hidden rounded-xl border transition-colors",
+                          isOpen && "border-l-2"
+                        )}
+                        style={
+                          isOpen
+                            ? { borderLeftColor: "var(--brand-resources)" }
+                            : undefined
+                        }
+                      >
+                        <button
+                          type="button"
+                          className="hover:bg-accent/40 flex w-full items-center gap-3 px-4 py-3 text-left"
+                          onClick={() => toggle(slug)}
+                          aria-expanded={isOpen}
+                        >
+                          <ChevronRight
+                            className={cn(
+                              "text-muted-foreground size-4 shrink-0 transition-transform",
+                              isOpen && "rotate-90"
+                            )}
+                          />
+                          <span className="text-foreground min-w-0 flex-1 truncate text-sm font-semibold">
+                            {subjectLabel(slug)}
+                          </span>
+                          <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                            {items.length}{" "}
+                            {items.length === 1 ? "resource" : "resources"}
+                          </span>
+                          <span className="hidden shrink-0 gap-1 sm:flex">
+                            {serverIds.map((id) => (
+                              <Badge
+                                key={id}
+                                variant="outline"
+                                className="px-1.5 py-0 text-[10px]"
+                              >
+                                {id}
+                              </Badge>
+                            ))}
+                          </span>
+                        </button>
+                        {isOpen && (
+                          <ul className="divide-border/60 border-border/60 divide-y border-t px-4 pt-1 pb-2 pl-11">
+                            {items.map((item) => (
+                              <ResourceRow
+                                key={`${item.serverId}:${item.name}`}
+                                item={item}
+                              />
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -1,8 +1,10 @@
+import { faBooks as faBooksLight } from "@fortawesome/pro-light-svg-icons";
 import { faComments as faCommentsLight } from "@fortawesome/pro-light-svg-icons";
 import { faLanguage as faLanguageLight } from "@fortawesome/pro-light-svg-icons";
 import { faMessageBot as faMessageBotLight } from "@fortawesome/pro-light-svg-icons";
 import { faPenToSquare as faPenToSquareLight } from "@fortawesome/pro-light-svg-icons";
 import { faUsers as faUsersLight } from "@fortawesome/pro-light-svg-icons";
+import { faBooks as faBooksSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faComments as faCommentsSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faLanguage as faLanguageSolid } from "@fortawesome/pro-solid-svg-icons";
 import { faMessageBot as faMessageBotSolid } from "@fortawesome/pro-solid-svg-icons";
@@ -83,6 +85,18 @@ export function ActivityBar() {
           }}
           disabled={!canAccessLanguages}
           disabledLabel="No language access — contact your admin"
+        />
+        {/* #230 — read-only resource inventory; open to every session,
+            matching the modes/languages GET convention in the worker. */}
+        <ActivityBarItem
+          icon={faBooksLight}
+          activeIcon={faBooksSolid}
+          label="Browse resources BT Servant can draw on"
+          isActive={activeSection === "resources"}
+          onClick={() => {
+            setActiveSection("resources");
+            void navigate("/resources");
+          }}
         />
         {isAdmin && (
           <ActivityBarItem

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -6,7 +6,7 @@ interface PageHeaderProps {
   subtitle: string;
   // Subtle context accent: tints a 3px top strip with a brand color so authors
   // can tell at a glance which kind of document they're editing (issue #78).
-  variant?: "modes" | "languages";
+  variant?: "modes" | "languages" | "resources";
 }
 
 export function PageHeader({ title, subtitle, variant }: PageHeaderProps) {
@@ -17,7 +17,9 @@ export function PageHeader({ title, subtitle, variant }: PageHeaderProps) {
       ? "var(--brand-modes)"
       : variant === "languages"
         ? "var(--brand-languages)"
-        : undefined;
+        : variant === "resources"
+          ? "var(--brand-resources)"
+          : undefined;
 
   return (
     <div

--- a/src/hooks/use-resources.ts
+++ b/src/hooks/use-resources.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+
+import * as resourcesApi from "@/lib/resources-api";
+
+// Org is part of every key so a super-admin's cross-org view doesn't collide
+// with the same-org cache (same rule as use-languages). Language is a key
+// segment too: the aggregation is resolved per-language on the worker side.
+const keys = {
+  resources: (language: string, org: string | null) =>
+    ["resources", language, org] as const,
+};
+
+function normalize(org?: string | null): string | null {
+  return org ?? null;
+}
+
+export function useResources(language: string | null, org?: string | null) {
+  const key = normalize(org);
+  return useQuery({
+    queryKey: keys.resources(language ?? "", key),
+    queryFn: ({ signal }) => resourcesApi.getResources(language!, signal, key),
+    enabled: !!language,
+  });
+}

--- a/src/hooks/use-sync-section.ts
+++ b/src/hooks/use-sync-section.ts
@@ -9,6 +9,7 @@ const pathToSection: Record<string, Section> = {
   "/modes": "modes",
   "/prompt-configuration": "prompt-configuration",
   "/languages": "languages",
+  "/resources": "resources",
   "/admin/users": "admin-users",
 };
 

--- a/src/lib/resource-href.ts
+++ b/src/lib/resource-href.ts
@@ -1,0 +1,20 @@
+// Resource URLs originate from third-party MCP servers (aquifer,
+// translation-helps) relayed by the worker — untrusted input as far as the
+// portal's origin is concerned. Only absolute http(s) URLs may reach an
+// <a href>: a compromised or misbehaving server must not be able to smuggle
+// javascript:/data:/etc. into the DOM. React's javascript:-URL mitigation is
+// a console error, not a guarantee, and it doesn't cover data: at all.
+export function safeResourceHref(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Relative or malformed — every legitimate source link in the worker
+    // contract is absolute, so reject rather than resolve against our origin.
+    return undefined;
+  }
+  return parsed.protocol === "http:" || parsed.protocol === "https:"
+    ? url
+    : undefined;
+}

--- a/src/lib/resource-subjects.ts
+++ b/src/lib/resource-subjects.ts
@@ -1,0 +1,15 @@
+import { KNOWN_SUBJECT_LABELS } from "@/types/resources";
+
+// The canonical subject set is OPEN by contract (worker#257): unmapped server
+// vocabulary is slugified by the worker rather than dropped, so new categories
+// must degrade to "visible but unknown" here — a readable humanized label,
+// never a raw slug and never a missing row.
+export function subjectLabel(slug: string): string {
+  const known = KNOWN_SUBJECT_LABELS[slug];
+  if (known) return known;
+  return slug
+    .split("-")
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/src/lib/resources-api.ts
+++ b/src/lib/resources-api.ts
@@ -1,0 +1,32 @@
+import type { AggregatedResourcesResponse } from "@/types/resources";
+
+const SAME_ORIGIN_HEADERS = {
+  "X-Requested-With": "XMLHttpRequest",
+} as const;
+
+// Unlike the other config APIs this endpoint carries a required `language`
+// query param alongside the optional super-admin `?org=`, so it builds its
+// query string with URLSearchParams instead of buildConfigUrl (which owns
+// the single-param case). Same org semantics: blank/whitespace orgs are
+// dropped rather than appended (see lib/config-url.ts for the rationale).
+export async function getResources(
+  language: string,
+  signal?: AbortSignal,
+  org?: string | null
+): Promise<AggregatedResourcesResponse> {
+  const params = new URLSearchParams({ language });
+  const trimmedOrg = org?.trim();
+  if (trimmedOrg) params.set("org", trimmedOrg);
+
+  const res = await fetch(`/api/config/resources?${params.toString()}`, {
+    headers: SAME_ORIGIN_HEADERS,
+    signal,
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to load resources (${res.status}): ${body}`);
+  }
+
+  return (await res.json()) as AggregatedResourcesResponse;
+}

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -1,0 +1,65 @@
+// Mirrors bt-servant-worker's aggregated-resources contract verbatim
+// (worker#257 item 1, final TS types posted 2026-07-30; design locked on
+// portal#230 Q4–Q6). Do not add portal-side fields here — the worker owns
+// this shape, and drift is exactly what mirroring is meant to prevent.
+
+/** GET /api/config/resources?language=xx (IETF-style, e.g. "en", "sw", "es-419") */
+export interface AggregatedResourcesResponse {
+  org: string;
+  language: string;
+  resources: ResourcesBySubject;
+  servers: ResourceServerReport[];
+}
+
+/**
+ * Grouped by canonical subject slug. Within a subject: server-default order,
+ * servers concatenated in ascending `priority` order (same comparator as the
+ * worker's chat path).
+ */
+export type ResourcesBySubject = Record<string, ResourceItem[]>;
+
+export interface ResourceItem {
+  /** Server-scoped identifier (e.g. "en_ult", "BiblicaStudyNotes"). */
+  name: string;
+  /** Canonical subject slug — an OPEN set; unmapped server vocabulary is
+      slugified by the worker rather than dropped, so unknown slugs must
+      render, not error (see subjectLabel in lib/resource-subjects). */
+  subject: string;
+  /** Attribution: MCPServerConfig.id of the server that listed this item. */
+  serverId: string;
+  /** Human-readable title, when it differs from name (aquifer). */
+  label?: string;
+  organization?: string;
+  version?: string;
+  url?: string;
+  /** Where the server exposes a count (aquifer). */
+  articleCount?: number;
+}
+
+export type ResourceServerStatus = "ok" | "unsupported" | "error";
+
+export interface ResourceServerReport {
+  serverId: string;
+  serverName: string;
+  /** unsupported = no listing tool (FIA); error = transient, retryable. */
+  status: ResourceServerStatus;
+  /** Present iff status === "error". */
+  error?: string;
+}
+
+// Display labels for the canonical subject slugs the worker normalizes to.
+// Mirrors the worker's SUBJECT_LABELS map (worker#257). The set is open —
+// anything not listed here gets a humanized fallback, never dropped.
+export const KNOWN_SUBJECT_LABELS: Record<string, string> = {
+  bible: "Bible Translations",
+  "aligned-bible": "Aligned Bibles",
+  "bible-stories": "Bible Stories",
+  dictionary: "Dictionaries",
+  media: "Images, Maps & Videos",
+  "study-notes": "Study Notes",
+  "translation-academy": "Translation Academy",
+  "translation-notes": "Translation Notes",
+  "translation-questions": "Translation Questions",
+  "translation-words": "Translation Words",
+  "translation-words-links": "Translation Words Links",
+};

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -3,4 +3,5 @@ export type Section =
   | "modes"
   | "prompt-configuration"
   | "languages"
+  | "resources"
   | "admin-users";

--- a/tests/config-resources.test.ts
+++ b/tests/config-resources.test.ts
@@ -1,0 +1,128 @@
+import { env } from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { handleConfig } from "../worker/config";
+import type { SessionData } from "../worker/types";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeSession(overrides: Partial<SessionData> = {}): SessionData {
+  return {
+    userId: crypto.randomUUID(),
+    email: "alice@acme.com",
+    name: "Alice",
+    org: "acme",
+    isAdmin: false,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeRequest(method: string, pathAndQuery: string): Request {
+  return new Request(`https://portal.example.test${pathAndQuery}`, { method });
+}
+
+function spyFetch() {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(() =>
+      Promise.resolve(new Response("{}", { status: 200 }))
+    );
+}
+
+describe("config — /api/config/resources (#230)", () => {
+  it("non-admin GET → proxies to the aggregated engine endpoint (read is open)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("GET", "/api/config/resources?language=en"),
+      env,
+      makeSession({ isAdmin: false }),
+      "/api/config/resources"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/resources?language=en"
+    );
+  });
+
+  it("missing language → 400, and the worker does not touch the engine", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("GET", "/api/config/resources"),
+      env,
+      makeSession(),
+      "/api/config/resources"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("blank language → 400 (whitespace is not a language)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("GET", "/api/config/resources?language=%20%20"),
+      env,
+      makeSession(),
+      "/api/config/resources"
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("URL-encodes the language before composing the upstream path", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequest(
+        "GET",
+        `/api/config/resources?language=${encodeURIComponent("es 419/x")}`
+      ),
+      env,
+      makeSession(),
+      "/api/config/resources"
+    );
+    const upstream = String(fetchSpy.mock.calls[0]![0]);
+    expect(upstream).toContain("resources?language=es%20419%2Fx");
+  });
+
+  it("PUT → 405 (read-only route)", async () => {
+    spyFetch();
+    const res = await handleConfig(
+      makeRequest("PUT", "/api/config/resources?language=en"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/resources"
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it("cross-org ?org= without super-admin → 403 before any engine call", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeRequest("GET", "/api/config/resources?language=en&org=other-org"),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/resources"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("cross-org ?org= with super-admin → proxies against the requested org", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      makeRequest(
+        "GET",
+        "/api/config/resources?language=sw&org=wordcollective"
+      ),
+      env,
+      makeSession({ isSuperAdmin: true }),
+      "/api/config/resources"
+    );
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/wordcollective/resources?language=sw"
+    );
+  });
+});

--- a/tests/resource-href.test.ts
+++ b/tests/resource-href.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { safeResourceHref } from "../src/lib/resource-href";
+
+describe("safeResourceHref", () => {
+  it("passes absolute http(s) URLs through unchanged", () => {
+    expect(safeResourceHref("https://git.door43.org/en_ult")).toBe(
+      "https://git.door43.org/en_ult"
+    );
+    expect(safeResourceHref("http://example.org/x?y=1#z")).toBe(
+      "http://example.org/x?y=1#z"
+    );
+  });
+
+  it("rejects non-http(s) schemes from a hostile or broken server", () => {
+    expect(safeResourceHref("javascript:alert(1)")).toBeUndefined();
+    expect(
+      safeResourceHref("data:text/html,<script>1</script>")
+    ).toBeUndefined();
+    expect(safeResourceHref("vbscript:x")).toBeUndefined();
+    expect(safeResourceHref("file:///etc/passwd")).toBeUndefined();
+  });
+
+  it("rejects relative and malformed URLs rather than resolving them", () => {
+    expect(safeResourceHref("/relative/path")).toBeUndefined();
+    expect(safeResourceHref("not a url")).toBeUndefined();
+    expect(safeResourceHref("//protocol-relative.example")).toBeUndefined();
+  });
+
+  it("returns undefined for missing input", () => {
+    expect(safeResourceHref(undefined)).toBeUndefined();
+    expect(safeResourceHref("")).toBeUndefined();
+  });
+});

--- a/tests/resource-subjects.test.ts
+++ b/tests/resource-subjects.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { subjectLabel } from "../src/lib/resource-subjects";
+
+describe("subjectLabel", () => {
+  it("maps canonical slugs to their display labels", () => {
+    expect(subjectLabel("bible")).toBe("Bible Translations");
+    expect(subjectLabel("translation-notes")).toBe("Translation Notes");
+    expect(subjectLabel("translation-words-links")).toBe(
+      "Translation Words Links"
+    );
+    expect(subjectLabel("media")).toBe("Images, Maps & Videos");
+  });
+
+  it("humanizes unknown slugs instead of dropping them (open-set contract)", () => {
+    // worker#257: unmapped server vocabulary is slugified, not dropped —
+    // new categories must degrade to "visible but unknown".
+    expect(subjectLabel("ubs-handbooks")).toBe("Ubs Handbooks");
+    expect(subjectLabel("commentary")).toBe("Commentary");
+  });
+
+  it("tolerates malformed slugs without crashing", () => {
+    expect(subjectLabel("")).toBe("");
+    expect(subjectLabel("--double--dashes--")).toBe("Double Dashes");
+  });
+});

--- a/tests/resources-api.test.ts
+++ b/tests/resources-api.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getResources } from "../src/lib/resources-api";
+import type { AggregatedResourcesResponse } from "../src/types/resources";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const SAMPLE: AggregatedResourcesResponse = {
+  org: "acme",
+  language: "en",
+  resources: {
+    bible: [
+      { name: "en_ult", subject: "bible", serverId: "translation-helps" },
+    ],
+  },
+  servers: [
+    {
+      serverId: "translation-helps",
+      serverName: "Translation Helps",
+      status: "ok",
+    },
+    { serverId: "fia", serverName: "FIA", status: "unsupported" },
+  ],
+};
+
+function mockFetchOnce(
+  status: number,
+  body: unknown
+): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+}
+
+describe("getResources", () => {
+  it("returns the aggregated response as-is (no envelope to unwrap)", async () => {
+    mockFetchOnce(200, SAMPLE);
+    const result = await getResources("en");
+    expect(result).toEqual(SAMPLE);
+  });
+
+  it("sends the language as a query param, URL-encoded", async () => {
+    const spy = mockFetchOnce(200, SAMPLE);
+    await getResources("es-419");
+    const url = String(spy.mock.calls[0]![0]);
+    expect(url).toBe("/api/config/resources?language=es-419");
+  });
+
+  it("appends ?org= for the super-admin cross-org path", async () => {
+    const spy = mockFetchOnce(200, SAMPLE);
+    await getResources("en", undefined, "wordcollective");
+    expect(String(spy.mock.calls[0]![0])).toBe(
+      "/api/config/resources?language=en&org=wordcollective"
+    );
+  });
+
+  it("drops blank/whitespace orgs instead of appending them", async () => {
+    const spy = mockFetchOnce(200, SAMPLE);
+    await getResources("en", undefined, "   ");
+    expect(String(spy.mock.calls[0]![0])).toBe(
+      "/api/config/resources?language=en"
+    );
+  });
+
+  it("sends the same-origin CSRF header", async () => {
+    const spy = mockFetchOnce(200, SAMPLE);
+    await getResources("en");
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe(
+      "XMLHttpRequest"
+    );
+  });
+
+  it("throws with status and body text on non-2xx", async () => {
+    mockFetchOnce(502, "upstream unavailable");
+    await expect(getResources("en")).rejects.toThrow(
+      /Failed to load resources \(502\): upstream unavailable/
+    );
+  });
+});

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -1251,6 +1251,25 @@ export async function handleConfig(
     );
   }
 
+  // /api/config/resources?language=xx → GET (#230). Read-only aggregation
+  // across the org's MCP servers; any session may read, matching the
+  // modes/languages GET convention. `language` is required — the upstream
+  // aggregation is language-scoped by contract (worker#257), and proxying
+  // without it would burn an engine round-trip on a guaranteed 4xx.
+  if (pathname === "/api/config/resources") {
+    const language =
+      new URL(request.url).searchParams.get("language")?.trim() ?? "";
+    if (!language) {
+      return errorResponse("Missing required query param: language", 400);
+    }
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${encodedOrg}/resources?language=${encodeURIComponent(language)}`,
+      ["GET"]
+    );
+  }
+
   return errorResponse("Not found", 404);
 }
 


### PR DESCRIPTION
## Summary

First portal slice of the resource visibility & prioritization panel — a read-only Resources inventory built against the contract locked on #230 (Q4–Q6, signed off 07-13) and the final TS types Ian posted on unfoldingWord/bt-servant-worker#257 on 07-30 (endpoint merged there as worker PR #343).

Tracks #230 — deliberately not `Closes`: the `resourcePriority` ordering editor waits for worker#257 item 2 (the `PromptMode` field), per the sequencing agreed on the issue.

## What's in it

- **`src/types/resources.ts`** — mirrors the worker contract verbatim: `AggregatedResourcesResponse`, `ResourceItem` (incl. the two additive deltas `label` / `articleCount` and `serverId` attribution), `ResourceServerReport`, plus the canonical subject-label map. `subjectLabel()` in `src/lib/resource-subjects.ts` humanizes unknown slugs — the subject set is open by contract, so new categories degrade to "visible but unknown," never dropped.
- **BFF route** — `GET /api/config/resources?language=xx` proxies to the worker's aggregated endpoint. `language` is required (400 without it, no upstream round-trip); reads are open to any session, matching the modes/languages GET convention; cross-org `?org=` inherits the existing `resolveOrg` gate unchanged.
- **Resources page** (`/resources`, new activity-bar entry next to Languages):
  - The `servers[]` status block renders honestly: `ok` / `unsupported` ("no resource listing" — FIA) / `error` (with retry) are visually and semantically distinct, per the portal-side commitments on #230.
  - An org whose servers are all non-`ok` (wordcollective, FIA-only) degrades to an explanatory state instead of an empty grid.
  - Category rows expand into attributed resource lists: display label (with the server-scoped `name` as secondary mono text when they differ), `serverId` badge, organization · version · article count, and a source link when the server provides one. Row order preserves the response's server-default order.
  - Content language is a free IETF-code input (default `en`), **not** the org-language dropdown: tuning-language slugs like `indonesian` aren't valid values for the endpoint's `language` param.
- **New brand accent** — `--brand-resources` (archive amber) joins the Modes blue / Languages teal context strips.

## Tests

16 new (612 total): BFF route authz + param handling (missing/blank language → 400 before any engine call, method gating, cross-org 403/allow), API lib (URL building, org trimming, CSRF header, error surfacing), and subject-label open-set behavior.

## Verification

- `npx vitest run` — 612 passed
- `npm run lint` — zero warnings
- `npm run typecheck` / `npm run build` — clean
- Not yet verified against the live worker endpoint (merged to worker main 07-30); the PR's ephemeral deploy is the natural place to smoke-test it end-to-end.
