### PR TITLE
feat(#261): MCP server visual map over the aggregated resources data

### DIFF
--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -1,7 +1,13 @@
 import { useMemo, useState } from "react";
 import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { ChevronRight, ExternalLink, RotateCw } from "lucide-react";
+import {
+  ChevronRight,
+  ExternalLink,
+  List,
+  Network,
+  RotateCw,
+} from "lucide-react";
 
 import { safeResourceHref } from "@/lib/resource-href";
 import { subjectLabel } from "@/lib/resource-subjects";
@@ -9,6 +15,7 @@ import { useUiStore } from "@/lib/ui-store";
 import { cn } from "@/lib/utils";
 import { OrgContextSelector } from "@/components/org-context-selector";
 import { PageHeader } from "@/components/page-header";
+import { ResourceServerMap } from "@/components/resource-server-map";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -135,6 +142,10 @@ export function ResourcesPage() {
     });
   };
 
+  // Two projections of the same query — the browsable list and the topology
+  // map (#261). No separate fetch: the map renders whatever the list has.
+  const [view, setView] = useState<"list" | "map">("list");
+
   const servers = data?.servers ?? [];
   const noneListable =
     servers.length > 0 && servers.every((s) => s.status !== "ok");
@@ -183,6 +194,40 @@ export function ResourcesPage() {
             IETF code — en, sw, es-419
           </p>
         </form>
+        <div
+          role="group"
+          aria-label="View"
+          className="bg-muted/40 ml-auto flex items-center gap-0.5 rounded-lg border p-0.5"
+        >
+          <button
+            type="button"
+            aria-pressed={view === "list"}
+            onClick={() => setView("list")}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+              view === "list"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <List className="size-3.5" />
+            List
+          </button>
+          <button
+            type="button"
+            aria-pressed={view === "map"}
+            onClick={() => setView("map")}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+              view === "map"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <Network className="size-3.5" />
+            Map
+          </button>
+        </div>
       </div>
 
       <div className="config-grid-bg min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
@@ -227,6 +272,8 @@ export function ResourcesPage() {
                     none are configured yet.
                   </p>
                 </div>
+              ) : view === "map" ? (
+                <ResourceServerMap data={data} />
               ) : noneListable ? (
                 <div className="bg-card rounded-xl border px-6 py-10 text-center">
                   <p className="text-foreground text-sm font-medium">

--- a/src/components/resource-server-map.tsx
+++ b/src/components/resource-server-map.tsx
@@ -1,6 +1,11 @@
 import { useMemo } from "react";
 
-import { MAP, buildResourceMapLayout } from "@/lib/resource-map-layout";
+import {
+  MAP,
+  buildResourceMapLayout,
+  serverCaption,
+} from "@/lib/resource-map-layout";
+import { subjectLabel } from "@/lib/resource-subjects";
 import { cn } from "@/lib/utils";
 import type {
   AggregatedResourcesResponse,
@@ -10,7 +15,8 @@ import type {
 // Auto-generated map of the org's MCP-server topology (#261): org → servers →
 // subject leaves, projected from the same aggregated response the list view
 // renders — no extra fetching, so the map is current by construction. All
-// geometry comes from the pure layout helper; this component only draws.
+// geometry and label text comes from the pure layout helper; this component
+// only draws.
 //
 // The signature encoding: branch strokes carry link health. A solid amber
 // branch means the server is listing resources; a dashed branch means the
@@ -36,17 +42,6 @@ const DOT_CLASS: Record<ResourceServerStatus, string> = {
   unsupported: "fill-muted-foreground/40",
   error: "fill-destructive",
 };
-
-function statusCaption(
-  status: ResourceServerStatus,
-  resourceCount: number,
-  language: string
-): string {
-  if (status === "unsupported") return "no resource listing";
-  if (status === "error") return "failed to respond";
-  if (resourceCount === 0) return `nothing listed for “${language}”`;
-  return `${String(resourceCount)} ${resourceCount === 1 ? "resource" : "resources"}`;
-}
 
 function LegendSwatch({
   dash,
@@ -95,19 +90,56 @@ export function ResourceServerMap({
 
   return (
     <div className="bg-card overflow-hidden rounded-xl border">
+      {/* Assistive-tech equivalent. An aggregate aria-label on the <svg> would
+          hand AT users strictly less than the list view — which server failed,
+          why, and what each one lists all live in the drawing. SVG text is not
+          dependably navigable, so the drawing is hidden outright and the same
+          facts are restated here as real DOM structure. Keep in sync with the
+          nodes below; both read from the same layout. */}
+      <div className="sr-only">
+        <h3>
+          MCP server map for org {layout.orgName} &mdash; content language
+          &ldquo;{data.language}&rdquo;
+        </h3>
+        <p>
+          {servers.length} {servers.length === 1 ? "server" : "servers"}:{" "}
+          {okCount} listing resources, {unsupportedCount} without resource
+          listing, {errorCount} failed. {totalResources}{" "}
+          {totalResources === 1 ? "resource" : "resources"} in total.
+        </p>
+        <ul>
+          {servers.map((server) => (
+            <li key={server.serverId}>
+              {server.serverName} &mdash;{" "}
+              {serverCaption(
+                server.status,
+                server.resourceCount,
+                data.language
+              )}
+              {server.status === "error" && server.error
+                ? `. Error: ${server.error}`
+                : null}
+              {server.leaves.length > 0 && (
+                <ul>
+                  {server.leaves.map((leaf) => (
+                    <li key={leaf.slug}>
+                      {subjectLabel(leaf.slug)}: {leaf.count}{" "}
+                      {leaf.count === 1 ? "resource" : "resources"}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+
       <div className="overflow-x-auto">
         <svg
           width={layout.width}
           height={layout.height}
           viewBox={`0 0 ${String(layout.width)} ${String(layout.height)}`}
-          role="img"
-          aria-label={`MCP server map for org ${data.org}: ${String(
-            servers.length
-          )} ${servers.length === 1 ? "server" : "servers"} — ${String(
-            okCount
-          )} listing resources, ${String(
-            unsupportedCount
-          )} without resource listing, ${String(errorCount)} failed.`}
+          aria-hidden
           className="block"
         >
           {/* Org → trunk → spine, in the resources brand amber. */}
@@ -125,6 +157,9 @@ export function ResourceServerMap({
 
           {/* Org node. */}
           <g>
+            {layout.orgDisplayName !== layout.orgName && (
+              <title>{layout.orgName}</title>
+            )}
             <rect
               x={MAP.org.x}
               y={layout.orgCenterY - MAP.org.height / 2}
@@ -152,13 +187,23 @@ export function ResourceServerMap({
               fontWeight={600}
               fill="var(--foreground)"
             >
-              {data.org}
+              {layout.orgDisplayName}
             </text>
           </g>
 
           {servers.map((server) => {
             const branch = BRANCH_STROKE[server.status];
             const nodeTop = server.centerY - MAP.server.height / 2;
+            // One <title> per node, or the second would be ignored: the full
+            // name matters exactly when the drawn one was cut short, and the
+            // error detail always matters.
+            const titleParts: string[] = [];
+            if (server.displayName !== server.serverName) {
+              titleParts.push(server.serverName);
+            }
+            if (server.status === "error" && server.error) {
+              titleParts.push(server.error);
+            }
             return (
               <g key={server.serverId}>
                 {/* Branch: spine → server, stroke style encodes link health. */}
@@ -175,8 +220,8 @@ export function ResourceServerMap({
 
                 {/* Server node. */}
                 <g>
-                  {server.status === "error" && server.error && (
-                    <title>{server.error}</title>
+                  {titleParts.length > 0 && (
+                    <title>{titleParts.join(" — ")}</title>
                   )}
                   <rect
                     x={MAP.server.x}
@@ -221,7 +266,7 @@ export function ResourceServerMap({
                     }
                     fillOpacity={server.status === "error" ? 0.9 : 1}
                   >
-                    {statusCaption(
+                    {serverCaption(
                       server.status,
                       server.resourceCount,
                       data.language

--- a/src/components/resource-server-map.tsx
+++ b/src/components/resource-server-map.tsx
@@ -1,0 +1,311 @@
+import { useMemo } from "react";
+
+import { MAP, buildResourceMapLayout } from "@/lib/resource-map-layout";
+import { cn } from "@/lib/utils";
+import type {
+  AggregatedResourcesResponse,
+  ResourceServerStatus,
+} from "@/types/resources";
+
+// Auto-generated map of the org's MCP-server topology (#261): org → servers →
+// subject leaves, projected from the same aggregated response the list view
+// renders — no extra fetching, so the map is current by construction. All
+// geometry comes from the pure layout helper; this component only draws.
+//
+// The signature encoding: branch strokes carry link health. A solid amber
+// branch means the server is listing resources; a dashed branch means the
+// link is degraded — muted for "no listing tool" (unsupported, e.g. FIA),
+// destructive for a failed response. Same three-way honesty as the status
+// chips (#230), extended into the connective tissue.
+
+const BRANCH_STROKE: Record<
+  ResourceServerStatus,
+  { stroke: string; dash?: string; opacity: number }
+> = {
+  ok: { stroke: "var(--brand-resources)", opacity: 0.9 },
+  unsupported: {
+    stroke: "var(--muted-foreground)",
+    dash: "4 4",
+    opacity: 0.45,
+  },
+  error: { stroke: "var(--destructive)", dash: "4 4", opacity: 0.7 },
+};
+
+const DOT_CLASS: Record<ResourceServerStatus, string> = {
+  ok: "fill-emerald-500",
+  unsupported: "fill-muted-foreground/40",
+  error: "fill-destructive",
+};
+
+function statusCaption(
+  status: ResourceServerStatus,
+  resourceCount: number,
+  language: string
+): string {
+  if (status === "unsupported") return "no resource listing";
+  if (status === "error") return "failed to respond";
+  if (resourceCount === 0) return `nothing listed for “${language}”`;
+  return `${String(resourceCount)} ${resourceCount === 1 ? "resource" : "resources"}`;
+}
+
+function LegendSwatch({
+  dash,
+  className,
+}: {
+  dash?: string;
+  className: string;
+}) {
+  return (
+    <svg width="20" height="6" aria-hidden className="shrink-0">
+      <line
+        x1="1"
+        y1="3"
+        x2="19"
+        y2="3"
+        strokeWidth="1.5"
+        strokeDasharray={dash}
+        className={className}
+      />
+    </svg>
+  );
+}
+
+export function ResourceServerMap({
+  data,
+}: {
+  data: AggregatedResourcesResponse;
+}) {
+  const layout = useMemo(() => buildResourceMapLayout(data), [data]);
+  const { servers } = layout;
+  const first = servers[0];
+  const last = servers[servers.length - 1];
+  if (!first || !last) return null;
+
+  const okCount = servers.filter((s) => s.status === "ok").length;
+  const unsupportedCount = servers.filter(
+    (s) => s.status === "unsupported"
+  ).length;
+  const errorCount = servers.filter((s) => s.status === "error").length;
+  const totalResources = servers.reduce((sum, s) => sum + s.resourceCount, 0);
+
+  const orgRight = MAP.org.x + MAP.org.width;
+  const serverRight = MAP.server.x + MAP.server.width;
+  const spineTop = Math.min(first.centerY, layout.orgCenterY);
+  const spineBottom = Math.max(last.centerY, layout.orgCenterY);
+
+  return (
+    <div className="bg-card overflow-hidden rounded-xl border">
+      <div className="overflow-x-auto">
+        <svg
+          width={layout.width}
+          height={layout.height}
+          viewBox={`0 0 ${String(layout.width)} ${String(layout.height)}`}
+          role="img"
+          aria-label={`MCP server map for org ${data.org}: ${String(
+            servers.length
+          )} ${servers.length === 1 ? "server" : "servers"} — ${String(
+            okCount
+          )} listing resources, ${String(
+            unsupportedCount
+          )} without resource listing, ${String(errorCount)} failed.`}
+          className="block"
+        >
+          {/* Org → trunk → spine, in the resources brand amber. */}
+          <path
+            d={`M ${String(orgRight)} ${String(layout.orgCenterY)} H ${String(
+              MAP.spineX
+            )} M ${String(MAP.spineX)} ${String(spineTop)} V ${String(
+              spineBottom
+            )}`}
+            fill="none"
+            stroke="var(--brand-resources)"
+            strokeOpacity={0.55}
+            strokeWidth={1.5}
+          />
+
+          {/* Org node. */}
+          <g>
+            <rect
+              x={MAP.org.x}
+              y={layout.orgCenterY - MAP.org.height / 2}
+              width={MAP.org.width}
+              height={MAP.org.height}
+              rx={10}
+              fill="var(--card)"
+              stroke="var(--brand-resources)"
+              strokeOpacity={0.6}
+              strokeWidth={1.5}
+            />
+            <text
+              x={MAP.org.x + 14}
+              y={layout.orgCenterY - 6}
+              fontSize={9}
+              letterSpacing="0.1em"
+              fill="var(--muted-foreground)"
+            >
+              ORG
+            </text>
+            <text
+              x={MAP.org.x + 14}
+              y={layout.orgCenterY + 12}
+              fontSize={12.5}
+              fontWeight={600}
+              fill="var(--foreground)"
+            >
+              {data.org}
+            </text>
+          </g>
+
+          {servers.map((server) => {
+            const branch = BRANCH_STROKE[server.status];
+            const nodeTop = server.centerY - MAP.server.height / 2;
+            return (
+              <g key={server.serverId}>
+                {/* Branch: spine → server, stroke style encodes link health. */}
+                <line
+                  x1={MAP.spineX}
+                  y1={server.centerY}
+                  x2={MAP.server.x}
+                  y2={server.centerY}
+                  stroke={branch.stroke}
+                  strokeOpacity={branch.opacity}
+                  strokeDasharray={branch.dash}
+                  strokeWidth={1.5}
+                />
+
+                {/* Server node. */}
+                <g>
+                  {server.status === "error" && server.error && (
+                    <title>{server.error}</title>
+                  )}
+                  <rect
+                    x={MAP.server.x}
+                    y={nodeTop}
+                    width={MAP.server.width}
+                    height={MAP.server.height}
+                    rx={9}
+                    fill="var(--card)"
+                    stroke={
+                      server.status === "error"
+                        ? "var(--destructive)"
+                        : "var(--border)"
+                    }
+                    strokeOpacity={server.status === "error" ? 0.5 : 1}
+                    strokeDasharray={
+                      server.status === "unsupported" ? "4 4" : undefined
+                    }
+                  />
+                  <circle
+                    cx={MAP.server.x + 16}
+                    cy={server.centerY - 8}
+                    r={3}
+                    className={DOT_CLASS[server.status]}
+                  />
+                  <text
+                    x={MAP.server.x + 26}
+                    y={server.centerY - 4}
+                    fontSize={12}
+                    fontWeight={500}
+                    fill="var(--foreground)"
+                  >
+                    {server.displayName}
+                  </text>
+                  <text
+                    x={MAP.server.x + 26}
+                    y={server.centerY + 13}
+                    fontSize={10}
+                    fill={
+                      server.status === "error"
+                        ? "var(--destructive)"
+                        : "var(--muted-foreground)"
+                    }
+                    fillOpacity={server.status === "error" ? 0.9 : 1}
+                  >
+                    {statusCaption(
+                      server.status,
+                      server.resourceCount,
+                      data.language
+                    )}
+                  </text>
+                </g>
+
+                {/* Subject leaves — only where resources were actually listed. */}
+                {server.leaves.map((leaf) => {
+                  const leafCenterY = leaf.y + MAP.leaf.height / 2;
+                  return (
+                    <g key={leaf.slug}>
+                      <path
+                        d={`M ${String(serverRight)} ${String(
+                          server.centerY
+                        )} H ${String(MAP.leafSpineX)} V ${String(
+                          leafCenterY
+                        )} H ${String(MAP.leaf.x)}`}
+                        fill="none"
+                        stroke="var(--border)"
+                        strokeWidth={1.25}
+                        strokeLinejoin="round"
+                      />
+                      <rect
+                        x={MAP.leaf.x}
+                        y={leaf.y}
+                        width={leaf.width}
+                        height={MAP.leaf.height}
+                        rx={MAP.leaf.height / 2}
+                        fill="var(--accent)"
+                        fillOpacity={0.5}
+                        stroke="var(--border)"
+                      />
+                      <text
+                        x={MAP.leaf.x + 12}
+                        y={leaf.y + 17}
+                        fontSize={11}
+                        fill="var(--foreground)"
+                        fillOpacity={0.85}
+                      >
+                        {leaf.label}
+                      </text>
+                      <text
+                        x={MAP.leaf.x + leaf.width - 12}
+                        y={leaf.y + 17}
+                        fontSize={11}
+                        textAnchor="end"
+                        fill="var(--muted-foreground)"
+                        className="tabular-nums"
+                      >
+                        {leaf.count}
+                      </text>
+                    </g>
+                  );
+                })}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <div
+        className={cn(
+          "text-muted-foreground border-border/60 flex flex-wrap items-center",
+          "gap-x-4 gap-y-1 border-t px-4 py-2.5 text-[11px]"
+        )}
+      >
+        <span className="inline-flex items-center gap-1.5">
+          <LegendSwatch className="stroke-(--brand-resources)" />
+          listing resources
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <LegendSwatch dash="4 4" className="stroke-muted-foreground/50" />
+          no listing tool
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <LegendSwatch dash="4 4" className="stroke-destructive/70" />
+          failed to respond
+        </span>
+        <span className="ml-auto">
+          Generated live for &ldquo;{data.language}&rdquo; &middot;{" "}
+          {totalResources} {totalResources === 1 ? "resource" : "resources"}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/resource-server-map.tsx
+++ b/src/components/resource-server-map.tsx
@@ -5,7 +5,6 @@ import {
   buildResourceMapLayout,
   serverCaption,
 } from "@/lib/resource-map-layout";
-import { subjectLabel } from "@/lib/resource-subjects";
 import { cn } from "@/lib/utils";
 import type {
   AggregatedResourcesResponse,
@@ -111,11 +110,13 @@ export function ResourceServerMap({
           {servers.map((server) => (
             <li key={server.serverId}>
               {server.serverName} &mdash;{" "}
-              {serverCaption(
-                server.status,
-                server.resourceCount,
-                data.language
-              )}
+              {
+                serverCaption(
+                  server.status,
+                  server.resourceCount,
+                  data.language
+                ).full
+              }
               {server.status === "error" && server.error
                 ? `. Error: ${server.error}`
                 : null}
@@ -123,7 +124,7 @@ export function ResourceServerMap({
                 <ul>
                   {server.leaves.map((leaf) => (
                     <li key={leaf.slug}>
-                      {subjectLabel(leaf.slug)}: {leaf.count}{" "}
+                      {leaf.fullLabel}: {leaf.count}{" "}
                       {leaf.count === 1 ? "resource" : "resources"}
                     </li>
                   ))}
@@ -194,12 +195,20 @@ export function ResourceServerMap({
           {servers.map((server) => {
             const branch = BRANCH_STROKE[server.status];
             const nodeTop = server.centerY - MAP.server.height / 2;
+            const caption = serverCaption(
+              server.status,
+              server.resourceCount,
+              data.language
+            );
             // One <title> per node, or the second would be ignored: the full
-            // name matters exactly when the drawn one was cut short, and the
-            // error detail always matters.
+            // name and the full caption matter exactly when the drawn forms
+            // were cut short, and the error detail always matters.
             const titleParts: string[] = [];
             if (server.displayName !== server.serverName) {
               titleParts.push(server.serverName);
+            }
+            if (caption.display !== caption.full) {
+              titleParts.push(caption.full);
             }
             if (server.status === "error" && server.error) {
               titleParts.push(server.error);
@@ -266,11 +275,7 @@ export function ResourceServerMap({
                     }
                     fillOpacity={server.status === "error" ? 0.9 : 1}
                   >
-                    {serverCaption(
-                      server.status,
-                      server.resourceCount,
-                      data.language
-                    )}
+                    {caption.display}
                   </text>
                 </g>
 
@@ -290,35 +295,43 @@ export function ResourceServerMap({
                         strokeWidth={1.25}
                         strokeLinejoin="round"
                       />
-                      <rect
-                        x={MAP.leaf.x}
-                        y={leaf.y}
-                        width={leaf.width}
-                        height={MAP.leaf.height}
-                        rx={MAP.leaf.height / 2}
-                        fill="var(--accent)"
-                        fillOpacity={0.5}
-                        stroke="var(--border)"
-                      />
-                      <text
-                        x={MAP.leaf.x + 12}
-                        y={leaf.y + 17}
-                        fontSize={11}
-                        fill="var(--foreground)"
-                        fillOpacity={0.85}
-                      >
-                        {leaf.label}
-                      </text>
-                      <text
-                        x={MAP.leaf.x + leaf.width - 12}
-                        y={leaf.y + 17}
-                        fontSize={11}
-                        textAnchor="end"
-                        fill="var(--muted-foreground)"
-                        className="tabular-nums"
-                      >
-                        {leaf.count}
-                      </text>
+                      {/* The chip gets its own group so a truncated label's
+                          <title> is scoped to the chip rather than to the
+                          elbow feeding it. Same pattern as the server node. */}
+                      <g>
+                        {leaf.label !== leaf.fullLabel && (
+                          <title>{leaf.fullLabel}</title>
+                        )}
+                        <rect
+                          x={MAP.leaf.x}
+                          y={leaf.y}
+                          width={leaf.width}
+                          height={MAP.leaf.height}
+                          rx={MAP.leaf.height / 2}
+                          fill="var(--accent)"
+                          fillOpacity={0.5}
+                          stroke="var(--border)"
+                        />
+                        <text
+                          x={MAP.leaf.x + 12}
+                          y={leaf.y + 17}
+                          fontSize={11}
+                          fill="var(--foreground)"
+                          fillOpacity={0.85}
+                        >
+                          {leaf.label}
+                        </text>
+                        <text
+                          x={MAP.leaf.x + leaf.width - 12}
+                          y={leaf.y + 17}
+                          fontSize={11}
+                          textAnchor="end"
+                          fill="var(--muted-foreground)"
+                          className="tabular-nums"
+                        >
+                          {leaf.count}
+                        </text>
+                      </g>
                     </g>
                   );
                 })}

--- a/src/lib/resource-map-layout.ts
+++ b/src/lib/resource-map-layout.ts
@@ -47,8 +47,23 @@ export const ORG_NAME_MAX_CHARS = Math.floor(
   (MAP.org.width - ORG_PAD_X * 2) / ORG_CHAR_W
 );
 
+// The caption renders at fontSize 10 inside the fixed-width server node,
+// starting SERVER_TEXT_X in from its left edge (clearing the status dot) with
+// a matching inset on the right. Derived from the node geometry exactly as
+// ORG_NAME_MAX_CHARS is, and for the same reason: the caption is not free
+// geometry. It carries either the degraded-status suffix or a user-typed
+// content-language tag, and both run past the node's right edge unbounded.
+const CAPTION_CHAR_W = 5.5;
+const SERVER_TEXT_X = 26;
+const SERVER_PAD_R = 12;
+export const SERVER_CAPTION_MAX_CHARS = Math.floor(
+  (MAP.server.width - SERVER_TEXT_X - SERVER_PAD_R) / CAPTION_CHAR_W
+);
+
 export interface ResourceMapLeaf {
   slug: string;
+  /** Full subjectLabel — the <title> fallback when `label` was cut short. */
+  fullLabel: string;
   /** Display label (subjectLabel), pre-truncated to fit the chip. */
   label: string;
   count: number;
@@ -92,28 +107,67 @@ export function truncateLabel(text: string, max: number): string {
   return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
 }
 
+/** The two forms of a server-node caption. */
+export interface ServerCaption {
+  /** Untruncated — the sr-only tree and the node <title> carry this. */
+  full: string;
+  /** Bounded to SERVER_CAPTION_MAX_CHARS, for the SVG <text>. */
+  display: string;
+}
+
+const EMPTY_CAPTION_PREFIX = "nothing listed for ";
+
+function quoteLanguage(tag: string): string {
+  return `${EMPTY_CAPTION_PREFIX}“${tag}”`;
+}
+
+/** What the tag itself may spend once the prose and quotes are paid for. */
+const LANGUAGE_TAG_MAX_CHARS = Math.max(
+  1,
+  SERVER_CAPTION_MAX_CHARS - quoteLanguage("").length
+);
+
+function bounded(full: string): ServerCaption {
+  return { full, display: truncateLabel(full, SERVER_CAPTION_MAX_CHARS) };
+}
+
 /**
  * Caption under a server node. Leaves are data-driven, so a degraded server
  * can still have items attributed to it (a cached listing behind a failed
  * refresh, say). Status alone would then read as "failed and empty" while
  * the map shows leaves and the totals count them — so the shown count is
  * appended to the reason rather than dropped.
+ *
+ * Neither long form fits the node unbounded: the degraded-with-count suffix
+ * is fixed prose that simply runs long, and the content language is a free
+ * IETF-code text field, so arbitrary user text lands inside the quotes. The
+ * tag is cut before the sentence around it — truncating the whole caption
+ * from the tail would eat the closing quote and the part that says what
+ * happened. The full text survives on `full` either way.
  */
 export function serverCaption(
   status: ResourceServerStatus,
   resourceCount: number,
   language: string
-): string {
+): ServerCaption {
   const counted = `${String(resourceCount)} ${
     resourceCount === 1 ? "resource" : "resources"
   }`;
   if (status !== "ok") {
     const reason =
       status === "unsupported" ? "no resource listing" : "failed to respond";
-    return resourceCount > 0 ? `${reason} — ${counted} shown` : reason;
+    return bounded(resourceCount > 0 ? `${reason} — ${counted} shown` : reason);
   }
-  if (resourceCount === 0) return `nothing listed for “${language}”`;
-  return counted;
+  if (resourceCount === 0) {
+    return {
+      full: quoteLanguage(language),
+      display: truncateLabel(
+        quoteLanguage(truncateLabel(language, LANGUAGE_TAG_MAX_CHARS)),
+        SERVER_CAPTION_MAX_CHARS
+      ),
+    };
+  }
+  return bounded(counted);
 }
 
 function leafWidth(label: string, count: number): number {
@@ -156,12 +210,11 @@ export function buildResourceMapLayout(
     const leavesTop = top + (height - leavesSpan) / 2;
 
     const leaves: ResourceMapLeaf[] = counted.map((entry, i) => {
-      const label = truncateLabel(
-        subjectLabel(entry.slug),
-        LEAF_LABEL_MAX_CHARS
-      );
+      const fullLabel = subjectLabel(entry.slug);
+      const label = truncateLabel(fullLabel, LEAF_LABEL_MAX_CHARS);
       return {
         slug: entry.slug,
+        fullLabel,
         label,
         count: entry.count,
         y: leavesTop + i * (MAP.leaf.height + MAP.leaf.gap),

--- a/src/lib/resource-map-layout.ts
+++ b/src/lib/resource-map-layout.ts
@@ -37,6 +37,16 @@ const MAX_LEAF_WIDTH = MAP.width - MAP.leaf.x - 16;
 const LEAF_LABEL_MAX_CHARS = 30;
 export const SERVER_NAME_MAX_CHARS = 24;
 
+// The org name renders at fontSize 12.5 semibold, inset ORG_PAD_X from each
+// side of the fixed-width org node. Same estimate-don't-measure approach as
+// the leaf chips, inverted: the node width is fixed here, so the character
+// budget is derived from it rather than the other way round.
+const ORG_CHAR_W = 7.4;
+const ORG_PAD_X = 14;
+export const ORG_NAME_MAX_CHARS = Math.floor(
+  (MAP.org.width - ORG_PAD_X * 2) / ORG_CHAR_W
+);
+
 export interface ResourceMapLeaf {
   slug: string;
   /** Display label (subjectLabel), pre-truncated to fit the chip. */
@@ -69,6 +79,10 @@ export interface ResourceMapLayout {
   width: number;
   height: number;
   orgCenterY: number;
+  /** Org identifier as the response gave it. */
+  orgName: string;
+  /** orgName pre-truncated for in-node rendering. */
+  orgDisplayName: string;
   servers: ResourceMapServer[];
 }
 
@@ -76,6 +90,30 @@ export interface ResourceMapLayout {
 export function truncateLabel(text: string, max: number): string {
   if (text.length <= max) return text;
   return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+/**
+ * Caption under a server node. Leaves are data-driven, so a degraded server
+ * can still have items attributed to it (a cached listing behind a failed
+ * refresh, say). Status alone would then read as "failed and empty" while
+ * the map shows leaves and the totals count them — so the shown count is
+ * appended to the reason rather than dropped.
+ */
+export function serverCaption(
+  status: ResourceServerStatus,
+  resourceCount: number,
+  language: string
+): string {
+  const counted = `${String(resourceCount)} ${
+    resourceCount === 1 ? "resource" : "resources"
+  }`;
+  if (status !== "ok") {
+    const reason =
+      status === "unsupported" ? "no resource listing" : "failed to respond";
+    return resourceCount > 0 ? `${reason} — ${counted} shown` : reason;
+  }
+  if (resourceCount === 0) return `nothing listed for “${language}”`;
+  return counted;
 }
 
 function leafWidth(label: string, count: number): number {
@@ -161,5 +199,12 @@ export function buildResourceMapLayout(
   // server) — the viewport must contain it either way.
   const height = Math.max(y, orgCenterY + MAP.org.height / 2) + MAP.padY;
 
-  return { width: MAP.width, height, orgCenterY, servers };
+  return {
+    width: MAP.width,
+    height,
+    orgCenterY,
+    orgName: data.org,
+    orgDisplayName: truncateLabel(data.org, ORG_NAME_MAX_CHARS),
+    servers,
+  };
 }

--- a/src/lib/resource-map-layout.ts
+++ b/src/lib/resource-map-layout.ts
@@ -1,0 +1,165 @@
+// Pure layout engine for the MCP server map (#261) — turns the aggregated
+// resources response (#230 / worker#257) into deterministic SVG geometry.
+// Deliberately DOM-free: it runs (and is tested) under the workers-pool
+// tsconfig, and the rendering component stays a thin projection of this
+// output. No diagram library — the topology is small and fixed-shape
+// (org → servers → subject leaves), so hand-rolled elbows beat a dependency.
+
+import { subjectLabel } from "@/lib/resource-subjects";
+import type {
+  AggregatedResourcesResponse,
+  ResourceServerStatus,
+} from "@/types/resources";
+
+// All coordinates are in SVG user units within a fixed-width viewport; the
+// container scrolls horizontally below MAP.width rather than reflowing.
+export const MAP = {
+  width: 920,
+  padY: 28,
+  org: { x: 16, width: 156, height: 58 },
+  /** Vertical trunk the org feeds; server branches tee off it. */
+  spineX: 204,
+  server: { x: 236, width: 204, height: 54 },
+  /** Vertical mini-spine between a server and its subject leaves. */
+  leafSpineX: 464,
+  leaf: { x: 488, height: 26, gap: 10 },
+  blockGap: 30,
+} as const;
+
+// Approximate glyph advance at the map's 11px label size. SVG text has no
+// CSS-driven truncation, so chip widths are estimated, not measured — the
+// generous padding absorbs the variance of a proportional face.
+const LEAF_CHAR_W = 6.0;
+const COUNT_CHAR_W = 6.6;
+const LEAF_PAD_X = 12;
+const LEAF_COUNT_GAP = 10;
+const MAX_LEAF_WIDTH = MAP.width - MAP.leaf.x - 16;
+const LEAF_LABEL_MAX_CHARS = 30;
+export const SERVER_NAME_MAX_CHARS = 24;
+
+export interface ResourceMapLeaf {
+  slug: string;
+  /** Display label (subjectLabel), pre-truncated to fit the chip. */
+  label: string;
+  count: number;
+  /** Top edge of the chip. */
+  y: number;
+  width: number;
+}
+
+export interface ResourceMapServer {
+  serverId: string;
+  serverName: string;
+  /** serverName pre-truncated for in-node rendering. */
+  displayName: string;
+  status: ResourceServerStatus;
+  error?: string;
+  /** Top edge of this server's block (node + leaves). */
+  top: number;
+  /** Height of the block: max(node height, leaves span). */
+  height: number;
+  /** Vertical center of the server node — branch lines land here. */
+  centerY: number;
+  /** Total resources this server contributed across all subjects. */
+  resourceCount: number;
+  leaves: ResourceMapLeaf[];
+}
+
+export interface ResourceMapLayout {
+  width: number;
+  height: number;
+  orgCenterY: number;
+  servers: ResourceMapServer[];
+}
+
+/** Ellipsis-truncate to at most `max` characters (including the ellipsis). */
+export function truncateLabel(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function leafWidth(label: string, count: number): number {
+  const raw =
+    LEAF_PAD_X * 2 +
+    label.length * LEAF_CHAR_W +
+    LEAF_COUNT_GAP +
+    String(count).length * COUNT_CHAR_W;
+  return Math.min(Math.ceil(raw), MAX_LEAF_WIDTH);
+}
+
+/**
+ * Compute the full map geometry. Leaves are data-driven: a server gets a
+ * subject leaf iff items are actually attributed to it (serverId match),
+ * independent of its status block — so the map can never claim resources a
+ * server didn't list, and never hides ones it did. Subject order follows the
+ * response's own key order; server order is the worker's server-default
+ * order. Both orderings are contract, not portal opinion (#230 Q5).
+ */
+export function buildResourceMapLayout(
+  data: AggregatedResourcesResponse
+): ResourceMapLayout {
+  const subjectEntries = Object.entries(data.resources);
+
+  let y = MAP.padY;
+  const servers: ResourceMapServer[] = data.servers.map((server) => {
+    const counted = subjectEntries
+      .map(([slug, items]) => ({
+        slug,
+        count: items.filter((item) => item.serverId === server.serverId).length,
+      }))
+      .filter((entry) => entry.count > 0);
+
+    const leavesSpan =
+      counted.length > 0
+        ? counted.length * MAP.leaf.height + (counted.length - 1) * MAP.leaf.gap
+        : 0;
+    const height = Math.max(MAP.server.height, leavesSpan);
+    const top = y;
+    const leavesTop = top + (height - leavesSpan) / 2;
+
+    const leaves: ResourceMapLeaf[] = counted.map((entry, i) => {
+      const label = truncateLabel(
+        subjectLabel(entry.slug),
+        LEAF_LABEL_MAX_CHARS
+      );
+      return {
+        slug: entry.slug,
+        label,
+        count: entry.count,
+        y: leavesTop + i * (MAP.leaf.height + MAP.leaf.gap),
+        width: leafWidth(label, entry.count),
+      };
+    });
+
+    y += height + MAP.blockGap;
+
+    return {
+      serverId: server.serverId,
+      serverName: server.serverName,
+      displayName: truncateLabel(server.serverName, SERVER_NAME_MAX_CHARS),
+      status: server.status,
+      error: server.error,
+      top,
+      height,
+      centerY: top + height / 2,
+      resourceCount: counted.reduce((sum, entry) => sum + entry.count, 0),
+      leaves,
+    };
+  });
+
+  if (servers.length > 0) y -= MAP.blockGap;
+  else y += MAP.org.height;
+
+  const firstServer = servers[0];
+  const lastServer = servers[servers.length - 1];
+  const orgCenterY =
+    firstServer && lastServer
+      ? (firstServer.centerY + lastServer.centerY) / 2
+      : MAP.padY + MAP.org.height / 2;
+
+  // The org node may extend past a short server column (e.g. one leafless
+  // server) — the viewport must contain it either way.
+  const height = Math.max(y, orgCenterY + MAP.org.height / 2) + MAP.padY;
+
+  return { width: MAP.width, height, orgCenterY, servers };
+}

--- a/tests/resource-map-layout.test.ts
+++ b/tests/resource-map-layout.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   MAP,
   ORG_NAME_MAX_CHARS,
+  SERVER_CAPTION_MAX_CHARS,
   buildResourceMapLayout,
   serverCaption,
   truncateLabel,
@@ -177,32 +178,99 @@ describe("buildResourceMapLayout", () => {
     expect(long.width).toBeGreaterThan(short.width);
     expect(MAP.leaf.x + long.width).toBeLessThanOrEqual(MAP.width - 16);
   });
+
+  it("keeps each leaf's full label beside the truncated one, so a cut chip can be titled", () => {
+    const longSubject =
+      "an-extremely-long-subject-slug-that-keeps-going-and-going";
+    const layout = buildResourceMapLayout(
+      response([server("a")], {
+        bible: [item("a", "bible", "r1")],
+        [longSubject]: [item("a", longSubject, "r2")],
+      })
+    );
+
+    const short = layout.servers[0]!.leaves[0]!;
+    const long = layout.servers[0]!.leaves[1]!;
+    // Untruncated chips must compare equal, or every chip would draw a title.
+    expect(short.label).toBe(short.fullLabel);
+    expect(long.label).not.toBe(long.fullLabel);
+    expect(long.fullLabel).toBe(
+      "An Extremely Long Subject Slug That Keeps Going And Going"
+    );
+    expect(long.fullLabel.startsWith(long.label.slice(0, -1))).toBe(true);
+  });
 });
 
 describe("serverCaption", () => {
   it("counts what a healthy server listed", () => {
-    expect(serverCaption("ok", 3, "en")).toBe("3 resources");
-    expect(serverCaption("ok", 1, "en")).toBe("1 resource");
+    expect(serverCaption("ok", 3, "en").full).toBe("3 resources");
+    expect(serverCaption("ok", 1, "en").full).toBe("1 resource");
   });
 
   it("names the language when a healthy server listed nothing", () => {
-    expect(serverCaption("ok", 0, "sw")).toBe("nothing listed for “sw”");
+    expect(serverCaption("ok", 0, "sw").full).toBe("nothing listed for “sw”");
   });
 
   it("gives the reason alone when a degraded server contributed nothing", () => {
-    expect(serverCaption("unsupported", 0, "en")).toBe("no resource listing");
-    expect(serverCaption("error", 0, "en")).toBe("failed to respond");
+    expect(serverCaption("unsupported", 0, "en").full).toBe(
+      "no resource listing"
+    );
+    expect(serverCaption("error", 0, "en").full).toBe("failed to respond");
   });
 
   it("acknowledges items a degraded server did contribute, so the caption never reads as failed-and-empty", () => {
     // The map still draws those leaves and the footer still totals them —
     // a bare "failed to respond" next to two visible leaves is a lie.
-    expect(serverCaption("error", 2, "en")).toBe(
+    expect(serverCaption("error", 2, "en").full).toBe(
       "failed to respond — 2 resources shown"
     );
-    expect(serverCaption("unsupported", 1, "en")).toBe(
+    expect(serverCaption("unsupported", 1, "en").full).toBe(
       "no resource listing — 1 resource shown"
     );
+  });
+});
+
+describe("serverCaption fits the fixed-width server node", () => {
+  it("leaves a caption that already fits alone", () => {
+    const caption = serverCaption("ok", 12, "en");
+    expect(caption.full).toBe("12 resources");
+    expect(caption.full.length).toBeLessThanOrEqual(SERVER_CAPTION_MAX_CHARS);
+    // Equal forms are what tells the renderer not to draw a <title>.
+    expect(caption.display).toBe(caption.full);
+  });
+
+  it("bounds the degraded-with-count caption and keeps the full text", () => {
+    const caption = serverCaption("error", 128, "en");
+    expect(caption.full).toBe("failed to respond — 128 resources shown");
+    expect(caption.full.length).toBeGreaterThan(SERVER_CAPTION_MAX_CHARS);
+    expect(caption.display).toHaveLength(SERVER_CAPTION_MAX_CHARS);
+    expect(caption.display.endsWith("…")).toBe(true);
+    // The drawn form is a genuine prefix of the full one, ellipsis aside.
+    expect(caption.full.startsWith(caption.display.slice(0, -1))).toBe(true);
+  });
+
+  it("cuts a free-text language tag inside the quotes, not the sentence around it", () => {
+    // The Resources filter takes a free IETF code, so arbitrary user text is
+    // interpolated straight into this caption.
+    const tag = "zh-Hant-TW-x-a-very-long-private-use-tag";
+    const caption = serverCaption("ok", 0, tag);
+    expect(caption.full).toBe(`nothing listed for “${tag}”`);
+    expect(caption.display.length).toBeLessThanOrEqual(
+      SERVER_CAPTION_MAX_CHARS
+    );
+    // What happened survives, and so does the closing quote — a tail cut of
+    // the whole caption would have eaten both.
+    expect(caption.display.startsWith("nothing listed for “")).toBe(true);
+    expect(caption.display.endsWith("”")).toBe(true);
+    expect(caption.display).toContain("…");
+  });
+
+  it("never lets a pathological tag outgrow the budget", () => {
+    const caption = serverCaption("ok", 0, "x".repeat(500));
+    expect(caption.display.length).toBeLessThanOrEqual(
+      SERVER_CAPTION_MAX_CHARS
+    );
+    expect(caption.full).toHaveLength("nothing listed for “”".length + 500);
   });
 });
 

--- a/tests/resource-map-layout.test.ts
+++ b/tests/resource-map-layout.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   MAP,
+  ORG_NAME_MAX_CHARS,
   buildResourceMapLayout,
+  serverCaption,
   truncateLabel,
 } from "../src/lib/resource-map-layout";
 import type {
@@ -26,9 +28,10 @@ function item(serverId: string, subject: string, name: string): ResourceItem {
 
 function response(
   servers: ResourceServerReport[],
-  resources: Record<string, ResourceItem[]> = {}
+  resources: Record<string, ResourceItem[]> = {},
+  org = "uw"
 ): AggregatedResourcesResponse {
-  return { org: "uw", language: "en", servers, resources };
+  return { org, language: "en", servers, resources };
 }
 
 describe("truncateLabel", () => {
@@ -173,5 +176,48 @@ describe("buildResourceMapLayout", () => {
     expect(long.label.length).toBeLessThanOrEqual(30);
     expect(long.width).toBeGreaterThan(short.width);
     expect(MAP.leaf.x + long.width).toBeLessThanOrEqual(MAP.width - 16);
+  });
+});
+
+describe("serverCaption", () => {
+  it("counts what a healthy server listed", () => {
+    expect(serverCaption("ok", 3, "en")).toBe("3 resources");
+    expect(serverCaption("ok", 1, "en")).toBe("1 resource");
+  });
+
+  it("names the language when a healthy server listed nothing", () => {
+    expect(serverCaption("ok", 0, "sw")).toBe("nothing listed for “sw”");
+  });
+
+  it("gives the reason alone when a degraded server contributed nothing", () => {
+    expect(serverCaption("unsupported", 0, "en")).toBe("no resource listing");
+    expect(serverCaption("error", 0, "en")).toBe("failed to respond");
+  });
+
+  it("acknowledges items a degraded server did contribute, so the caption never reads as failed-and-empty", () => {
+    // The map still draws those leaves and the footer still totals them —
+    // a bare "failed to respond" next to two visible leaves is a lie.
+    expect(serverCaption("error", 2, "en")).toBe(
+      "failed to respond — 2 resources shown"
+    );
+    expect(serverCaption("unsupported", 1, "en")).toBe(
+      "no resource listing — 1 resource shown"
+    );
+  });
+});
+
+describe("org node label", () => {
+  it("passes a short org name through untouched", () => {
+    const layout = buildResourceMapLayout(response([server("a")]));
+    expect(layout.orgName).toBe("uw");
+    expect(layout.orgDisplayName).toBe("uw");
+  });
+
+  it("truncates a long org slug to the fixed-width node's character budget", () => {
+    const org = "an-extremely-long-organization-slug";
+    const layout = buildResourceMapLayout(response([server("a")], {}, org));
+    expect(layout.orgName).toBe(org);
+    expect(layout.orgDisplayName).toHaveLength(ORG_NAME_MAX_CHARS);
+    expect(layout.orgDisplayName.endsWith("…")).toBe(true);
   });
 });

--- a/tests/resource-map-layout.test.ts
+++ b/tests/resource-map-layout.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAP,
+  buildResourceMapLayout,
+  truncateLabel,
+} from "../src/lib/resource-map-layout";
+import type {
+  AggregatedResourcesResponse,
+  ResourceItem,
+  ResourceServerReport,
+  ResourceServerStatus,
+} from "../src/types/resources";
+
+function server(
+  serverId: string,
+  status: ResourceServerStatus = "ok",
+  error?: string
+): ResourceServerReport {
+  return { serverId, serverName: `${serverId} server`, status, error };
+}
+
+function item(serverId: string, subject: string, name: string): ResourceItem {
+  return { serverId, subject, name };
+}
+
+function response(
+  servers: ResourceServerReport[],
+  resources: Record<string, ResourceItem[]> = {}
+): AggregatedResourcesResponse {
+  return { org: "uw", language: "en", servers, resources };
+}
+
+describe("truncateLabel", () => {
+  it("returns strings at or under the limit unchanged", () => {
+    expect(truncateLabel("short", 10)).toBe("short");
+    expect(truncateLabel("exactly-10", 10)).toBe("exactly-10");
+  });
+
+  it("truncates over-limit strings to max chars ending in an ellipsis", () => {
+    const out = truncateLabel("a very long resource subject label", 12);
+    expect(out).toHaveLength(12);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("trims trailing whitespace before the ellipsis", () => {
+    // Slicing "abcd efgh" at 6 chars lands on the space — "abcd …" would
+    // read as a typo.
+    expect(truncateLabel("abcd efgh", 6)).toBe("abcd…");
+  });
+});
+
+describe("buildResourceMapLayout", () => {
+  it("lays out an org-only map when no servers are connected", () => {
+    const layout = buildResourceMapLayout(response([]));
+    expect(layout.servers).toEqual([]);
+    expect(layout.orgCenterY).toBe(MAP.padY + MAP.org.height / 2);
+    expect(layout.height).toBe(MAP.padY * 2 + MAP.org.height);
+  });
+
+  it("rolls up per-server subject counts in response key order, omitting zero-count subjects", () => {
+    const layout = buildResourceMapLayout(
+      response([server("a"), server("b")], {
+        bible: [item("a", "bible", "ult"), item("b", "bible", "niv")],
+        "study-notes": [
+          item("a", "study-notes", "sn1"),
+          item("a", "study-notes", "sn2"),
+        ],
+        dictionary: [item("b", "dictionary", "tw")],
+      })
+    );
+
+    const a = layout.servers[0]!;
+    const b = layout.servers[1]!;
+    expect(a.leaves.map((l) => [l.slug, l.count])).toEqual([
+      ["bible", 1],
+      ["study-notes", 2],
+    ]);
+    expect(b.leaves.map((l) => [l.slug, l.count])).toEqual([
+      ["bible", 1],
+      ["dictionary", 1],
+    ]);
+    expect(a.resourceCount).toBe(3);
+    expect(b.resourceCount).toBe(2);
+  });
+
+  it("keeps leaves data-driven: attributed items surface even on a non-ok server, none are invented for unsupported ones", () => {
+    const layout = buildResourceMapLayout(
+      response(
+        [server("fia", "unsupported"), server("flaky", "error", "boom")],
+        { bible: [item("flaky", "bible", "cached")] }
+      )
+    );
+
+    const fia = layout.servers[0]!;
+    const flaky = layout.servers[1]!;
+    expect(fia.leaves).toEqual([]);
+    expect(fia.resourceCount).toBe(0);
+    expect(flaky.leaves.map((l) => l.slug)).toEqual(["bible"]);
+    expect(flaky.error).toBe("boom");
+  });
+
+  it("sizes a server block to its leaves span when leaves outgrow the node", () => {
+    const layout = buildResourceMapLayout(
+      response([server("a")], {
+        bible: [item("a", "bible", "r1")],
+        dictionary: [item("a", "dictionary", "r2")],
+        media: [item("a", "media", "r3")],
+      })
+    );
+
+    const a = layout.servers[0]!;
+    const leavesSpan = 3 * MAP.leaf.height + 2 * MAP.leaf.gap;
+    expect(leavesSpan).toBeGreaterThan(MAP.server.height);
+    expect(a.height).toBe(leavesSpan);
+    expect(a.centerY).toBe(a.top + a.height / 2);
+    // Leaves are vertically centered on the block: first leaf top == block top.
+    expect(a.leaves[0]!.y).toBe(a.top);
+    expect(a.leaves[2]!.y + MAP.leaf.height).toBe(a.top + a.height);
+  });
+
+  it("keeps a leafless server block at node height", () => {
+    const layout = buildResourceMapLayout(response([server("a")]));
+    expect(layout.servers[0]!.height).toBe(MAP.server.height);
+  });
+
+  it("stacks server blocks in input order with the block gap", () => {
+    const layout = buildResourceMapLayout(
+      response([server("z"), server("a"), server("m")])
+    );
+
+    expect(layout.servers.map((s) => s.serverId)).toEqual(["z", "a", "m"]);
+    const first = layout.servers[0]!;
+    const second = layout.servers[1]!;
+    const third = layout.servers[2]!;
+    expect(second.top).toBe(first.top + first.height + MAP.blockGap);
+    expect(third.top).toBe(second.top + second.height + MAP.blockGap);
+    expect(layout.height).toBe(third.top + third.height + MAP.padY);
+  });
+
+  it("centers the org node between the first and last server centers", () => {
+    const layout = buildResourceMapLayout(
+      response([server("a"), server("b"), server("c")])
+    );
+    const { servers } = layout;
+    expect(layout.orgCenterY).toBe(
+      (servers[0]!.centerY + servers[2]!.centerY) / 2
+    );
+  });
+
+  it("grows the viewport when the org node extends past a short server column", () => {
+    // One leafless server: node height (54) is shorter than the org node
+    // (58), so the org's bottom edge, not the server block, sets the height.
+    const layout = buildResourceMapLayout(response([server("a")]));
+    expect(layout.height).toBe(
+      layout.orgCenterY + MAP.org.height / 2 + MAP.padY
+    );
+  });
+
+  it("truncates leaf labels and widens chips with label length, within the viewport", () => {
+    const longSubject =
+      "an-extremely-long-subject-slug-that-keeps-going-and-going";
+    const layout = buildResourceMapLayout(
+      response([server("a")], {
+        bible: [item("a", "bible", "r1")],
+        [longSubject]: [item("a", longSubject, "r2")],
+      })
+    );
+
+    const short = layout.servers[0]!.leaves[0]!;
+    const long = layout.servers[0]!.leaves[1]!;
+    expect(long.label.endsWith("…")).toBe(true);
+    expect(long.label.length).toBeLessThanOrEqual(30);
+    expect(long.width).toBeGreaterThan(short.width);
+    expect(MAP.leaf.x + long.width).toBeLessThanOrEqual(MAP.width - 16);
+  });
+});


### PR DESCRIPTION
## What

Adds a **Map** view to the Resources page: an auto-generated topology diagram of the org's MCP-server surface — org → servers → subject leaves — rendered from the same aggregated resources response the existing list view consumes (worker#257 endpoint, integrated in #230). A List/Map toggle in the page toolbar switches between the two projections; no new fetching, so the map is current by construction.

Closes #261

## How

- `src/lib/resource-map-layout.ts` — pure, DOM-free layout engine: rolls up per-server subject counts (attribution via `serverId`, so the map never claims resources a server didn't list), sizes server blocks to their leaves, stacks blocks, and centers the org node. Exported `MAP` constants + `buildResourceMapLayout` are the whole geometry contract.
- `src/components/resource-server-map.tsx` — thin SVG projection of that layout. Branch strokes encode link health with the same three-way honesty as the #230 status chips: solid amber = listing resources, dashed muted = no listing tool (`unsupported`, e.g. FIA), dashed destructive = failed to respond (`error`, with the error text as a hover title). A legend row spells out the encoding; the SVG carries a `role="img"` aria-label summarizing server counts by status.
- `src/app/pages/resources.tsx` — List/Map segmented toggle. The map renders even when no server is listable (that state is exactly what it visualizes); the "no servers connected" empty state still short-circuits both views.

No diagram library was added — the topology is small and fixed-shape, so hand-rolled elbows keep the bundle flat and the output deterministic. All theme colors come from existing CSS variables (`--brand-resources`, `--destructive`, etc.), so light/dark both work.

All upstream strings (server names, error messages, subject slugs) render as React-escaped SVG text nodes — no HTML injection surface, no links from relayed data.

## Testing

- `npm run typecheck` — pass
- `npm run lint` — pass (zero warnings)
- `npm test` — 628 tests in 27 files, all pass; includes 11 new tests in `tests/resource-map-layout.test.ts` covering empty-org layout, per-server subject rollup and ordering, data-driven leaves on non-ok servers, block sizing/stacking, org-node centering, viewport growth, and label truncation