### PR TITLE
feat(#209): "Requires group chat" toggle on the mode editor + export

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -11,6 +11,12 @@ import {
   buildModeExportContent,
   buildModeExportFilename,
 } from "@/lib/mode-export";
+import {
+  DEFAULT_MODE_FLAGS,
+  readModeFlags,
+  reconcileModeFlags,
+  type ModeFlags,
+} from "@/lib/mode-flags";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
 import { humanizeModeSlug, slugifyModeName } from "@/lib/mode-slug";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
@@ -151,18 +157,32 @@ export function ModesPage() {
 
   // Local document draft (auto-save target).
   //
-  // We track `lastSyncedDoc` / `lastSyncedPublished` separately from the
+  // We track `lastSyncedDoc` / `lastSyncedFlags` separately from the
   // React Query cache so that edits typed *during* an in-flight save are
   // preserved, and so a subsequent autosave after Publish/Unpublish doesn't
   // read stale `published` from the cache and silently revert the toggle.
   // Sync rule: pulled from the server only on selection change; advanced on
-  // successful save with the value we sent (never re-read from the cache).
+  // successful save from the PUT response (server truth for the merged
+  // mode), falling back to what we sent for any key the worker omits.
   // See `src/app/pages/languages.tsx` for the parallel implementation —
   // both pages share this pattern.
   const [draft, setDraft] = useState("");
   const [lastSyncedDoc, setLastSyncedDoc] = useState("");
-  const [lastSyncedPublished, setLastSyncedPublished] = useState(false);
-  const [lastSyncedRequiresGroup, setLastSyncedRequiresGroup] = useState(false);
+  // `published` and `requires_group` are ONE tracker, never two. Every PUT
+  // re-asserts both (the worker has no partial update — see
+  // `lib/mode-flags.ts`), so a tracker that advanced one flag without the
+  // other would let the next save write a stale counterpart back over a
+  // change that already landed. The ref mirror is what the save handlers
+  // read at call time: a `useCallback` closure only sees the flags as of
+  // its own render, which during an in-flight save is by definition the
+  // pre-flight pair.
+  const [lastSyncedFlags, setLastSyncedFlags] =
+    useState<ModeFlags>(DEFAULT_MODE_FLAGS);
+  const lastSyncedFlagsRef = useRef(lastSyncedFlags);
+  const applyLastSyncedFlags = useCallback((next: ModeFlags) => {
+    lastSyncedFlagsRef.current = next;
+    setLastSyncedFlags(next);
+  }, []);
   // Pauses autosave on a draft that already failed once, so a failed save
   // doesn't loop on every isPending → false transition (Frank P2 on
   // PR #122). User recovers by editing further (changes debouncedDraft) or
@@ -182,8 +202,7 @@ export function ModesPage() {
       syncedNameRef.current = null;
       setDraft("");
       setLastSyncedDoc("");
-      setLastSyncedPublished(false);
-      setLastSyncedRequiresGroup(false);
+      applyLastSyncedFlags(DEFAULT_MODE_FLAGS);
       setLastFailedDoc(null);
       return;
     }
@@ -192,11 +211,10 @@ export function ModesPage() {
     if (syncedNameRef.current === selectedMode) return;
     setDraft(modeQuery.data.document);
     setLastSyncedDoc(modeQuery.data.document);
-    setLastSyncedPublished(modeQuery.data.published ?? false);
-    setLastSyncedRequiresGroup(modeQuery.data.requires_group ?? false);
+    applyLastSyncedFlags(readModeFlags(modeQuery.data));
     setLastFailedDoc(null);
     syncedNameRef.current = selectedMode;
-  }, [selectedMode, modeQuery.data]);
+  }, [applyLastSyncedFlags, selectedMode, modeQuery.data]);
 
   const isDirty = draft !== lastSyncedDoc;
   const isSaving = saveMode.isPending;
@@ -205,6 +223,7 @@ export function ModesPage() {
   const performSave = useCallback(
     (doc: string) => {
       if (!selectedMode) return;
+      const sent = lastSyncedFlagsRef.current;
       saveMode.mutate(
         {
           name: selectedMode,
@@ -212,22 +231,21 @@ export function ModesPage() {
             label: serverLabel,
             description: serverDescription,
             document: doc,
-            published: lastSyncedPublished,
-            requires_group: lastSyncedRequiresGroup,
+            ...sent,
           },
         },
         {
-          onSuccess: () => {
+          onSuccess: (saved) => {
             setLastSyncedDoc(doc);
             setLastFailedDoc(null);
+            applyLastSyncedFlags(reconcileModeFlags(sent, saved));
           },
           onError: () => setLastFailedDoc(doc),
         }
       );
     },
     [
-      lastSyncedPublished,
-      lastSyncedRequiresGroup,
+      applyLastSyncedFlags,
       saveMode,
       selectedMode,
       serverDescription,
@@ -284,8 +302,7 @@ export function ModesPage() {
         ...modeQuery.data,
         name: selectedMode,
         document: draft,
-        published: lastSyncedPublished,
-        requires_group: lastSyncedRequiresGroup,
+        ...lastSyncedFlags,
       },
       ctx
     );
@@ -302,14 +319,7 @@ export function ModesPage() {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, [
-    draft,
-    effectiveOrg,
-    lastSyncedPublished,
-    lastSyncedRequiresGroup,
-    modeQuery.data,
-    selectedMode,
-  ]);
+  }, [draft, effectiveOrg, lastSyncedFlags, modeQuery.data, selectedMode]);
 
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
@@ -423,22 +433,32 @@ export function ModesPage() {
       // mode, so we always send the current draft. The worker contract
       // requires a `document` on every PUT — there's no partial-update path.
       if (name !== selectedMode) return;
-      await saveMode.mutateAsync({
+      // Flag writes are serialized. This PUT re-asserts `requires_group`
+      // as well, so one started while another save is in flight would ship
+      // that flag's pre-flight value and undo whatever the in-flight write
+      // is landing. The selector's publish controls are already disabled
+      // by the same `saveMode.isPending` the page reads as `isSaving`; the
+      // throw is the backstop for any caller that misses that gate, and it
+      // surfaces inline in the unpublish dialog via `runConfirmedAction`.
+      if (saveMode.isPending) {
+        throw new Error("Another save is in flight. Try again in a moment.");
+      }
+      const sent: ModeFlags = { ...lastSyncedFlagsRef.current, published };
+      const saved = await saveMode.mutateAsync({
         name,
         body: {
           label: serverLabel,
           description: serverDescription,
           document: draft,
-          published,
-          requires_group: lastSyncedRequiresGroup,
+          ...sent,
         },
       });
       setLastSyncedDoc(draft);
-      setLastSyncedPublished(published);
+      applyLastSyncedFlags(reconcileModeFlags(sent, saved));
     },
     [
+      applyLastSyncedFlags,
       draft,
-      lastSyncedRequiresGroup,
       saveMode,
       selectedMode,
       serverDescription,
@@ -448,29 +468,37 @@ export function ModesPage() {
 
   // #209 — immediate-save toggle, mirroring handleSetPublished: the
   // worker contract has no partial update, so the current draft rides
-  // along and both last-synced trackers advance on success. A failure
-  // surfaces through the page-level saveError banner, and the switch
-  // visually reverts on its own because it renders from
-  // lastSyncedRequiresGroup (not advanced on error).
+  // along and the flag pair advances together from the PUT response. A
+  // failure surfaces through the page-level saveError banner, and the
+  // switch visually reverts on its own because it renders from
+  // `lastSyncedFlags` (not advanced on error). Same serialization gate as
+  // Publish — in the mirror image of that race, this PUT re-asserts
+  // `published`.
   const handleSetRequiresGroup = useCallback(
     async (requiresGroup: boolean) => {
       if (!selectedMode) return;
-      await saveMode.mutateAsync({
+      if (saveMode.isPending) {
+        throw new Error("Another save is in flight. Try again in a moment.");
+      }
+      const sent: ModeFlags = {
+        ...lastSyncedFlagsRef.current,
+        requires_group: requiresGroup,
+      };
+      const saved = await saveMode.mutateAsync({
         name: selectedMode,
         body: {
           label: serverLabel,
           description: serverDescription,
           document: draft,
-          published: lastSyncedPublished,
-          requires_group: requiresGroup,
+          ...sent,
         },
       });
       setLastSyncedDoc(draft);
-      setLastSyncedRequiresGroup(requiresGroup);
+      applyLastSyncedFlags(reconcileModeFlags(sent, saved));
     },
     [
+      applyLastSyncedFlags,
       draft,
-      lastSyncedPublished,
       saveMode,
       selectedMode,
       serverDescription,
@@ -652,7 +680,7 @@ export function ModesPage() {
             description: labelSync.description,
             document: labelSync.document,
             published: labelSync.published ?? false,
-            requires_group: labelSync.requires_group,
+            requires_group: labelSync.requires_group ?? false,
           },
         }),
       setLabelSyncError,
@@ -715,7 +743,10 @@ export function ModesPage() {
               isRenaming={renameMode.isPending}
               isCloning={cloneMode.isPending}
               isRetiring={retireMode.isPending}
-              isSettingPublished={saveMode.isPending}
+              // Page-level saving flag, not a publish-only one: it gates
+              // the publish controls against EVERY in-flight save, which
+              // is what keeps two flag-carrying PUTs from overlapping.
+              isSettingPublished={isSaving}
               showDrafts={showDrafts}
               onToggleShowDrafts={setShowDrafts}
               canCreate={canCreate}
@@ -743,15 +774,15 @@ export function ModesPage() {
           {hasSelection && (
             <div className="flex shrink-0 items-center gap-3">
               {/* #209 — group-only gate. Saves immediately on toggle
-                  (like Publish); renders from lastSyncedRequiresGroup so
-                  a failed save reverts visually. */}
+                  (like Publish); renders from `lastSyncedFlags` so a
+                  failed save reverts visually. */}
               <div
                 className="flex items-center gap-2"
                 title="When on, this mode is only offered in group chats (Telegram groups) — hidden from WhatsApp, web, and DMs."
               >
                 <Switch
                   id="mode-requires-group"
-                  checked={lastSyncedRequiresGroup}
+                  checked={lastSyncedFlags.requires_group}
                   onCheckedChange={(checked) => {
                     handleSetRequiresGroup(checked).catch(() => {});
                   }}

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -51,6 +51,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   MarkdownEditor,
   type MarkdownEditorHandle,
@@ -161,6 +162,7 @@ export function ModesPage() {
   const [draft, setDraft] = useState("");
   const [lastSyncedDoc, setLastSyncedDoc] = useState("");
   const [lastSyncedPublished, setLastSyncedPublished] = useState(false);
+  const [lastSyncedRequiresGroup, setLastSyncedRequiresGroup] = useState(false);
   // Pauses autosave on a draft that already failed once, so a failed save
   // doesn't loop on every isPending → false transition (Frank P2 on
   // PR #122). User recovers by editing further (changes debouncedDraft) or
@@ -181,6 +183,7 @@ export function ModesPage() {
       setDraft("");
       setLastSyncedDoc("");
       setLastSyncedPublished(false);
+      setLastSyncedRequiresGroup(false);
       setLastFailedDoc(null);
       return;
     }
@@ -190,6 +193,7 @@ export function ModesPage() {
     setDraft(modeQuery.data.document);
     setLastSyncedDoc(modeQuery.data.document);
     setLastSyncedPublished(modeQuery.data.published ?? false);
+    setLastSyncedRequiresGroup(modeQuery.data.requires_group ?? false);
     setLastFailedDoc(null);
     syncedNameRef.current = selectedMode;
   }, [selectedMode, modeQuery.data]);
@@ -209,6 +213,7 @@ export function ModesPage() {
             description: serverDescription,
             document: doc,
             published: lastSyncedPublished,
+            requires_group: lastSyncedRequiresGroup,
           },
         },
         {
@@ -222,6 +227,7 @@ export function ModesPage() {
     },
     [
       lastSyncedPublished,
+      lastSyncedRequiresGroup,
       saveMode,
       selectedMode,
       serverDescription,
@@ -267,18 +273,19 @@ export function ModesPage() {
     const ctx = { org: effectiveOrg, exportedAt: new Date() };
     // Spread `modeQuery.data` so every PromptMode field (label,
     // description, aliases, and anything added later) flows through
-    // without a per-field update here. The three overrides below are
+    // without a per-field update here. The overrides below are
     // intentional: `name` follows the user's selection, `document`
-    // captures unsaved edits, `published` uses the locally-tracked
-    // toggle (not cache, which can be stale during a Publish race).
-    // Original inline construction dropped `aliases` silently — #241 PR A
-    // Frank review.
+    // captures unsaved edits, `published` and `requires_group` use the
+    // locally-tracked toggles (not cache, which can be stale during a
+    // Publish/toggle race). Original inline construction dropped
+    // `aliases` silently — #241 PR A Frank review.
     const content = buildModeExportContent(
       {
         ...modeQuery.data,
         name: selectedMode,
         document: draft,
         published: lastSyncedPublished,
+        requires_group: lastSyncedRequiresGroup,
       },
       ctx
     );
@@ -295,7 +302,14 @@ export function ModesPage() {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, [draft, effectiveOrg, lastSyncedPublished, modeQuery.data, selectedMode]);
+  }, [
+    draft,
+    effectiveOrg,
+    lastSyncedPublished,
+    lastSyncedRequiresGroup,
+    modeQuery.data,
+    selectedMode,
+  ]);
 
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
@@ -416,12 +430,52 @@ export function ModesPage() {
           description: serverDescription,
           document: draft,
           published,
+          requires_group: lastSyncedRequiresGroup,
         },
       });
       setLastSyncedDoc(draft);
       setLastSyncedPublished(published);
     },
-    [draft, saveMode, selectedMode, serverDescription, serverLabel]
+    [
+      draft,
+      lastSyncedRequiresGroup,
+      saveMode,
+      selectedMode,
+      serverDescription,
+      serverLabel,
+    ]
+  );
+
+  // #209 — immediate-save toggle, mirroring handleSetPublished: the
+  // worker contract has no partial update, so the current draft rides
+  // along and both last-synced trackers advance on success. A failure
+  // surfaces through the page-level saveError banner, and the switch
+  // visually reverts on its own because it renders from
+  // lastSyncedRequiresGroup (not advanced on error).
+  const handleSetRequiresGroup = useCallback(
+    async (requiresGroup: boolean) => {
+      if (!selectedMode) return;
+      await saveMode.mutateAsync({
+        name: selectedMode,
+        body: {
+          label: serverLabel,
+          description: serverDescription,
+          document: draft,
+          published: lastSyncedPublished,
+          requires_group: requiresGroup,
+        },
+      });
+      setLastSyncedDoc(draft);
+      setLastSyncedRequiresGroup(requiresGroup);
+    },
+    [
+      draft,
+      lastSyncedPublished,
+      saveMode,
+      selectedMode,
+      serverDescription,
+      serverLabel,
+    ]
   );
 
   const handleDeleteMode = useCallback(
@@ -598,6 +652,7 @@ export function ModesPage() {
             description: labelSync.description,
             document: labelSync.document,
             published: labelSync.published ?? false,
+            requires_group: labelSync.requires_group,
           },
         }),
       setLabelSyncError,
@@ -687,6 +742,28 @@ export function ModesPage() {
 
           {hasSelection && (
             <div className="flex shrink-0 items-center gap-3">
+              {/* #209 — group-only gate. Saves immediately on toggle
+                  (like Publish); renders from lastSyncedRequiresGroup so
+                  a failed save reverts visually. */}
+              <div
+                className="flex items-center gap-2"
+                title="When on, this mode is only offered in group chats (Telegram groups) — hidden from WhatsApp, web, and DMs."
+              >
+                <Switch
+                  id="mode-requires-group"
+                  checked={lastSyncedRequiresGroup}
+                  onCheckedChange={(checked) => {
+                    handleSetRequiresGroup(checked).catch(() => {});
+                  }}
+                  disabled={!canEditSelected || isSaving}
+                />
+                <Label
+                  htmlFor="mode-requires-group"
+                  className="text-muted-foreground text-xs font-normal"
+                >
+                  Requires group chat
+                </Label>
+              </div>
               <span
                 className="text-muted-foreground text-xs tabular-nums"
                 aria-live="polite"

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -68,6 +68,13 @@ import { PageHeader } from "@/components/page-header";
 
 const AUTO_SAVE_DEBOUNCE_MS = 800;
 
+// One sentence, one meaning: the Save button and the group-chat switch
+// explain a denied edit with the SAME words, so a shepherd who can't act
+// on a mode reads the same reason wherever they look.
+const NO_EDIT_RIGHTS_REASON = "You don't have edit rights on this mode.";
+const REQUIRES_GROUP_HELP =
+  "When on, this mode is only offered in group chats (Telegram groups) — hidden from WhatsApp, web, and DMs.";
+
 export function ModesPage() {
   const user = useAuthStore((s) => s.user);
   const setUser = useAuthStore((s) => s.setUser);
@@ -183,6 +190,17 @@ export function ModesPage() {
     lastSyncedFlagsRef.current = next;
     setLastSyncedFlags(next);
   }, []);
+  // Hard, SYNCHRONOUS in-flight lock, held as a COUNT rather than a
+  // boolean. `saveMode.isPending` is render state, so two interactions in
+  // the same tick (double-click, pointer + keyboard on the switch, an
+  // autosave landing on the same tick as a toggle) both observe the
+  // pre-render `false` and both fire a PUT. A boolean would break the
+  // moment two saves legitimately overlap — the first to settle would
+  // release a lock the second still holds. Every save path increments on
+  // entry and decrements on settle; the paths whose overlap would corrupt
+  // the shared flag pair refuse to start while the count is non-zero,
+  // which is the truth the `disabled` props merely reflect.
+  const inFlightSavesRef = useRef(0);
   // Pauses autosave on a draft that already failed once, so a failed save
   // doesn't loop on every isPending → false transition (Frank P2 on
   // PR #122). User recovers by editing further (changes debouncedDraft) or
@@ -216,6 +234,21 @@ export function ModesPage() {
     syncedNameRef.current = selectedMode;
   }, [applyLastSyncedFlags, selectedMode, modeQuery.data]);
 
+  // `lastSyncedDoc` / `lastSyncedFlags` describe exactly ONE mode — the
+  // one `syncedNameRef` names, since both are (re)anchored together in
+  // the effect above and cleared together when the selection empties. A
+  // save can outlive its selection: the switch-confirm dialog offers
+  // "Discard and switch" while a PUT is in flight, and the flag toggle
+  // made that state common (isSaving with nothing dirty). Advancing the
+  // trackers from mode A's response after they have been re-anchored on
+  // mode B would hand B mode A's content — and B's next save would write
+  // it upstream. Every completion path routes its tracker writes through
+  // this guard.
+  const trackersOwn = useCallback(
+    (name: string) => syncedNameRef.current === name,
+    []
+  );
+
   const isDirty = draft !== lastSyncedDoc;
   const isSaving = saveMode.isPending;
   const hasSelection = selectedMode !== null && modeQuery.data;
@@ -223,10 +256,15 @@ export function ModesPage() {
   const performSave = useCallback(
     (doc: string) => {
       if (!selectedMode) return;
+      if (inFlightSavesRef.current > 0) return;
       const sent = lastSyncedFlagsRef.current;
+      // Bind the completion to the mode this PUT is FOR, not to whatever
+      // happens to be selected when it lands.
+      const target = selectedMode;
+      inFlightSavesRef.current += 1;
       saveMode.mutate(
         {
-          name: selectedMode,
+          name: target,
           body: {
             label: serverLabel,
             description: serverDescription,
@@ -236,11 +274,18 @@ export function ModesPage() {
         },
         {
           onSuccess: (saved) => {
+            if (!trackersOwn(target)) return;
             setLastSyncedDoc(doc);
             setLastFailedDoc(null);
             applyLastSyncedFlags(reconcileModeFlags(sent, saved));
           },
-          onError: () => setLastFailedDoc(doc),
+          onError: () => {
+            if (!trackersOwn(target)) return;
+            setLastFailedDoc(doc);
+          },
+          onSettled: () => {
+            inFlightSavesRef.current -= 1;
+          },
         }
       );
     },
@@ -250,6 +295,7 @@ export function ModesPage() {
       selectedMode,
       serverDescription,
       serverLabel,
+      trackersOwn,
     ]
   );
 
@@ -411,6 +457,13 @@ export function ModesPage() {
 
   const handleCreateMode = useCallback(
     (name: string, label: string, description: string) => {
+      // Deliberately does NOT refuse while another save is in flight: the
+      // create dialog is fire-and-forget (it closes as soon as this
+      // returns), so a silent no-op would swallow the user's new mode.
+      // Nor can it corrupt the trackers — it targets a brand-new slug and
+      // only moves the selection. It still counts, so the paths that do
+      // need serialization can see it.
+      inFlightSavesRef.current += 1;
       saveMode.mutate(
         {
           name,
@@ -418,10 +471,20 @@ export function ModesPage() {
             label: label || undefined,
             description: description || undefined,
             document: MODE_DOCUMENT_SCAFFOLD,
+            // Both flags, always explicit. The worker has no partial
+            // update — an omitted key means "keep whatever is stored" —
+            // so every body this page sends states the full pair rather
+            // than leaning on an engine default (#209).
             published: false,
+            requires_group: false,
           },
         },
-        { onSuccess: () => setSelectedMode(name) }
+        {
+          onSuccess: () => setSelectedMode(name),
+          onSettled: () => {
+            inFlightSavesRef.current -= 1;
+          },
+        }
       );
     },
     [saveMode, setSelectedMode]
@@ -440,21 +503,27 @@ export function ModesPage() {
       // by the same `saveMode.isPending` the page reads as `isSaving`; the
       // throw is the backstop for any caller that misses that gate, and it
       // surfaces inline in the unpublish dialog via `runConfirmedAction`.
-      if (saveMode.isPending) {
+      if (inFlightSavesRef.current > 0 || saveMode.isPending) {
         throw new Error("Another save is in flight. Try again in a moment.");
       }
       const sent: ModeFlags = { ...lastSyncedFlagsRef.current, published };
-      const saved = await saveMode.mutateAsync({
-        name,
-        body: {
-          label: serverLabel,
-          description: serverDescription,
-          document: draft,
-          ...sent,
-        },
-      });
-      setLastSyncedDoc(draft);
-      applyLastSyncedFlags(reconcileModeFlags(sent, saved));
+      inFlightSavesRef.current += 1;
+      try {
+        const saved = await saveMode.mutateAsync({
+          name,
+          body: {
+            label: serverLabel,
+            description: serverDescription,
+            document: draft,
+            ...sent,
+          },
+        });
+        if (!trackersOwn(name)) return;
+        setLastSyncedDoc(draft);
+        applyLastSyncedFlags(reconcileModeFlags(sent, saved));
+      } finally {
+        inFlightSavesRef.current -= 1;
+      }
     },
     [
       applyLastSyncedFlags,
@@ -463,6 +532,7 @@ export function ModesPage() {
       selectedMode,
       serverDescription,
       serverLabel,
+      trackersOwn,
     ]
   );
 
@@ -477,24 +547,31 @@ export function ModesPage() {
   const handleSetRequiresGroup = useCallback(
     async (requiresGroup: boolean) => {
       if (!selectedMode) return;
-      if (saveMode.isPending) {
+      if (inFlightSavesRef.current > 0 || saveMode.isPending) {
         throw new Error("Another save is in flight. Try again in a moment.");
       }
+      const target = selectedMode;
       const sent: ModeFlags = {
         ...lastSyncedFlagsRef.current,
         requires_group: requiresGroup,
       };
-      const saved = await saveMode.mutateAsync({
-        name: selectedMode,
-        body: {
-          label: serverLabel,
-          description: serverDescription,
-          document: draft,
-          ...sent,
-        },
-      });
-      setLastSyncedDoc(draft);
-      applyLastSyncedFlags(reconcileModeFlags(sent, saved));
+      inFlightSavesRef.current += 1;
+      try {
+        const saved = await saveMode.mutateAsync({
+          name: target,
+          body: {
+            label: serverLabel,
+            description: serverDescription,
+            document: draft,
+            ...sent,
+          },
+        });
+        if (!trackersOwn(target)) return;
+        setLastSyncedDoc(draft);
+        applyLastSyncedFlags(reconcileModeFlags(sent, saved));
+      } finally {
+        inFlightSavesRef.current -= 1;
+      }
     },
     [
       applyLastSyncedFlags,
@@ -503,6 +580,7 @@ export function ModesPage() {
       selectedMode,
       serverDescription,
       serverLabel,
+      trackersOwn,
     ]
   );
 
@@ -672,17 +750,25 @@ export function ModesPage() {
       return;
     }
     return runConfirmedAction(
-      () =>
-        saveMode.mutateAsync({
-          name: labelSync.name,
-          body: {
-            label: nextLabel,
-            description: labelSync.description,
-            document: labelSync.document,
-            published: labelSync.published ?? false,
-            requires_group: labelSync.requires_group ?? false,
-          },
-        }),
+      async () => {
+        // Participates in the same synchronous lock as every other save
+        // path, so an in-flight PUT is visible to them all.
+        inFlightSavesRef.current += 1;
+        try {
+          return await saveMode.mutateAsync({
+            name: labelSync.name,
+            body: {
+              label: nextLabel,
+              description: labelSync.description,
+              document: labelSync.document,
+              published: labelSync.published ?? false,
+              requires_group: labelSync.requires_group ?? false,
+            },
+          });
+        } finally {
+          inFlightSavesRef.current -= 1;
+        }
+      },
       setLabelSyncError,
       () => {
         setLabelSync(null);
@@ -707,6 +793,12 @@ export function ModesPage() {
   // misleading (neither is a save). #241 PR B Frank F3; retire matches
   // the same policy on introduction (#241 PR C).
   const saveError = saveMode.error ?? deleteMode.error ?? renameMode.error;
+
+  // Base description, plus the reason when the switch is gated off. See
+  // the sr-only span below for why the title isn't enough on its own.
+  const requiresGroupHelp = canEditSelected
+    ? REQUIRES_GROUP_HELP
+    : `${REQUIRES_GROUP_HELP} ${NO_EDIT_RIGHTS_REASON}`;
 
   const saveStatus = useMemo(() => {
     if (isSaving) return "Saving…";
@@ -778,11 +870,12 @@ export function ModesPage() {
                   failed save reverts visually. */}
               <div
                 className="flex items-center gap-2"
-                title="When on, this mode is only offered in group chats (Telegram groups) — hidden from WhatsApp, web, and DMs."
+                title={requiresGroupHelp}
               >
                 <Switch
                   id="mode-requires-group"
                   checked={lastSyncedFlags.requires_group}
+                  aria-describedby="mode-requires-group-help"
                   onCheckedChange={(checked) => {
                     handleSetRequiresGroup(checked).catch(() => {});
                   }}
@@ -794,6 +887,14 @@ export function ModesPage() {
                 >
                   Requires group chat
                 </Label>
+                {/* The tooltip alone can't carry the reason: a disabled
+                    control is out of the tab order and gets no hover on
+                    touch, so keyboard and screen-reader users would meet a
+                    dead switch with no explanation. Same sentence the Save
+                    button uses for the same denial. */}
+                <span id="mode-requires-group-help" className="sr-only">
+                  {requiresGroupHelp}
+                </span>
               </div>
               <span
                 className="text-muted-foreground text-xs tabular-nums"
@@ -815,11 +916,7 @@ export function ModesPage() {
                 size="sm"
                 onClick={flushSave}
                 disabled={!isDirty || isSaving || !canEditSelected}
-                title={
-                  canEditSelected
-                    ? undefined
-                    : "You don't have edit rights on this mode."
-                }
+                title={canEditSelected ? undefined : NO_EDIT_RIGHTS_REASON}
               >
                 <Save className="mr-1.5 size-3.5" />
                 Save
@@ -920,12 +1017,28 @@ export function ModesPage() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Switch mode?</AlertDialogTitle>
+            {/* The dialog also opens on a save-in-flight with nothing
+                dirty — routine now that the group-chat toggle saves on
+                touch — and "unsaved edits" is simply untrue there. */}
             <AlertDialogDescription>
-              You have unsaved edits to{" "}
-              <span className="text-foreground font-medium">
-                &ldquo;{selectedMode}&rdquo;
-              </span>
-              . Switching will discard them.
+              {isDirty ? (
+                <>
+                  You have unsaved edits to{" "}
+                  <span className="text-foreground font-medium">
+                    &ldquo;{selectedMode}&rdquo;
+                  </span>
+                  . Switching will discard them.
+                </>
+              ) : (
+                <>
+                  A save for{" "}
+                  <span className="text-foreground font-medium">
+                    &ldquo;{selectedMode}&rdquo;
+                  </span>{" "}
+                  is still in flight. Switching now won&rsquo;t cancel it, but
+                  you won&rsquo;t see whether it succeeded.
+                </>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -85,6 +85,7 @@ export function useSaveMode(org?: string | null) {
         description?: string;
         document: string;
         published?: boolean;
+        requires_group?: boolean;
       };
     }) => configApi.putMode(name, body, undefined, key),
     onSuccess: (_data, { name }) => {

--- a/src/lib/config-api.ts
+++ b/src/lib/config-api.ts
@@ -144,6 +144,7 @@ export async function putMode(
     description?: string;
     document: string;
     published?: boolean;
+    requires_group?: boolean;
   },
   signal?: AbortSignal,
   org?: string | null

--- a/src/lib/mode-export.ts
+++ b/src/lib/mode-export.ts
@@ -27,6 +27,14 @@ export function buildModeExportContent(
     lines.push(`description: ${yamlScalar(mode.description)}`);
   }
   lines.push(`published: ${mode.published === true ? "true" : "false"}`);
+  // Emitted only when set (#209): absent and false are semantically
+  // identical (mode visible everywhere), and omitting the key keeps
+  // existing modes' exports byte-stable — same rule as `aliases` below.
+  // Additive optional key, so MODE_EXPORT_VERSION stays put (precedent:
+  // the #241 PR A aliases addition).
+  if (mode.requires_group === true) {
+    lines.push("requires_group: true");
+  }
   // Engine omits `aliases` when empty (#232 reconciliation §2); mirror
   // that on export so round-tripped files don't sprout an empty key.
   if (mode.aliases?.length) {

--- a/src/lib/mode-flags.ts
+++ b/src/lib/mode-flags.ts
@@ -1,0 +1,71 @@
+// Pure helpers for the mode boolean-flag pair (`published`,
+// `requires_group`) that every mode PUT must carry (#209).
+//
+// The worker's mode PUT has no partial-update path: a body always carries
+// the full document, and each omitted scalar key falls back to the STORED
+// value (`incoming.published ?? existing.published`, worker
+// `mergeExistingMode`). An explicit `false` is therefore the only way to
+// turn either flag off — which means every save path, including the ones
+// that conceptually touch only one flag (Publish, the group-chat toggle),
+// re-asserts BOTH. Two flag writes that overlap would each carry the
+// other's pre-flight value and the loser would clobber the winner, so the
+// page keeps the pair as ONE value that only ever moves together.
+//
+// The worker echoes the merged mode back on every PUT
+// (`{ org, mode: toMarkdownView(savedMode) }`), including `published` and
+// `requires_group` — its `compactOptional` filter drops `undefined` and
+// `""` but keeps `false`. That response is server truth, so it is what the
+// local trackers re-anchor on rather than assuming the write landed
+// exactly as sent.
+
+import type { PromptMode } from "@/types/prompt-override";
+
+export interface ModeFlags {
+  published: boolean;
+  requires_group: boolean;
+}
+
+/** Flags for a mode with neither key set (and for "nothing selected"). */
+export const DEFAULT_MODE_FLAGS: ModeFlags = {
+  published: false,
+  requires_group: false,
+};
+
+type ModeFlagSource = Partial<
+  Pick<PromptMode, "published" | "requires_group">
+> | null;
+
+/**
+ * Read the flag pair off a server mode payload, coercing absent keys to
+ * `false`. Absent and `false` are semantically identical on the wire for
+ * both flags; the portal works in plain booleans so it can always send
+ * them explicitly.
+ */
+export function readModeFlags(mode: ModeFlagSource | undefined): ModeFlags {
+  return {
+    published: mode?.published ?? false,
+    requires_group: mode?.requires_group ?? false,
+  };
+}
+
+/**
+ * Re-anchor the locally-tracked flag pair after a successful PUT.
+ *
+ * `saved` is the mode the worker echoed back (post-merge server truth) and
+ * wins per key when present. A key the worker omitted means the stored
+ * value is `undefined`, only reachable by never having set that flag — so
+ * fall back to what we sent, which is what the merge just stored.
+ *
+ * `??` (not `||`) is load-bearing: a server-echoed `false` has to survive
+ * against a sent `true`, which is exactly the disagreement this
+ * reconciliation exists to catch.
+ */
+export function reconcileModeFlags(
+  sent: ModeFlags,
+  saved: ModeFlagSource | undefined
+): ModeFlags {
+  return {
+    published: saved?.published ?? sent.published,
+    requires_group: saved?.requires_group ?? sent.requires_group,
+  };
+}

--- a/src/types/prompt-override.ts
+++ b/src/types/prompt-override.ts
@@ -60,6 +60,14 @@ export interface PromptMode {
   // that on the wire by only sending the key when there are entries, and
   // guard reads with `aliases?.length`.
   aliases?: string[];
+  // Group-only gate (#209, worker #270): when true the worker hides the
+  // mode from `list_modes` and the `#`-trigger in non-group chats
+  // (WhatsApp, web, Telegram DMs). Absent and false are semantically
+  // identical (mode visible everywhere). Worker merge carries the stored
+  // value through when the key is omitted on PUT (same rule as
+  // `published`), so the portal always sends the boolean explicitly on
+  // save — an omitted key could never turn the flag off.
+  requires_group?: boolean;
 }
 
 export interface OrgModes {

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -281,6 +281,7 @@ function spyFetchWithCurrent(
     label?: string;
     description?: string;
     published?: boolean;
+    requires_group?: boolean;
   } | null
 ) {
   let callCount = 0;
@@ -927,6 +928,149 @@ function findEnginePost(
   );
   return call ? [String(call[0]), call[1] as RequestInit] : undefined;
 }
+
+describe("config authz — #209 requires_group is edit-gated", () => {
+  it("publish-only shepherd flipping ONLY requires_group → 403 (no engine write)", async () => {
+    // The load-bearing case. This caller clears the early-deny (they hold
+    // publish on the row) and the body changes nothing the pre-fix gate
+    // modelled, so the diff computed [] and the PUT sailed through to the
+    // engine — group-visibility flipped without edit rights.
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## same\n",
+      published: false,
+      requires_group: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          document: "## same\n",
+          published: false,
+          requires_group: true,
+        }),
+      }),
+      env,
+      makeSession({
+        mode_edit_rights: [],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    // Only the gate's current-state read — the proxy never ran.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("publish-only shepherd flipping requires_group on a legacy row (field omitted) → 403", async () => {
+    // Same denial when the stored row predates #209, so the coercion
+    // can't be used as a bypass in the other direction.
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## same\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          document: "## same\n",
+          published: false,
+          requires_group: true,
+        }),
+      }),
+      env,
+      makeSession({
+        mode_edit_rights: [],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("edit-rights shepherd flipping requires_group → 200 (proxied)", async () => {
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## same\n",
+      published: false,
+      requires_group: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          document: "## same\n",
+          published: false,
+          requires_group: true,
+        }),
+      }),
+      env,
+      makeSession({
+        mode_edit_rights: ["spoken"],
+        mode_publish_rights: [],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const init = fetchSpy.mock.calls[1]![1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      requires_group: true,
+    });
+  });
+
+  it("publish-only shepherd publishing while re-asserting an UNCHANGED requires_group → 200", async () => {
+    // The regression this fix must not cause: the portal sends the flag
+    // pair on every PUT, so an explicit `requires_group: false` against a
+    // legacy row (field omitted) must NOT demand edit — otherwise every
+    // publish and every autosave by a single-verb shepherd starts 403ing.
+    const fetchSpy = spyFetchWithCurrent("mode", {
+      document: "## same\n",
+      published: false,
+    });
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          document: "## same\n",
+          published: true,
+          requires_group: false,
+        }),
+      }),
+      env,
+      makeSession({
+        mode_edit_rights: [],
+        mode_publish_rights: ["spoken"],
+      }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("admin flipping requires_group → 200 (admin trump, no diff)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request("https://portal.example.test/api/config/modes/spoken", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          document: "## same\n",
+          published: false,
+          requires_group: true,
+        }),
+      }),
+      env,
+      makeSession({ isAdmin: true }),
+      "/api/config/modes/spoken"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("config authz — #232 mode rename (_rename)", () => {
   it("admin → proxies POST to engine _rename path", async () => {
@@ -2650,6 +2794,77 @@ describe("config authz — #181 verb diff (pure function)", () => {
       computeRequiredVerbsForPut(
         { document: "## same\n", description: "New", published: false },
         { document: "## same\n", description: "Old", published: false }
+      )
+    ).toEqual(["edit"]);
+  });
+
+  it("#209 update changing only requires_group → ['edit']", () => {
+    // The flag is mode configuration, gated on the same verb as the
+    // document. Pre-fix this returned [] and any caller past the
+    // early-deny could flip group-visibility for free.
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "## same\n", published: false, requires_group: true },
+        { document: "## same\n", published: false, requires_group: false }
+      )
+    ).toEqual(["edit"]);
+  });
+
+  it("#209 unchanged requires_group against a row that OMITS the field → []", () => {
+    // The coercion case. Mode rows predating #209 have no
+    // `requires_group` key, and the portal re-asserts the flag pair on
+    // every PUT — without `current?.requires_group ?? false`, every
+    // ordinary autosave against a legacy row would demand edit.
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "## same\n", published: false, requires_group: false },
+        { document: "## same\n", published: false }
+      )
+    ).toEqual([]);
+  });
+
+  it("#209 setting requires_group on a row that omits the field → ['edit']", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "## same\n", published: false, requires_group: true },
+        { document: "## same\n", published: false }
+      )
+    ).toEqual(["edit"]);
+  });
+
+  it("#209 requires_group flip + publish flip → ['edit', 'publish']", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        { document: "## same\n", published: true, requires_group: true },
+        { document: "## same\n", published: false, requires_group: false }
+      )
+    ).toEqual(["edit", "publish"]);
+  });
+
+  it("#209 creation with requires_group: true and no document → ['edit']", () => {
+    // The only shape where the create arm changes observable behavior:
+    // an ordinary create carries a `document`, which already demands
+    // edit on its own (see the case below).
+    expect(computeRequiredVerbsForPut({ requires_group: true }, null)).toEqual([
+      "edit",
+    ]);
+  });
+
+  it("#209 creation with requires_group: false and no document → [] (default state isn't a change)", () => {
+    expect(computeRequiredVerbsForPut({ requires_group: false }, null)).toEqual(
+      []
+    );
+  });
+
+  it("#209 creation with document + requires_group: false → ['edit'] (unchanged from pre-#209)", () => {
+    expect(
+      computeRequiredVerbsForPut(
+        {
+          document: "# brand new\n",
+          published: false,
+          requires_group: false,
+        },
+        null
       )
     ).toEqual(["edit"]);
   });

--- a/tests/mode-export.test.ts
+++ b/tests/mode-export.test.ts
@@ -111,6 +111,46 @@ describe("buildModeExportContent — frontmatter", () => {
     expect(out).toContain('  - "back\\\\slash"');
   });
 
+  it("emits requires_group: true when the flag is set (#209)", () => {
+    const out = buildModeExportContent(
+      { ...baseMode, requires_group: true },
+      { org: "unfoldingWord", exportedAt: FIXED_DATE }
+    );
+    expect(out).toContain("requires_group: true");
+    // Emitted inside the frontmatter block, not the body.
+    const lines = out.split("\n");
+    const closingIdx = lines.indexOf("---", 1);
+    expect(lines.indexOf("requires_group: true")).toBeLessThan(closingIdx);
+  });
+
+  it("omits requires_group when absent or explicitly false", () => {
+    // Absent and false are semantically identical (mode visible
+    // everywhere); omitting keeps existing modes' exports byte-stable —
+    // same rule as `aliases`.
+    const absent = buildModeExportContent(baseMode, {
+      org: "uW",
+      exportedAt: FIXED_DATE,
+    });
+    const explicitFalse = buildModeExportContent(
+      { ...baseMode, requires_group: false },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(absent).not.toContain("requires_group");
+    expect(explicitFalse).not.toContain("requires_group");
+  });
+
+  it("lets a spread-construction override carry requires_group (handleExport pattern)", () => {
+    // modes.tsx handleExport overrides the cached value with the
+    // locally-tracked toggle, same as `published` — pin that an
+    // override of false suppresses a stale cached true.
+    const cached: PromptMode = { ...baseMode, requires_group: true };
+    const out = buildModeExportContent(
+      { ...cached, requires_group: false },
+      { org: "uW", exportedAt: FIXED_DATE }
+    );
+    expect(out).not.toContain("requires_group");
+  });
+
   it("emits published as the literal boolean — false when undefined or false", () => {
     const undef = buildModeExportContent(
       { name: "x", document: "" },

--- a/tests/mode-flags.test.ts
+++ b/tests/mode-flags.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MODE_FLAGS,
+  readModeFlags,
+  reconcileModeFlags,
+} from "../src/lib/mode-flags";
+
+describe("readModeFlags", () => {
+  it("coerces both absent keys to false", () => {
+    expect(readModeFlags({ published: undefined })).toEqual({
+      published: false,
+      requires_group: false,
+    });
+  });
+
+  it("returns the defaults for a missing mode", () => {
+    expect(readModeFlags(undefined)).toEqual(DEFAULT_MODE_FLAGS);
+    expect(readModeFlags(null)).toEqual(DEFAULT_MODE_FLAGS);
+  });
+
+  it("passes explicit booleans through in both directions", () => {
+    expect(readModeFlags({ published: true, requires_group: false })).toEqual({
+      published: true,
+      requires_group: false,
+    });
+    expect(readModeFlags({ published: false, requires_group: true })).toEqual({
+      published: false,
+      requires_group: true,
+    });
+  });
+
+  it("reads each key independently when only one is present", () => {
+    expect(readModeFlags({ requires_group: true })).toEqual({
+      published: false,
+      requires_group: true,
+    });
+  });
+});
+
+describe("reconcileModeFlags", () => {
+  const sent = { published: true, requires_group: true };
+
+  it("takes the server echo when it agrees with what we sent", () => {
+    expect(reconcileModeFlags(sent, { ...sent })).toEqual(sent);
+  });
+
+  it("lets a server-echoed false win over a sent true", () => {
+    // The `??`-not-`||` case: another writer (or a worker-side rule) landed
+    // a different value than we asked for. Server truth wins, so the UI
+    // shows what is actually stored instead of what we hoped for.
+    expect(
+      reconcileModeFlags(sent, { published: false, requires_group: false })
+    ).toEqual({ published: false, requires_group: false });
+  });
+
+  it("reconciles each flag independently", () => {
+    expect(
+      reconcileModeFlags(sent, { published: false, requires_group: true })
+    ).toEqual({ published: false, requires_group: true });
+  });
+
+  it("falls back to the sent value for a key the worker omitted", () => {
+    // The worker's `compactOptional` drops keys whose stored value is
+    // `undefined`. Anything we sent explicitly was just merged in, so the
+    // sent value is the correct fallback.
+    expect(reconcileModeFlags(sent, { published: true })).toEqual(sent);
+    expect(reconcileModeFlags(sent, {})).toEqual(sent);
+  });
+
+  it("falls back wholesale when there is no response payload", () => {
+    expect(reconcileModeFlags(sent, undefined)).toEqual(sent);
+    expect(reconcileModeFlags(sent, null)).toEqual(sent);
+  });
+
+  it("keeps a sent false when the worker omits the key", () => {
+    // Turning a flag OFF is the fragile direction: `false` must not be
+    // resurrected as `true` by the fallback.
+    const off = { published: false, requires_group: false };
+    expect(reconcileModeFlags(off, {})).toEqual(off);
+  });
+
+  it("does not alias the sent object", () => {
+    const out = reconcileModeFlags(sent, undefined);
+    expect(out).not.toBe(sent);
+  });
+});

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -120,10 +120,11 @@ async function proxyToEngine(
 // ---------------------------------------------------------------------------
 
 // PUT body shape we diff against current state. Both languages and modes
-// share `document` and `published`; modes additionally carry `label` and
-// `description`. We treat any of those three editorial fields as an edit
-// signal so a future `{label: "new"}` PUT for languages stays on the edit
-// gate even though today's portal only sends `document`.
+// share `document` and `published`; modes additionally carry `label`,
+// `description` and `requires_group`. We treat every one of those
+// editorial fields as an edit signal so a future `{label: "new"}` PUT for
+// languages stays on the edit gate even though today's portal only sends
+// `document`.
 interface ResourceShape {
   // Canonical slug from the engine's admin view. The rename arm's
   // preflights compare it against URL/body slugs — the engine resolves
@@ -134,6 +135,13 @@ interface ResourceShape {
   label?: string;
   description?: string;
   published?: boolean;
+  // #209 group-chat gate. MUST be modelled here: a field the diff cannot
+  // see is a field that ANY caller who cleared the early-deny changes for
+  // free (a publish-only shepherd, say), because the diff then computes
+  // zero required verbs. This worker is the only enforcement point — the
+  // engine takes one shared admin token and has no per-user identity — so
+  // an unmodelled field is an unguarded one.
+  requires_group?: boolean;
 }
 
 // Tri-state resource lookup — the single copy of the engine GET +
@@ -227,6 +235,12 @@ async function preflightMode(
 // Creation case (`current === null`): treat any editorial field as an
 // edit, and only require publish if `published: true` is being set
 // (since the engine's create-default is unpublished).
+//
+// `requires_group` (#209) maps to the EDIT verb, not to a verb of its
+// own: it is mode configuration, and the portal gates its switch on the
+// same `canEditSelected` predicate that gates the document. Publish is
+// deliberately NOT sufficient — flipping group-visibility changes which
+// surfaces offer the mode, which is an authoring decision.
 function computeRequiredVerbsForPut(
   body: ResourceShape,
   current: ResourceShape | null
@@ -237,6 +251,13 @@ function computeRequiredVerbsForPut(
   // `published: false` against such a row doesn't spuriously demand
   // publish rights (false !== undefined would otherwise trigger).
   const currentPublished = current?.published ?? false;
+  // Same coercion, same reason: every mode row created before #209 omits
+  // `requires_group` on read, while the portal now re-asserts the flag
+  // pair explicitly on EVERY PUT. Without the `?? false`, an ordinary
+  // document autosave carrying `requires_group: false` would read as a
+  // change against such a row and demand edit rights on a request that
+  // changes nothing.
+  const currentRequiresGroup = current?.requires_group ?? false;
   const docChanged =
     body.document !== undefined &&
     (isCreate || body.document !== current.document);
@@ -248,9 +269,22 @@ function computeRequiredVerbsForPut(
   const publishChanged =
     body.published !== undefined &&
     (isCreate ? body.published === true : body.published !== currentPublished);
+  // On create, mirror the `published` shape — the engine's create-default
+  // is `false`, so only `requires_group: true` is a change. This arm is
+  // near-inert in practice: a create already carries a `document`, which
+  // demands edit on its own. It matters for the one shape that doesn't —
+  // a bodyless-document create that sets the flag — and it keeps the
+  // create/update semantics from disagreeing about what the flag means.
+  const requiresGroupChanged =
+    body.requires_group !== undefined &&
+    (isCreate
+      ? body.requires_group === true
+      : body.requires_group !== currentRequiresGroup);
 
   const verbs: RightsVerb[] = [];
-  if (docChanged || labelChanged || descChanged) verbs.push("edit");
+  if (docChanged || labelChanged || descChanged || requiresGroupChanged) {
+    verbs.push("edit");
+  }
   if (publishChanged) verbs.push("publish");
   return verbs;
 }
@@ -282,7 +316,8 @@ function computeRequiredVerbsForPut(
 //   5. DELETE → requires BOTH edit + publish on the row. Deletion is
 //      strictly more destructive than either alone.
 //   6. PUT → diff body vs current and require the union of verbs the
-//      diff implies (`edit` if any editorial field changed, `publish`
+//      diff implies (`edit` if any editorial field changed — document,
+//      label, description, or the #209 `requires_group` flag; `publish`
 //      if the published flag flipped). When the diff denies, one
 //      carve-out (#247): a same-org admin's language PUT is allowed IF
 //      the engine CONFIRMED the target doesn't exist — pure creation.


### PR DESCRIPTION
## What / why

Portal half of the group-only mode gate (worker unfoldingWord/bt-servant-worker#270, shipped): modes flagged `requires_group` are hidden by the worker from `list_modes` and the `#`-trigger in non-group chats (WhatsApp, web, Telegram DMs). This PR adds the admin-side switch and persistence so admins can set the flag and it survives save + Export Config.

- **Type** — `PromptMode` gains optional `requires_group` (`src/types/prompt-override.ts`). Absent and false are semantically identical (mode visible everywhere).
- **Editor toggle** — the mode toolbar renders a "Requires group chat" switch (new shadcn `Switch` primitive in `src/components/ui/switch.tsx`, first use of `SwitchPrimitive` from the unified `radix-ui` package already in the deps). It saves immediately on toggle, mirroring the Publish flow: the current draft rides along (the worker contract has no partial PUT) and the locally-tracked `lastSyncedRequiresGroup` advances only on success — a failed save reverts the switch visually and the page-level error banner surfaces the failure. Gated by `canEditSelected` and disabled while a save is in flight.
- **Save** — every mode PUT body (autosave, publish/unpublish, the new toggle, and the #260 label-sync prompt) now carries the flag, so no save path can clobber it. The worker merge preserves the stored value when the key is omitted; an explicit `false` is the only way to turn the flag off — same contract as `published`.
- **Export Config** — frontmatter emits `requires_group: true` only when set. Omission keeps existing modes' exports byte-stable, the same rule as `aliases`; an additive optional key does not bump `MODE_EXPORT_VERSION` (precedent: the #241 PR A aliases addition, which kept version 1).
- **Tests** — `tests/mode-export.test.ts` covers emission when set, omission when absent or explicitly false, and the `handleExport` spread-override pattern (a locally-tracked `false` suppressing a stale cached `true`). The repo has no component-test infrastructure (vitest pure-function suites only), so the toggle itself is covered at the same level as the existing Publish toggle.

Closes #209

## Testing

- `npm run typecheck` — passes
- `npm run lint` — passes (zero warnings)
- `npm test` — 619 tests in 26 files, all passing (includes the 3 new `mode-export` cases)