### PR TITLE
feat(#249): language admin trump + org-wide draft visibility (option 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ worker/
 ├── baruch.ts           → Baruch SSE streaming, initiation & history proxy
 ├── config.ts           → Modes, languages & prompt-override proxy + verb-perms authorization gate
 ├── admin.ts            → Admin user CRUD (tri-mode auth: secret / super admin / org admin)
-├── rights-migration.ts → Per-user rights migration for rename, plus clone/bootstrap auto-grants
+├── rights-migration.ts → Per-user rights migration for rename, plus the mode clone auto-grant
 ├── crypto.ts           → PBKDF2 hashing, constant-time compare
 ├── helpers.ts          → Response helpers, same-origin guard, KV listing, org-shape guard
 └── types.ts            → StoredUser / SessionData shapes
@@ -54,6 +54,7 @@ worker/
 Shared page features:
 
 - **Markdown editor** (Modes + Languages): CodeMirror with heading TOC, debounced autosave (800 ms), manual Save flush, unsaved-changes guards on navigation / selection switch / org-context switch, and read-only rendering when the user lacks edit rights on the selected row.
+- **Language visibility** (#249): the Languages dropdown lists every draft in the org for anyone who can reach the page — rows the user holds no edit right on open read-only. Modes still list only the rows a non-admin shepherd holds a verb on.
 - **Org context selector** (Modes, Languages, Prompt Overrides): super admins can switch the pages to any org that has at least one user; the choice persists across the three pages and is sent as `?org=` to the BFF.
 - **Test chat panel**: slide-out BT Servant chat (SSE) available on every page. Uses a synthetic per-session test user ID so test conversations never touch the caller's own history, with a mode picker that pins the test user's active mode.
 - **User menu**: change password, light/dark theme toggle, sign out, app version.
@@ -62,7 +63,7 @@ Shared page features:
 
 The engine trusts the portal with a single shared API token, so this worker's BFF is the enforcement point for per-user authorization.
 
-- **Org admin** (`isAdmin`): manages users in their own org; can edit any _mode_ in their org (admin trump); can create the _first_ language draft in their org (bootstrap carve-out, with auto-grant of both verbs to the creator) — but existing language documents remain per-row gated even for admins.
+- **Org admin** (`isAdmin`): manages users in their own org; can read, create, edit, publish and delete any _mode_ or _language_ in their org (admin trump — per-row verb rights scope non-admin shepherds only).
 - **Super admin** (`isSuperAdmin`): cross-org powers — sees/manages users in every org, moves users between orgs, grants/revokes `isSuperAdmin`, and bypasses per-row gates when operating on _another_ org's config (their home-org rights stay enforced at home).
 - **Verb rights** (per user, per resource): `language_edit_rights`, `language_publish_rights`, `mode_edit_rights`, `mode_publish_rights` — each either `"*"` or an array of slugs, assigned via a four-selector matrix in the user dialogs. Edit gates document/label/description changes; publish gates the published flag; delete requires both.
 - **Legacy fallback**: the pre-verb-perms `language_rights` field is lazily migrated at session time — it applies only when _both_ language verb fields are unset (setting one verb makes the unset partner an explicit deny, not legacy-full). Modes have no legacy fallback: a non-admin with both mode fields unset has no mode access.
@@ -118,23 +119,23 @@ Worker configuration (`wrangler.jsonc`): `ENGINE_BASE_URL` / `BARUCH_BASE_URL` v
 
 The Cloudflare Worker acts as a BFF, authenticating requests (session cookie + `X-Requested-With` same-origin guard) and forwarding to the engine or Baruch with the shared API keys.
 
-| Route                             | Auth                                                          | Description                                            |
-| --------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------ |
-| `/api/auth/*`                     | None (login) / session                                        | Login, logout, session check (`/me`), change password  |
-| `/api/admin/users[/:email]`       | `X-Admin-Secret` OR admin/super-admin session                 | User CRUD with org scoping and self-lockout guards     |
-| `/api/chat/stream`                | Session                                                       | BT Servant SSE streaming                               |
-| `/api/chat/history`               | Session                                                       | GET/DELETE chat history                                |
-| `/api/chat/memory`                | Session                                                       | DELETE user memory                                     |
-| `/api/baruch/*`                   | Session                                                       | Baruch SSE streaming, initiation, history (GET/DELETE) |
-| `/api/config/prompt-overrides`    | Session (writes: admin)                                       | Org prompt-override slots                              |
-| `/api/config/modes[/:name]`       | Session (writes: verb-perms, admin trump)                     | List/read/write/delete modes                           |
-| `/api/config/modes/:name/_rename` | Admin or edit-on-source                                       | Rename + per-user rights migration                     |
-| `/api/config/modes/:name/_clone`  | Admin or edit-on-source                                       | Clone + cloner auto-grant                              |
-| `/api/config/modes/:name/_retire` | Admin, or edit+publish-on-source + edit-on-target             | Retire-and-forward                                     |
-| `/api/config/languages[/:name]`   | Session (writes: verb-perms, no admin trump on existing rows) | List/read/write/delete language documents              |
-| `/api/config/language-scaffold`   | Session (read-only)                                           | Org scaffold template for new language drafts          |
-| `/api/config/user-mode/:userId`   | Session                                                       | PUT/DELETE the test-chat user's active mode            |
-| `/api/config/user-memory/:userId` | Session                                                       | GET/DELETE a user's persistent memory                  |
+| Route                             | Auth                                              | Description                                            |
+| --------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
+| `/api/auth/*`                     | None (login) / session                            | Login, logout, session check (`/me`), change password  |
+| `/api/admin/users[/:email]`       | `X-Admin-Secret` OR admin/super-admin session     | User CRUD with org scoping and self-lockout guards     |
+| `/api/chat/stream`                | Session                                           | BT Servant SSE streaming                               |
+| `/api/chat/history`               | Session                                           | GET/DELETE chat history                                |
+| `/api/chat/memory`                | Session                                           | DELETE user memory                                     |
+| `/api/baruch/*`                   | Session                                           | Baruch SSE streaming, initiation, history (GET/DELETE) |
+| `/api/config/prompt-overrides`    | Session (writes: admin)                           | Org prompt-override slots                              |
+| `/api/config/modes[/:name]`       | Session (writes: verb-perms, admin trump)         | List/read/write/delete modes                           |
+| `/api/config/modes/:name/_rename` | Admin or edit-on-source                           | Rename + per-user rights migration                     |
+| `/api/config/modes/:name/_clone`  | Admin or edit-on-source                           | Clone + cloner auto-grant                              |
+| `/api/config/modes/:name/_retire` | Admin, or edit+publish-on-source + edit-on-target | Retire-and-forward                                     |
+| `/api/config/languages[/:name]`   | Session (writes: verb-perms, admin trump)         | List/read/write/delete language documents              |
+| `/api/config/language-scaffold`   | Session (read-only)                               | Org scaffold template for new language drafts          |
+| `/api/config/user-mode/:userId`   | Session                                           | PUT/DELETE the test-chat user's active mode            |
+| `/api/config/user-memory/:userId` | Session                                           | GET/DELETE a user's persistent memory                  |
 
 Notes:
 

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -8,10 +8,8 @@ import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
-  mirrorBootstrapGrant,
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
-  filterByAnyRights,
   hasAdminPowers,
   hasAnyLanguageAccess,
   hasAnyRights,
@@ -51,7 +49,6 @@ const AUTO_SAVE_DEBOUNCE_MS = 800;
 
 export function LanguagesPage() {
   const user = useAuthStore((s) => s.user);
-  const setUser = useAuthStore((s) => s.setUser);
   const selectedLanguage = useUiStore((s) => s.selectedLanguage);
   const setSelectedLanguage = useUiStore((s) => s.setSelectedLanguage);
   const showDrafts = useUiStore((s) => s.showDrafts);
@@ -59,36 +56,33 @@ export function LanguagesPage() {
   const contextOrg = useUiStore((s) => s.contextOrg);
   const setContextOrg = useUiStore((s) => s.setContextOrg);
 
-  // Cross-org reuses the worker's PR A carve-out: super-admins bypass
-  // per-row rights when editing a different org's languages, because
-  // shepherd rights are scoped to the user's home org and don't
-  // translate to a foreign namespace. Treat both verb rights as "*" in
-  // that case so the same filter/gate logic works without a separate
-  // cross-org branch.
+  // Admins and cross-org super-admins bypass per-row rights, so treat
+  // both verb rights as "*" for them and let one set of gates serve
+  // every caller (mirrors modes.tsx):
+  //   - admin (#249): the worker's gate trumps per-row language rights
+  //     for anyone with admin powers — rights scope non-admin shepherds,
+  //     while admins administer the whole org's language catalog.
+  //   - cross-org: shepherd rights are scoped to the user's home org and
+  //     don't translate to a foreign namespace (worker PR A carve-out).
   //
-  // #181: each verb-perm falls back to legacy `language_rights` for pre-
-  // PR-1 users, mirroring the worker's rightsFor language logic.
+  // #181: for non-admin same-org users each verb-perm applies the
+  // worker's partner-aware rule (effective* helpers), so a user with
+  // `language_rights:"*"` plus only an explicit edit grant sees
+  // publish=[] in the UI — matching what the worker sees — not
+  // publish="*" via a naive `?? language_rights` fallback (Frank rd-2 P1).
   const isCrossOrg = contextOrg !== null;
-  // Worker-effective verb-perms — applies the partner-aware rule so a
-  // user with `language_rights:"*"` plus only an explicit edit grant
-  // sees publish=[] in the UI (matching what the worker sees), not
-  // publish="*" via the naive `?? language_rights` fallback (Frank
-  // rd-2 P1).
-  const editRights = isCrossOrg ? "*" : effectiveLanguageEditRights(user);
-  const publishRights = isCrossOrg ? "*" : effectiveLanguagePublishRights(user);
-  // #247 — admins always reach the page and the Create affordance: the
-  // worker allows a same-org admin to CREATE a draft that doesn't exist
-  // yet (and auto-grants them both verbs on it), which is the only way
-  // a fresh org's first draft can come into existence when every user
-  // holds explicit (non-"*") rights.
   const isAdmin = hasAdminPowers(user);
+  const editRights =
+    isAdmin || isCrossOrg ? "*" : effectiveLanguageEditRights(user);
+  const publishRights =
+    isAdmin || isCrossOrg ? "*" : effectiveLanguagePublishRights(user);
+  // Zero-rights non-admins still see nothing: #249 scopes org-wide
+  // visibility to users who hold at least one verb on at least one row.
   const hasAccess = isCrossOrg || isAdmin || hasAnyLanguageAccess(user);
 
-  // Per-row capability gates passed to LanguageSelector. Languages
-  // don't carry an admin trump for EXISTING rows (PR #185 enforced
-  // per-row even for super-admins), so the selected-row gates are pure
-  // verb-perm reads; only creation (#247 above) consults isAdmin.
-  const canCreate = hasAnyRights(editRights) || isAdmin;
+  // Per-row capability gates passed to LanguageSelector. Admins reach
+  // every branch via the "*" short-circuit above.
+  const canCreate = hasAnyRights(editRights);
   const canEditSelected =
     selectedLanguage !== null && hasRights(editRights, selectedLanguage);
   const canPublishSelected =
@@ -101,24 +95,6 @@ export function LanguagesPage() {
   const saveLanguage = useSaveLanguage(contextOrg);
   const deleteLanguage = useDeleteLanguage(contextOrg);
   const scaffoldQuery = useLanguageScaffold(contextOrg);
-
-  // Filter the language list to those the user has any verb on. Union
-  // semantic: an edit-only or publish-only grant still surfaces the
-  // language (the worker further gates the specific action). Engine
-  // #207 will eventually filter server-side too, but until then this
-  // is the primary gate against showing forbidden entries in the
-  // dropdown.
-  const authorizedLanguagesData = useMemo(() => {
-    if (!languagesQuery.data) return languagesQuery.data;
-    return {
-      ...languagesQuery.data,
-      languages: filterByAnyRights(
-        languagesQuery.data.languages,
-        editRights,
-        publishRights
-      ),
-    };
-  }, [languagesQuery.data, editRights, publishRights]);
 
   // Every keystroke re-renders this page (the editor draft lives in
   // component state), so the raw-name list for the create-dialog
@@ -318,32 +294,6 @@ export function LanguagesPage() {
     setPendingContextOrg(null);
   }, [pendingContextOrg, setContextOrg]);
 
-  // If the persisted selection is no longer authorized (e.g. an admin
-  // revoked rights mid-session, or rights changed since last login), drop
-  // it so we don't render an editor for a language the user can't read.
-  // Skip the gate under cross-org context: `setContextOrg` already cleared
-  // `selectedLanguage` to null when the user switched orgs, and any new
-  // selection in cross-org mode is gated server-side via the worker's
-  // super-admin carve-out (PR A) rather than by per-row rights. Union
-  // semantic: at least one of edit / publish on the row is enough to
-  // keep the selection — the worker further gates the specific verb.
-  useEffect(() => {
-    if (selectedLanguage === null) return;
-    if (isCrossOrg) return;
-    if (
-      hasRights(editRights, selectedLanguage) ||
-      hasRights(publishRights, selectedLanguage)
-    )
-      return;
-    setSelectedLanguage(null);
-  }, [
-    isCrossOrg,
-    editRights,
-    publishRights,
-    selectedLanguage,
-    setSelectedLanguage,
-  ]);
-
   const confirmSwitch = useCallback(() => {
     setSelectedLanguage(pendingSwitch);
     setPendingSwitch(null);
@@ -369,31 +319,16 @@ export function LanguagesPage() {
           },
         },
         {
-          onSuccess: (data) => {
+          onSuccess: () => {
+            // #249 — no creator auto-grant to mirror any more: creation
+            // is an ordinary admin write under the worker's admin trump,
+            // and admins read every row through the "*" short-circuit.
             setSelectedLanguage(name);
-            // #247 — when the worker's bootstrap carve-out created this
-            // draft, it auto-granted the creator both verbs server-side,
-            // but the session user in the auth store still carries the
-            // pre-grant rights, and the page's list filter + edit gates
-            // read from it. Mirror the grant locally, keyed STRICTLY on
-            // the worker's X-Bootstrap-Grant signal — an ordinary create
-            // performs no server grant, and inferring the carve-out from
-            // the local rights snapshot broke under session skew and
-            // published:true shapes (#256 rds 2–3). Local mirror rather
-            // than a /me refetch because KV read-after-write isn't
-            // guaranteed: an immediate refetch could re-store the STALE
-            // pre-grant record. Read the store at callback time, not
-            // the render snapshot — a slow create must not clobber
-            // store writes that landed mid-flight (#256 rd-3).
-            if (data.bootstrapGranted && !isCrossOrg) {
-              const current = useAuthStore.getState().user;
-              if (current) setUser(mirrorBootstrapGrant(current, name));
-            }
           },
         }
       );
     },
-    [saveLanguage, scaffoldQuery.data, setSelectedLanguage, setUser, isCrossOrg]
+    [saveLanguage, scaffoldQuery.data, setSelectedLanguage]
   );
 
   const handleSetPublished = useCallback(
@@ -463,12 +398,16 @@ export function LanguagesPage() {
     return null;
   }, [saveError, deleteError]);
 
+  // #249 — with the dropdown listing every draft in the org, opening a
+  // row you can't edit is an ordinary state rather than an error, so
+  // label it instead of showing a save status that will never change.
   const saveStatus = useMemo(() => {
+    if (hasSelection && !canEditSelected) return "Read-only";
     if (isSaving) return "Saving…";
     if (isDirty) return "Unsaved changes";
     if (hasSelection) return "Saved";
     return "";
-  }, [hasSelection, isDirty, isSaving]);
+  }, [canEditSelected, hasSelection, isDirty, isSaving]);
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -482,8 +421,15 @@ export function LanguagesPage() {
         <div className="flex flex-wrap items-center gap-3 p-4 sm:p-6">
           <OrgContextSelector onRequestChange={handleRequestContextChange} />
           <div className="min-w-0 flex-1">
+            {/* #249 — the dropdown lists EVERY draft in the org,
+                unfiltered: a shared catalog only some users could see
+                is what made drafts look like they had vanished (#247).
+                Rows the user holds no edit right on open read-only via
+                `canEditSelected`, and the worker gates every write.
+                Deliberately wider than modes, which still filter the
+                dropdown for non-admin shepherds. */}
             <LanguageSelector
-              languagesData={authorizedLanguagesData}
+              languagesData={languagesQuery.data}
               selectedLanguage={selectedLanguage}
               onSelectLanguage={handleSelectLanguage}
               onCreateLanguage={handleCreateLanguage}
@@ -578,9 +524,7 @@ export function LanguagesPage() {
         ) : !hasSelection ? (
           <EmptyState
             canCreate={canCreate}
-            hasAny={(authorizedLanguagesData?.languages.length ?? 0) > 0}
-            hasHidden={takenNames.length > 0}
-            isAdmin={isAdmin}
+            hasAny={(languagesQuery.data?.languages.length ?? 0) > 0}
           />
         ) : (
           <>
@@ -695,39 +639,21 @@ export function LanguagesPage() {
 
 interface EmptyStateProps {
   canCreate: boolean;
-  /** The user's rights-filtered list has entries. */
+  /** The org's list has entries. #249 dropped the rights filter, so an
+      empty list now means the org genuinely has no drafts — the old
+      "drafts exist but are hidden from you" copy is unreachable. */
   hasAny: boolean;
-  /** The org's RAW list has entries (visible to this user or not).
-      #247: an admin with no per-row rights sees an empty filtered list
-      even when drafts exist — telling them "No languages yet" would
-      misrepresent the org and invite name collisions. */
-  hasHidden: boolean;
-  /** Only admins may create a NEW name in an org whose drafts are all
-      hidden from them (the worker's carve-out is admin-only) — a
-      non-admin whose rights are all inert entries would 403 on any
-      new slug, so the copy must not invite them to create (#256 rd-2
-      F2). */
-  isAdmin: boolean;
 }
 
-function EmptyState({
-  canCreate,
-  hasAny,
-  hasHidden,
-  isAdmin,
-}: EmptyStateProps) {
+function EmptyState({ canCreate, hasAny }: EmptyStateProps) {
   return (
     <div className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
       <p className="text-sm">
         {hasAny
           ? "Pick a language above to start editing."
-          : hasHidden
-            ? isAdmin
-              ? "This org has languages, but none you have access to. Create a new draft, or ask a shepherd for access to an existing one."
-              : "This org has languages, but none you have access to. Ask a shepherd or admin for access."
-            : canCreate
-              ? "No languages yet. Create one to get started."
-              : "No languages are available for your account."}
+          : canCreate
+            ? "No languages yet. Create one to get started."
+            : "No languages are available for your account."}
       </p>
     </div>
   );

--- a/src/components/activity-bar.tsx
+++ b/src/components/activity-bar.tsx
@@ -41,11 +41,12 @@ export function ActivityBar() {
   // undefined-undefined means "no access" for non-admins), which is
   // why the Modes entry combines it with the admin trump.
   //
-  // #247 — admins get the Languages entry regardless of per-row rights:
-  // the worker lets a same-org admin CREATE drafts that don't exist yet
-  // (breaking the no-rights-without-drafts bootstrap deadlock), so the
-  // entry point must be reachable. Existing drafts remain per-row-gated
-  // on the page and in the worker (PR #185 — no admin trump there).
+  // #249 — admins get the Languages entry regardless of per-row rights:
+  // the worker's gate trumps per-row language rights for admins (mode
+  // parity), so they can read, create, edit, publish and delete every
+  // draft in the org. Non-admins still need at least one verb on at
+  // least one row; they then see the whole org catalog, read-only where
+  // they hold no edit right.
   const canAccessLanguages = isAdmin || hasAnyLanguageAccess(user);
   const canEditModes = isAdmin || hasAnyModeAccess(user);
 

--- a/src/lib/language-bootstrap-gate.ts
+++ b/src/lib/language-bootstrap-gate.ts
@@ -48,11 +48,11 @@ interface Args extends CrossOrgArgs {
 // `targetOrg`. Mirrors the Languages page's `canCreate` gate:
 //   - Cross-org super-admin: bypasses per-row rights via worker's PR A
 //     carve-out (#166).
-//   - Same-org admins: always — the worker's bootstrap carve-out lets
-//     them create drafts that don't exist yet (and auto-grants both
-//     verbs). Added with the carve-out itself (#256 rd-2 F4: this gate
-//     had drifted from the page's canCreate, hiding the empty-drafts
-//     CTA from exactly the zero-rights-admin population #247 unblocks).
+//   - Same-org admins: always — the worker's admin trump (#249) covers
+//     every language write, creation included, so a zero-rights admin
+//     can still start an org's catalog. (#256 rd-2 F4: this gate had
+//     drifted from the page's canCreate, hiding the empty-drafts CTA
+//     from exactly the zero-rights-admin population #247 unblocks.)
 //   - Everyone else: needs some effective `language_edit_rights` —
 //     undefined counts as legacy full access, [] doesn't.
 export function canBootstrapLanguage({

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -66,17 +66,6 @@ export async function getLanguage(
   return data as unknown as Language;
 }
 
-// #247 — a PUT that created the language via the worker's admin
-// bootstrap carve-out comes back flagged (X-Bootstrap-Grant header):
-// the worker auto-granted the caller edit + publish on the new slug,
-// and the client mirrors that into its session user. An explicit wire
-// signal, NOT client-side inference — inferring the carve-out from the
-// local rights snapshot broke under session skew and published:true
-// shapes (#256 review rounds 2–3).
-export interface PutLanguageResult extends Language {
-  bootstrapGranted: boolean;
-}
-
 export async function putLanguage(
   name: string,
   body: {
@@ -86,7 +75,7 @@ export async function putLanguage(
   },
   signal?: AbortSignal,
   org?: string | null
-): Promise<PutLanguageResult> {
+): Promise<Language> {
   const res = await fetch(
     buildConfigUrl(`/api/config/languages/${encodeURIComponent(name)}`, org),
     {
@@ -105,15 +94,14 @@ export async function putLanguage(
     throw new Error(`Failed to save language (${res.status}): ${text}`);
   }
 
-  const bootstrapGranted = res.headers.get("X-Bootstrap-Grant") === "1";
   const data = (await res.json()) as Record<string, unknown>;
 
   // Worker wraps PUT response as { org, language, message }. Unwrap to
   // match getLanguage so callers consistently get a Language object.
   if ("language" in data && typeof data.language === "object") {
-    return { ...(data.language as Language), bootstrapGranted };
+    return data.language as Language;
   }
-  return { ...(data as unknown as Language), bootstrapGranted };
+  return data as unknown as Language;
 }
 
 export async function deleteLanguage(

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -91,38 +91,14 @@ export function effectiveLanguagePublishRights(
   return user.language_rights;
 }
 
-// #247 — mirror the worker's bootstrap auto-grant (both verbs on `slug`)
-// into the local session user. Call ONLY when the worker signalled the
-// grant (X-Bootstrap-Grant on the create response → `bootstrapGranted`
-// on PutLanguageResult) — this helper deliberately performs no
-// inference about whether a grant occurred: every inference variant
-// broke under some rights shape (session skew after a mid-session
-// grant, published:true creates; #256 review rounds 2–3).
-//
-// Materializes via the partner-aware effective* helpers so the local
-// result matches what the worker's grant wrote (worker/rights-migration
-// grantLanguageSlugToUser). Wildcard / undefined (full-access) fields
-// pass through untouched, matching the server-side grant's no-op rule.
-export function mirrorBootstrapGrant<T extends LanguageRightsCarrier>(
-  user: T,
-  slug: string
-): T {
-  const withSlug = (rights: LanguageRights | undefined) =>
-    rights === undefined || rights === "*" || rights.includes(slug)
-      ? rights
-      : [...rights, slug];
-  return {
-    ...user,
-    language_edit_rights: withSlug(effectiveLanguageEditRights(user)),
-    language_publish_rights: withSlug(effectiveLanguagePublishRights(user)),
-  };
-}
-
 // #257 — mirror the worker's clone auto-grant into the local session
 // user. Call ONLY when the worker signalled the grant (X-Bootstrap-
-// Grant on the clone response → `bootstrapGranted` on CloneModeResult)
-// — no client-side inference, same rationale as mirrorBootstrapGrant
-// above. The worker grants the verbs the cloner holds on the SOURCE
+// Grant on the clone response → `bootstrapGranted` on CloneModeResult):
+// this helper deliberately performs no inference about whether a grant
+// occurred, because every inference variant broke under some rights
+// shape (session skew after a mid-session grant, published:true
+// creates; #256 review rounds 2–3). The worker grants the verbs the
+// cloner holds on the SOURCE
 // mode (edit always; publish only if held there — #258 rd-1: an
 // unconditional both-verbs grant handed publish to edit-only
 // shepherds), so the caller passes `includePublish` computed from its

--- a/tests/config-authz.test.ts
+++ b/tests/config-authz.test.ts
@@ -3098,12 +3098,16 @@ describe("config authz — cross-org via ?org= (#166)", () => {
     );
   });
 
-  it("super-admin with ?org=<own org> + restricted language_rights → 403 (no self-referential bypass)", async () => {
-    // Frank's PR #185 review caught this: an earlier draft set
-    // `crossOrg: true` for any present ?org=, so a restricted super
-    // admin could bypass their own org's language_rights by adding a
-    // self-referential ?org=acme. `crossOrg` must reflect the resolved
-    // target vs. session.org, not merely the param's presence.
+  it("super-admin with ?org=<own org> + restricted language_rights → 200 via the #249 admin trump", async () => {
+    // Pre-#249 this was a 403: PR #185 enforced per-row language rights
+    // even for admins, so a restricted super admin was denied on a row
+    // they didn't shepherd. #249 makes admin powers trump per-row
+    // language rights (mode parity), so the same request now proxies.
+    // The self-referential-?org= discriminator this test used to pin
+    // (crossOrg must reflect resolved-target-vs-session.org, not the
+    // param's presence — Frank, PR #185) is still pinned for the
+    // population it can bite: the non-super shepherd test below
+    // ("non-super with ?org=<own org> + restricted language_rights").
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRequestWithQuery("PUT", "/api/config/languages/english", "org=acme", {
@@ -3118,15 +3122,15 @@ describe("config authz — cross-org via ?org= (#166)", () => {
       }),
       "/api/config/languages/english"
     );
-    expect(res.status).toBe(403);
-    // One fetch: the #247 bootstrap carve-out's existence probe (the
-    // caller has admin powers and zero rights on this row). The spy's
-    // 200 reads as "exists", so the carve-out declines — the proxy PUT
-    // must never fire.
+    expect(res.status).toBe(200);
+    // Exactly one fetch, and it is the proxy PUT: the trump returns
+    // before the gate parses the body or probes existence, so admin
+    // language PUTs cost one engine call, like admin mode PUTs.
     expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(
-      (fetchSpy.mock.calls[0]![1] as RequestInit | undefined)?.method
-    ).toBeUndefined();
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/languages/english"
+    );
   });
 
   it("super-admin with ?org=<own org> + matching language_rights → 200 (treated as same-org)", async () => {
@@ -3149,15 +3153,12 @@ describe("config authz — cross-org via ?org= (#166)", () => {
       "/api/config/languages/spanish"
     );
     expect(res.status).toBe(200);
-    // Two fetches under #181 verb-perms: GET current state for the diff,
-    // PUT proxy. Both target the same resource — the gate doesn't add
-    // path churn, only verb-aware authz on top.
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // One fetch since #249: the caller has admin powers, so the trump
+    // returns before the diff GET and only the proxy PUT reaches the
+    // engine. No path churn — the gate never rewrites the target.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
     expect(String(fetchSpy.mock.calls[0]![0])).toContain(
-      "/api/v1/admin/orgs/acme/languages/spanish"
-    );
-    expect((fetchSpy.mock.calls[1]![1] as RequestInit).method).toBe("PUT");
-    expect(String(fetchSpy.mock.calls[1]![0])).toContain(
       "/api/v1/admin/orgs/acme/languages/spanish"
     );
   });
@@ -3173,19 +3174,18 @@ describe("config authz — cross-org via ?org= (#166)", () => {
       env,
       makeSession({
         org: "acme",
-        isAdmin: true,
         language_rights: ["spanish"],
       }),
       "/api/config/languages/english"
     );
     expect(res.status).toBe(403);
-    // Same-org admin + zero rights on the row → the #247 carve-out
-    // probes existence once; the spy's 200 reads as "exists" so the
-    // deny stands and the proxy PUT never fires.
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(
-      (fetchSpy.mock.calls[0]![1] as RequestInit | undefined)?.method
-    ).toBeUndefined();
+    // Non-admin shepherd with zero rights on this row: the early-deny
+    // fires before the body is read, so the engine is never touched.
+    // (#249 note: this session was `isAdmin: true` until the admin
+    // trump landed, which contradicted the test's own "non-super
+    // shepherd" intent — the admin case is covered by the "language
+    // admin trump (#249)" describe below.)
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("super-admin GET languages list with ?org=other → proxies to /orgs/other/languages", async () => {
@@ -3591,194 +3591,56 @@ describe("config authz — same-org ?org= (#247)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// #247 — language bootstrap create carve-out
+// #249 — language admin trump (option 4: full mode parity)
 // ---------------------------------------------------------------------------
 //
-// A same-org admin with NO per-row language rights may CREATE a language
-// that doesn't exist yet; the worker auto-grants them both verbs on the
-// new slug before the engine call. Everything else about the PR #185
-// "no admin trump on languages" rule stays intact: existing rows,
-// DELETE, non-admins, and any ambiguous engine state all still 403.
+// Anyone with admin powers (isAdmin OR isSuperAdmin) may edit, publish,
+// delete and create ANY language in their own org, regardless of per-row
+// verb rights — exactly as they always could for modes. Per-row rights
+// keep governing non-admin shepherds, unchanged.
+//
+// This replaces the #247 bootstrap carve-out (a probe-gated,
+// creation-only exception with a creator auto-grant), which the trump
+// subsumes: creation is now an ordinary admin write, so no auto-grant,
+// no existence probe, and no X-Bootstrap-Grant signal on language PUTs.
 
-// First fetch = the gate's existence probe, second = the proxy PUT.
-function spyFetchBootstrap(
-  probe: () => Promise<Response>,
-  proxy: () => Promise<Response> = () =>
-    Promise.resolve(new Response("{}", { status: 200 }))
-) {
-  let call = 0;
-  return vi.spyOn(globalThis, "fetch").mockImplementation(() => {
-    call++;
-    return call === 1 ? probe() : proxy();
-  });
-}
-
-function makeCreateRequest(name: string): Request {
+function makeLanguagePut(name: string, body: object): Request {
   return new Request(
     `https://portal.example.test/api/config/languages/${name}`,
     {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ document: "## Identity\n", published: false }),
+      body: JSON.stringify(body),
     }
   );
 }
 
-const missing = () => Promise.resolve(new Response("", { status: 404 }));
-
-describe("#247 language bootstrap create", () => {
-  it("same-org admin with explicit empty rights + missing language → 200, creator granted both verbs", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    const fetchSpy = spyFetchBootstrap(missing);
-
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-    expect((fetchSpy.mock.calls[1]![1] as RequestInit).method).toBe("PUT");
-
-    const after = await readRightsUser("admin@acme.com");
-    expect(after.language_edit_rights).toEqual(["swahili"]);
-    expect(after.language_publish_rights).toEqual(["swahili"]);
-  });
-
-  it("grant materializes from restricted legacy language_rights", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_rights: ["en"],
-    });
-    const fetchSpy = spyFetchBootstrap(missing);
-
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_rights: ["en"],
-        // validateSession lazy-migrates legacy → verb fields on the
-        // session; mirror that here so the gate sees what it would in
-        // production.
-        language_edit_rights: ["en"],
-        language_publish_rights: ["en"],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-
-    const after = await readRightsUser("admin@acme.com");
-    expect(after.language_edit_rights).toEqual(["en", "swahili"]);
-    expect(after.language_publish_rights).toEqual(["en", "swahili"]);
-    expect(after.language_rights).toEqual(["en"]);
-  });
-
-  it("existing language → 403, no grant, no proxy (PR #185 rule intact)", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    const fetchSpy = spyFetchBootstrap(() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ language: { document: "x" } }), {
-          status: 200,
-        })
-      )
-    );
-
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(403);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const after = await readRightsUser("admin@acme.com");
-    expect(after.language_edit_rights).toEqual([]);
-  });
-
-  it("existence probe 5xx → 403 (fail closed)", async () => {
-    const fetchSpy = spyFetchBootstrap(() =>
-      Promise.resolve(new Response("", { status: 500 }))
-    );
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(403);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("existence probe throws → request fails, no grant, no proxy (rd-5 parity)", async () => {
-    // Thrown fetch propagates on the PUT path, same as for rights-
-    // holding callers — still fail-closed: nothing is mutated.
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockImplementation(() => Promise.reject(new Error("network down")));
-    await expect(
-      handleConfig(
-        makeCreateRequest("swahili"),
-        env,
-        makeSession({
-          isAdmin: true,
-          language_edit_rights: [],
-          language_publish_rights: [],
-        }),
-        "/api/config/languages/swahili"
-      )
-    ).rejects.toThrow("network down");
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("non-admin with empty rights → 403 before any engine traffic", async () => {
+describe("language admin trump (#249)", () => {
+  it("admin with explicit empty rights PUTs an EXISTING draft → 200, single proxy fetch, no probe", async () => {
+    // Pre-#249 this 403'd: PR #185 enforced per-row rights on existing
+    // rows even for admins, and the #247 carve-out was creation-only.
     const fetchSpy = spyFetch();
     const res = await handleConfig(
-      makeCreateRequest("swahili"),
+      makeLanguagePut("swahili", { document: "# Swahili\n" }),
       env,
       makeSession({
-        isAdmin: false,
+        isAdmin: true,
         language_edit_rights: [],
         language_publish_rights: [],
       }),
       "/api/config/languages/swahili"
     );
-    expect(res.status).toBe(403);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    // One fetch, and it is the PUT: the trump returns before the body
+    // parse and the diff GET, so no existence probe is issued.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/languages/swahili"
+    );
   });
 
-  it("admin DELETE without rights → 403 (carve-out is PUT-only)", async () => {
+  it("admin with explicit empty rights DELETEs a draft → 200 (the #247 carve-out was PUT-only)", async () => {
     const fetchSpy = spyFetch();
     const res = await handleConfig(
       makeRequest("DELETE", "/api/config/languages/swahili"),
@@ -3790,11 +3652,15 @@ describe("#247 language bootstrap create", () => {
       }),
       "/api/config/languages/swahili"
     );
-    expect(res.status).toBe(403);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
   });
 
-  it("engine rejects the create with 4xx → grant compensated", async () => {
+  it("admin creates a MISSING draft → 200 with no creator grant and no X-Bootstrap-Grant header", async () => {
+    // The #247 pipeline wrote both verb fields to the creator's KV
+    // record and flagged the response. Under the trump neither happens:
+    // the admin needs no rights to keep working on what they created.
     await seedRightsUser({
       email: "admin@acme.com",
       org: "acme",
@@ -3802,12 +3668,13 @@ describe("#247 language bootstrap create", () => {
       language_edit_rights: [],
       language_publish_rights: [],
     });
-    const fetchSpy = spyFetchBootstrap(missing, () =>
-      Promise.resolve(new Response("bad name", { status: 400 }))
-    );
+    const fetchSpy = spyFetch();
 
     const res = await handleConfig(
-      makeCreateRequest("swahili"),
+      makeLanguagePut("swahili", {
+        document: "## Identity\n",
+        published: false,
+      }),
       env,
       makeSession({
         email: "admin@acme.com",
@@ -3817,341 +3684,139 @@ describe("#247 language bootstrap create", () => {
       }),
       "/api/config/languages/swahili"
     );
-    expect(res.status).toBe(400);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
+
     const after = await readRightsUser("admin@acme.com");
     expect(after.language_edit_rights).toEqual([]);
     expect(after.language_publish_rights).toEqual([]);
   });
 
-  it("engine 5xx on the create → grant kept (ambiguity never contracts)", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    spyFetchBootstrap(missing, () =>
-      Promise.resolve(new Response("", { status: 500 }))
-    );
-
+  it("admin flips published on a row they hold no publish right for → 200", async () => {
+    const fetchSpy = spyFetch();
     const res = await handleConfig(
-      makeCreateRequest("swahili"),
+      makeLanguagePut("swahili", { document: "# same\n", published: true }),
       env,
       makeSession({
-        email: "admin@acme.com",
         isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
+        language_edit_rights: ["spanish"],
+        language_publish_rights: ["spanish"],
       }),
       "/api/config/languages/swahili"
     );
-    expect(res.status).toBe(500);
-    const after = await readRightsUser("admin@acme.com");
-    expect(after.language_edit_rights).toEqual(["swahili"]);
-    expect(after.language_publish_rights).toEqual(["swahili"]);
-  });
-
-  it("stored user missing at grant time → 502, engine never called", async () => {
-    // No seed for this email — grant aborts the create.
-    const fetchSpy = spyFetchBootstrap(missing);
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        email: "ghost@acme.com",
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(502);
-    // Only the existence probe fired; the proxy PUT never did.
+    expect(res.status).toBe(200);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).method).toBe("PUT");
   });
 
-  it("bootstrap create with published: true → allowed (creator holds both verbs)", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    const fetchSpy = spyFetchBootstrap(missing);
-
+  it("super-admin WITHOUT isAdmin gets the trump too (hasAdminPowers parity with modes)", async () => {
+    // A super admin who self-demoted isAdmin keeps cross-org powers and
+    // must keep config powers, or the partial-power state is
+    // inconsistent across the worker (mirrors the mode-path test).
+    const fetchSpy = spyFetch();
     const res = await handleConfig(
-      new Request("https://portal.example.test/api/config/languages/swahili", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ document: "## Identity\n", published: true }),
-      }),
+      makeLanguagePut("swahili", { document: "# Swahili\n" }),
       env,
       makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
+        isAdmin: false,
+        isSuperAdmin: true,
         language_edit_rights: [],
         language_publish_rights: [],
       }),
       "/api/config/languages/swahili"
     );
     expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("invalid JSON body on the carve-out path → 400 before any engine traffic", async () => {
-    const fetchSpy = spyFetchBootstrap(missing);
+  it("deadlock regression (#247): every user holds explicit non-'*' rights → an admin can still create the org's FIRST draft", async () => {
+    // The original #247 bug: per-row rights can only name drafts that
+    // already exist, but creating a draft required rights on it — so an
+    // org whose users all hold explicit arrays could never create draft
+    // one. The trump dissolves it without any bootstrap machinery.
+    await seedRightsUser({
+      email: "admin@acme.com",
+      org: "acme",
+      isAdmin: true,
+      language_rights: ["en"],
+      language_edit_rights: ["en"],
+      language_publish_rights: ["en"],
+    });
+    const fetchSpy = spyFetch();
+
     const res = await handleConfig(
-      new Request("https://portal.example.test/api/config/languages/swahili", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: "{not json",
+      makeLanguagePut("swahili", {
+        document: "## Identity\n",
+        published: false,
       }),
       env,
       makeSession({
+        email: "admin@acme.com",
         isAdmin: true,
+        language_rights: ["en"],
+        language_edit_rights: ["en"],
+        language_publish_rights: ["en"],
+      }),
+      "/api/config/languages/swahili"
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Rights are untouched: the admin's access comes from the trump, so
+    // nothing is written to KV on their behalf.
+    const after = await readRightsUser("admin@acme.com");
+    expect(after.language_edit_rights).toEqual(["en"]);
+    expect(after.language_publish_rights).toEqual(["en"]);
+  });
+
+  it("non-admin with explicit [] → 403 on PUT (existing row), engine never touched", async () => {
+    // The trump is admin-only; with the #247 exemption gone, the
+    // early-deny fires before the body is read.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      makeLanguagePut("swahili", { document: "# Swahili\n" }),
+      env,
+      makeSession({
         language_edit_rights: [],
         language_publish_rights: [],
       }),
       "/api/config/languages/swahili"
     );
-    expect(res.status).toBe(400);
-    // Body parse precedes the existence probe on the PUT path.
+    expect(res.status).toBe(403);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("zero-rights admin, EXISTING row, empty-diff body → 403, no proxy (#256 rd-2/rd-3 F0)", async () => {
-    // The widening both later review rounds confirmed: a body echoing
-    // the current state (or omitting fields) computes ZERO required
-    // verbs, and without the zeroRightsOnRow guard the gate returned
-    // ok — putting an engine write on a row PR #185 says a zero-rights
-    // admin must never touch. Main answered 403.
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    const currentDoc = "## Identity\n";
-    const fetchSpy = spyFetchBootstrap(() =>
-      Promise.resolve(
-        new Response(
-          JSON.stringify({
-            language: { document: currentDoc, published: false },
-          }),
-          { status: 200 }
-        )
-      )
-    );
-
+  it("non-admin with explicit [] → 403 on PUT of a MISSING name (no creation path for shepherds)", async () => {
+    const fetchSpy = spyFetch();
     const res = await handleConfig(
-      new Request("https://portal.example.test/api/config/languages/english", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        // Exactly equals the mocked current state → zero required verbs.
-        body: JSON.stringify({ document: currentDoc, published: false }),
+      makeLanguagePut("brand-new", {
+        document: "## Identity\n",
+        published: false,
       }),
       env,
       makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
+        language_edit_rights: ["spanish"],
+        language_publish_rights: ["spanish"],
       }),
-      "/api/config/languages/english"
+      "/api/config/languages/brand-new"
     );
     expect(res.status).toBe(403);
-    // Only the existence probe fired — the proxy PUT never did.
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    // And no grant was written.
-    const after = await readRightsUser("admin@acme.com");
-    expect(after.language_edit_rights).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("zero-rights admin, MISSING row, empty body {} → still a bootstrap create with grant (not an ungoverned pass-through)", async () => {
-    // An empty body against a missing row also computes zero required
-    // verbs; the zeroRightsOnRow guard must route it through the
-    // carve-out (grant + flag), never the ordinary allow.
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    const fetchSpy = spyFetchBootstrap(missing);
-
+  it("non-admin with explicit [] → 403 on DELETE, engine never touched", async () => {
+    const fetchSpy = spyFetch();
     const res = await handleConfig(
-      new Request("https://portal.example.test/api/config/languages/swahili", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: "{}",
-      }),
+      makeRequest("DELETE", "/api/config/languages/swahili"),
       env,
       makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
         language_edit_rights: [],
         language_publish_rights: [],
       }),
       "/api/config/languages/swahili"
     );
-    expect(res.status).toBe(200);
-    expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-    const after = await readRightsUser("admin@acme.com");
-    expect(after.language_edit_rights).toEqual(["swahili"]);
-    expect(after.language_publish_rights).toEqual(["swahili"]);
-  });
-
-  it("bootstrap create response carries X-Bootstrap-Grant: 1", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    spyFetchBootstrap(missing);
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(200);
-    expect(res.headers.get("X-Bootstrap-Grant")).toBe("1");
-  });
-
-  it("ORDINARY create (edit wildcard) → no header, no grant (#256 rd-3: the client mirror keys on this)", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: "*",
-      language_publish_rights: [],
-    });
-    const fetchSpy = spyFetchBootstrap(missing);
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_edit_rights: "*",
-        language_publish_rights: [],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(200);
-    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-    const after = await readRightsUser("admin@acme.com");
-    // No grant: publish stays an explicit deny.
-    expect(after.language_edit_rights).toBe("*");
-    expect(after.language_publish_rights).toEqual([]);
-  });
-
-  it("engine 4xx on a bootstrap create → no X-Bootstrap-Grant header alongside the compensation", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    spyFetchBootstrap(missing, () =>
-      Promise.resolve(new Response("bad", { status: 400 }))
-    );
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: [],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(400);
-    expect(res.headers.get("X-Bootstrap-Grant")).toBeNull();
-  });
-
-  it("mixed shape edit=[] + publish='*' → carve-out still reachable on a missing name (#256 review F2)", async () => {
-    // The wildcard on one verb bypasses the zero-rights early-deny, so
-    // the carve-out must live on the PUT diff's deny path — nested
-    // inside early-deny it never ran for this shape and the bootstrap
-    // deadlock persisted.
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_edit_rights: [],
-      language_publish_rights: "*",
-    });
-    const fetchSpy = spyFetchBootstrap(missing);
-
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_edit_rights: [],
-        language_publish_rights: "*",
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-
-    const after = await readRightsUser("admin@acme.com");
-    expect(after.language_edit_rights).toEqual(["swahili"]);
-    // The wildcard side needs no entry and must not be narrowed.
-    expect(after.language_publish_rights).toBe("*");
-  });
-
-  it("partner-deny shape (publish explicit, edit unset) → creator granted BOTH verbs, legacy never leaks (#256 review F1)", async () => {
-    await seedRightsUser({
-      email: "admin@acme.com",
-      org: "acme",
-      isAdmin: true,
-      language_rights: ["x"],
-      language_publish_rights: ["x"],
-    });
-    const fetchSpy = spyFetchBootstrap(missing);
-
-    const res = await handleConfig(
-      makeCreateRequest("swahili"),
-      env,
-      // Session mirrors lazyMigrateLanguageRights: explicit publish,
-      // partner-denied edit ([]), legacy carried alongside.
-      makeSession({
-        email: "admin@acme.com",
-        isAdmin: true,
-        language_rights: ["x"],
-        language_edit_rights: [],
-        language_publish_rights: ["x"],
-      }),
-      "/api/config/languages/swahili"
-    );
-    expect(res.status).toBe(200);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-
-    const after = await readRightsUser("admin@acme.com");
-    // Edit was a deliberate deny: it materializes as [slug] only — the
-    // legacy "x" must NOT reappear (that would durably restore revoked
-    // access; the escalation face of review F1).
-    expect(after.language_edit_rights).toEqual(["swahili"]);
-    expect(after.language_publish_rights).toEqual(["x", "swahili"]);
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -48,29 +48,7 @@ describe("putLanguage", () => {
       label: "Arabic",
       document: "## Tone\n",
       published: false,
-      // #247 — no X-Bootstrap-Grant header on the mocked response.
-      bootstrapGranted: false,
     });
-  });
-
-  it("surfaces the worker's X-Bootstrap-Grant header as bootstrapGranted", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          org: "uw",
-          language: { name: "swahili", document: "## Tone\n" },
-        }),
-        {
-          status: 200,
-          headers: {
-            "Content-Type": "application/json",
-            "X-Bootstrap-Grant": "1",
-          },
-        }
-      )
-    );
-    const result = await putLanguage("swahili", { document: "## Tone\n" });
-    expect(result.bootstrapGranted).toBe(true);
   });
 
   it("returns an already-unwrapped response unchanged (back-compat)", async () => {

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  mirrorBootstrapGrant,
   mirrorModeGrant,
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
@@ -398,100 +397,10 @@ describe("renameSlugInRights (#240 client mirror)", () => {
   });
 });
 
-// #247 / #256 rds 2-3 — local mirror of the worker's bootstrap
-// auto-grant, driven strictly by the worker's X-Bootstrap-Grant wire
-// signal (no client-side inference — every inference variant broke
-// under some rights shape: session skew, published:true creates).
-// These tests pin that the mirror reproduces exactly what the
-// server-side grant wrote for each shape.
-
-describe("mirrorBootstrapGrant", () => {
-  it("mirrors both verbs (explicit empty rights)", () => {
-    expect(
-      mirrorBootstrapGrant(
-        { language_edit_rights: [], language_publish_rights: [] },
-        "sw"
-      )
-    ).toEqual({
-      language_edit_rights: ["sw"],
-      language_publish_rights: ["sw"],
-    });
-  });
-
-  it("full-access fields pass through untouched (server grant no-ops too)", () => {
-    expect(
-      mirrorBootstrapGrant(
-        { language_edit_rights: "*", language_publish_rights: "*" },
-        "sw"
-      )
-    ).toEqual({ language_edit_rights: "*", language_publish_rights: "*" });
-    // Legacy full-access user (all fields unset) → stays unset.
-    expect(mirrorBootstrapGrant({}, "sw")).toEqual({
-      language_edit_rights: undefined,
-      language_publish_rights: undefined,
-    });
-  });
-
-  it("idempotent when a verb already names the slug", () => {
-    expect(
-      mirrorBootstrapGrant(
-        { language_edit_rights: ["sw"], language_publish_rights: [] },
-        "sw"
-      )
-    ).toEqual({
-      language_edit_rights: ["sw"],
-      language_publish_rights: ["sw"],
-    });
-  });
-
-  it("split wildcard: edit [] + publish '*' → edit gains the slug, wildcard untouched", () => {
-    expect(
-      mirrorBootstrapGrant(
-        { language_edit_rights: [], language_publish_rights: "*" },
-        "sw"
-      )
-    ).toEqual({ language_edit_rights: ["sw"], language_publish_rights: "*" });
-  });
-
-  it("partner-deny shape: publish explicit, edit unset → edit materializes [slug], not legacy", () => {
-    expect(
-      mirrorBootstrapGrant(
-        { language_rights: ["x"], language_publish_rights: ["x"] },
-        "sw"
-      )
-    ).toEqual({
-      language_rights: ["x"],
-      language_edit_rights: ["sw"],
-      language_publish_rights: ["x", "sw"],
-    });
-  });
-
-  it("restricted legacy-only user → both verbs materialize legacy + slug (matches server grant)", () => {
-    expect(mirrorBootstrapGrant({ language_rights: ["en"] }, "sw")).toEqual({
-      language_rights: ["en"],
-      language_edit_rights: ["en", "sw"],
-      language_publish_rights: ["en", "sw"],
-    });
-  });
-
-  it("preserves unrelated fields and does not mutate the input", () => {
-    const user = {
-      email: "a@acme.com",
-      isAdmin: true,
-      language_edit_rights: [] as string[],
-      language_publish_rights: [] as string[],
-    };
-    expect(mirrorBootstrapGrant(user, "sw")).toMatchObject({
-      email: "a@acme.com",
-      isAdmin: true,
-    });
-    expect(user.language_edit_rights).toEqual([]);
-  });
-});
-
 // #257 — local mirror of the worker's clone auto-grant, driven strictly
-// by the X-Bootstrap-Grant wire signal (no inference — see
-// mirrorBootstrapGrant above for the history).
+// by the X-Bootstrap-Grant wire signal. No client-side inference: every
+// inference variant broke under some rights shape (session skew,
+// published:true creates — #256 rds 2-3).
 
 describe("mirrorModeGrant", () => {
   it("adds the slug to both verb fields when includePublish, materializing unset fields as [slug]", () => {

--- a/tests/rights-migration.test.ts
+++ b/tests/rights-migration.test.ts
@@ -12,10 +12,8 @@ import {
   contractOrgModeRights,
   expandOrgModeRights,
   expandRights,
-  grantLanguageSlugToUser,
   grantModeSlugToUser,
   removeSlugIfPartnerPresent,
-  revokeLanguageSlugFromUser,
   revokeModeSlugFromUser,
 } from "../worker/rights-migration";
 import type { StoredUser } from "../worker/types";
@@ -302,136 +300,6 @@ describe("contractOrgModeRights", () => {
         "b"
       )
     ).resolves.toBeUndefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// #247 — bootstrap auto-grant (single-user, both language verb fields)
-// ---------------------------------------------------------------------------
-
-describe("grantLanguageSlugToUser", () => {
-  it("grants both verb fields and returns the modified fields", async () => {
-    await seed("boot@acme.com", "acme", {
-      language_edit_rights: [],
-      language_publish_rights: [],
-    });
-    const fields = await grantLanguageSlugToUser(env, "boot@acme.com", "sw");
-    expect(fields).toEqual(["language_edit_rights", "language_publish_rights"]);
-    const after = await read("boot@acme.com");
-    expect(after.language_edit_rights).toEqual(["sw"]);
-    expect(after.language_publish_rights).toEqual(["sw"]);
-  });
-
-  it("materializes explicit fields from restricted legacy rights", async () => {
-    await seed("legacy@acme.com", "acme", { language_rights: ["en"] });
-    const fields = await grantLanguageSlugToUser(env, "legacy@acme.com", "sw");
-    expect(fields).toEqual(["language_edit_rights", "language_publish_rights"]);
-    const after = await read("legacy@acme.com");
-    expect(after.language_edit_rights).toEqual(["en", "sw"]);
-    expect(after.language_publish_rights).toEqual(["en", "sw"]);
-    // Legacy field itself is untouched — it stays the lazy-migration
-    // source of truth for anything else that still reads it.
-    expect(after.language_rights).toEqual(["en"]);
-  });
-
-  it("no-ops (and does not write) for full-access users", async () => {
-    // Truly full = both wildcards, or both unset with no legacy (the
-    // pre-rights default). Neither needs a stored grant.
-    await seed("full@acme.com", "acme", {
-      language_edit_rights: "*",
-      language_publish_rights: "*",
-    });
-    expect(await grantLanguageSlugToUser(env, "full@acme.com", "sw")).toEqual(
-      []
-    );
-    expect((await read("full@acme.com")).language_edit_rights).toBe("*");
-
-    await seed("unset@acme.com", "acme");
-    expect(await grantLanguageSlugToUser(env, "unset@acme.com", "sw")).toEqual(
-      []
-    );
-    const after = await read("unset@acme.com");
-    expect(after.language_edit_rights).toBeUndefined();
-    expect(after.language_publish_rights).toBeUndefined();
-  });
-
-  it("partner-aware: an unset field with an explicit partner is a DENY, so the grant materializes [slug] — not full access, not legacy (#256 review F1)", async () => {
-    // Under-grant face of the bug: publish explicit, edit unset. The
-    // naive `explicit ?? legacy` treated unset edit as full access and
-    // skipped the grant — while every session (worker/auth.ts
-    // lazyMigrateLanguageRights) saw edit=[] and locked the creator out
-    // of the draft they just made.
-    await seed("mixed@acme.com", "acme", {
-      language_publish_rights: ["es"],
-    });
-    const fields = await grantLanguageSlugToUser(env, "mixed@acme.com", "sw");
-    expect(fields).toEqual(["language_edit_rights", "language_publish_rights"]);
-    const after = await read("mixed@acme.com");
-    expect(after.language_edit_rights).toEqual(["sw"]);
-    expect(after.language_publish_rights).toEqual(["es", "sw"]);
-  });
-
-  it("partner-aware: legacy entries never materialize into a partner-denied field (#256 review F1, escalation face)", async () => {
-    // Over-grant face: publish explicit, edit unset, legacy holds "x".
-    // The partner-aware rule made edit a deliberate deny; the naive
-    // fallback would have written edit=["x","sw"], durably restoring
-    // access the rule had revoked.
-    await seed("esc@acme.com", "acme", {
-      language_rights: ["x"],
-      language_publish_rights: ["x"],
-    });
-    await grantLanguageSlugToUser(env, "esc@acme.com", "sw");
-    const after = await read("esc@acme.com");
-    expect(after.language_edit_rights).toEqual(["sw"]);
-    expect(after.language_publish_rights).toEqual(["x", "sw"]);
-  });
-
-  it("partner-aware: a one-sided wildcard leaves that side untouched and grants the denied side", async () => {
-    await seed("wild@acme.com", "acme", {
-      language_edit_rights: [],
-      language_publish_rights: "*",
-    });
-    const fields = await grantLanguageSlugToUser(env, "wild@acme.com", "sw");
-    expect(fields).toEqual(["language_edit_rights"]);
-    const after = await read("wild@acme.com");
-    expect(after.language_edit_rights).toEqual(["sw"]);
-    expect(after.language_publish_rights).toBe("*");
-  });
-
-  it("throws when the stored user is missing", async () => {
-    await expect(
-      grantLanguageSlugToUser(env, "ghost@acme.com", "sw")
-    ).rejects.toThrow(/no stored user/);
-  });
-});
-
-describe("revokeLanguageSlugFromUser", () => {
-  it("removes the slug from exactly the recorded fields", async () => {
-    await seed("rev@acme.com", "acme", {
-      language_edit_rights: ["en", "sw"],
-      language_publish_rights: ["sw"],
-    });
-    await revokeLanguageSlugFromUser(env, "rev@acme.com", "sw", [
-      "language_edit_rights",
-    ]);
-    const after = await read("rev@acme.com");
-    expect(after.language_edit_rights).toEqual(["en"]);
-    // Not recorded → untouched, even though it holds the slug.
-    expect(after.language_publish_rights).toEqual(["sw"]);
-  });
-
-  it("tolerates a vanished user and drifted fields", async () => {
-    await expect(
-      revokeLanguageSlugFromUser(env, "gone@acme.com", "sw", [
-        "language_edit_rights",
-      ])
-    ).resolves.toBeUndefined();
-
-    await seed("drift@acme.com", "acme", { language_edit_rights: "*" });
-    await revokeLanguageSlugFromUser(env, "drift@acme.com", "sw", [
-      "language_edit_rights",
-    ]);
-    expect((await read("drift@acme.com")).language_edit_rights).toBe("*");
   });
 });
 

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -3,11 +3,8 @@ import { errorResponse, isPathShapedOrg } from "./helpers";
 import {
   contractOrgModeRights,
   expandOrgModeRights,
-  grantLanguageSlugToUser,
   grantModeSlugToUser,
-  revokeLanguageSlugFromUser,
   revokeModeSlugFromUser,
-  type LanguageVerbRightsField,
   type MigrationRecord,
   type RightsField,
 } from "./rights-migration";
@@ -293,16 +290,20 @@ function computeRequiredVerbsForPut(
 // Returns `{ ok: true }` to proceed (with optional `parsedBody` when the
 // gate already consumed it), or `{ error: Response }` to reject.
 //
-// Order of checks (intentionally asymmetric language ↔ mode):
+// Order of checks:
 //   1. crossOrg (super-admin viewing another org's config) — bypass
 //      per-row gates; shepherd rights are home-org-scoped and don't
 //      translate. Same carve-out as the pre-#181 language gate.
-//   2. hasAdminPowers — bypasses the gate FOR MODES ONLY. Pre-#181 the
-//      mode path was admin-only and languages were per-row for everyone
-//      (PR #185 review explicitly assertion: same-org super-admin with
-//      restricted `language_rights` still gets 403 on unauthorized
-//      langs). Preserve that asymmetry — admin doesn't trump per-row
-//      languages, only modes.
+//   2. hasAdminPowers — bypasses the gate for BOTH kinds (#249 option
+//      4, joint pick by Ian + Elsy). Languages used to be the
+//      exception: per-row rights bound admins too (PR #185 review),
+//      which left drafts invisible-and-uneditable to the very people
+//      who administer the org (#247, #249) while modes had trumped
+//      since pre-#181. Per-row rights were always aimed at NON-admin
+//      shepherds, and an admin can self-grant any language right at
+//      will, so the asymmetry bought no security — only a workflow
+//      speed bump and a first-draft deadlock. Non-admin shepherds are
+//      untouched: checks 3–6 still decide every write they make.
 //   3. Mode-baseline gate (modes only) — non-admin with both
 //      mode_*_rights unset → 403, preserving pre-#181 admin-only for
 //      legacy users. Escape by admin-granting at least one explicit
@@ -310,35 +311,20 @@ function computeRequiredVerbsForPut(
 //   4. Early-deny — if the caller has zero rights on this row across
 //      both verbs, reject before consuming the body. Keeps bodyless
 //      probes (DELETE, GET-with-method-override, malformed PUTs) on
-//      the 403 path rather than a downstream 400. Same-org-admin
-//      language PUTs are exempted — they fall through to check 6,
-//      whose #247 carve-out must see them.
+//      the 403 path rather than a downstream 400. No exemptions:
+//      everyone reaching this check is a non-admin (check 2 returned
+//      for the rest), and no PUT diff can let a zero-rights non-admin
+//      through.
 //   5. DELETE → requires BOTH edit + publish on the row. Deletion is
 //      strictly more destructive than either alone.
 //   6. PUT → diff body vs current and require the union of verbs the
 //      diff implies (`edit` if any editorial field changed — document,
 //      label, description, or the #209 `requires_group` flag; `publish`
-//      if the published flag flipped). When the diff denies, one
-//      carve-out (#247): a same-org admin's language PUT is allowed IF
-//      the engine CONFIRMED the target doesn't exist — pure creation.
-//      Without it, an org whose users all hold explicit (non-"*")
-//      language rights can never create its FIRST draft: rights can
-//      only name drafts that exist, and creating a draft requires
-//      rights — a deadlock. The carve-out sits on the deny path of the
-//      diff (not inside check 4) so mixed shapes like edit=[] +
-//      publish="*" — which pass the zero-rights screen on one verb yet
-//      still fail creation's edit demand — reach it too. It fails
-//      CLOSED (found or probe-error → 403) and never applies to DELETE
-//      or existing rows, so the PR #185 "admin doesn't trump per-row
-//      languages" rule holds for everything that already exists. The
-//      caller pairs it with an auto-grant of both verbs to the creator
-//      (rights-migration.ts). Failure-surface note for the exempted
-//      shape (zero-rights same-org admin): malformed JSON answers 400
-//      and an engine outage during the probe propagates as a request
-//      failure, where main answered a bodyless 403 — both are still
-//      fail-closed (no mutation), and the caller is a same-org admin
-//      to whom the row's existence is already visible via the ungated
-//      GET; accepted.
+//      if the published flag flipped). No carve-outs: the #247
+//      admin-bootstrap-create exception (and its creator auto-grant)
+//      is deleted in #249 — check 2 subsumes it, so creating an org's
+//      first language draft is now an ordinary admin write instead of
+//      a probe-gated special case.
 async function gateConfigMutation(
   request: Request,
   env: Env,
@@ -347,19 +333,15 @@ async function gateConfigMutation(
   kind: ResourceKind,
   name: string,
   crossOrg: boolean
-): Promise<
-  | { ok: true; parsedBody?: ResourceShape; adminBootstrapCreate?: boolean }
-  | { error: Response }
-> {
+): Promise<{ ok: true; parsedBody?: ResourceShape } | { error: Response }> {
   if (crossOrg) return { ok: true };
 
-  // Admin trumps PER-MODE rights only. Pre-#181, modes were admin-only
-  // and languages were per-row for everyone — including super-admin
-  // shepherds with restricted same-org `language_rights` (PR #185
-  // review). Preserve that asymmetry: a same-org admin doesn't get a
-  // free pass on a language they don't shepherd, but does keep the
-  // legacy "admin can edit any mode" capability.
-  if (kind === "mode" && hasAdminPowers(session)) return { ok: true };
+  // Admin trumps per-row rights for modes AND languages (#249). Rights
+  // scope non-admin shepherds; admins administer the whole org's config
+  // in both kinds. Returning here skips the PUT body parse and the
+  // existence/diff probe, so an admin language PUT costs one engine
+  // fetch instead of two — the same shape mode PUTs have always had.
+  if (hasAdminPowers(session)) return { ok: true };
 
   // Modes had no per-row rights pre-#181 — the gate was admin-only. The
   // "undefined === legacy full access" rule that languages inherit from
@@ -376,23 +358,12 @@ async function gateConfigMutation(
     return { error: errorResponse("Forbidden", 403) };
   }
 
-  // #247 — the shape eligible for the bootstrap carve-out in the PUT
-  // path below. Computed once: it also exempts these requests from the
-  // early-deny, which would otherwise 403 the zero-rights-admin case
-  // before the creation probe could run.
-  const adminLanguageCreatePath =
-    kind === "language" && request.method === "PUT" && hasAdminPowers(session);
-
   // Early-deny: if the caller has zero rights on this row across both
   // verbs, no PUT diff can let them through. Rejecting before reading
   // the body keeps the gate side-effect-free in the impossible case and
   // preserves the pre-#181 same-org "restricted shepherd → 403 on any
-  // unauthorized row" behavior even for bodyless probes. Same-org-admin
-  // language PUTs fall through instead — for them the PUT diff CAN
-  // allow (creation via the #247 carve-out), at the cost of a body
-  // parse + existence probe on what may still end as a 403.
+  // unauthorized row" behavior even for bodyless probes.
   if (
-    !adminLanguageCreatePath &&
     !hasRights(rightsFor(session, kind, "edit"), name) &&
     !hasRights(rightsFor(session, kind, "publish"), name)
   ) {
@@ -421,36 +392,13 @@ async function gateConfigMutation(
     // test) — do not add a catch here. An "error" status collapses to
     // null for the verb diff, treating the PUT as a creation, which is
     // conservative (every editorial field present demands edit;
-    // published: true demands publish). The #247 carve-out is stricter:
-    // it requires a CONFIRMED "missing", so an engine blip can tighten
-    // the diff but can never widen admin creation onto an existing row.
+    // published: true demands publish).
     const state = await fetchResourceState(env, kind, org, name);
     const current = state.status === "found" ? state.mode : null;
-    // Zero rights on the row can only reach this point via the
-    // adminLanguageCreatePath exemption (the early-deny catches everyone
-    // else). Such callers must NEVER take the ordinary allow below: an
-    // empty diff (body echoing current state, or omitting fields)
-    // computes zero required verbs, which on main was unreachable for
-    // them — letting it through would put an engine write on a row the
-    // PR #185 rule says they can't touch (#256 rd-2 F0). Their only
-    // allowed outcome is the bootstrap carve-out; it also tags an
-    // empty-diff PUT against a MISSING row as a bootstrap create, so
-    // the creator auto-grant can never be skipped on a creation.
-    const zeroRightsOnRow =
-      !hasRights(rightsFor(session, kind, "edit"), name) &&
-      !hasRights(rightsFor(session, kind, "publish"), name);
     const denied = computeRequiredVerbsForPut(body, current).some(
       (verb) => !hasRights(rightsFor(session, kind, verb), name)
     );
-    if (denied || zeroRightsOnRow) {
-      // #247 bootstrap carve-out — see the gate's doc comment (check 6).
-      // TOCTOU: a same-name create landing between the "missing" read
-      // and the engine PUT means one admin's scaffold overwrites the
-      // other's seconds-old scaffold — same-org, admin-only, and
-      // bounded to brand-new drafts; accepted.
-      if (adminLanguageCreatePath && state.status === "missing") {
-        return { ok: true, parsedBody: body, adminBootstrapCreate: true };
-      }
+    if (denied) {
       return { error: errorResponse("Forbidden", 403) };
     }
     return { ok: true, parsedBody: body };
@@ -1158,62 +1106,13 @@ export async function handleConfig(
         resolved.crossOrg
       );
       if ("error" in gate) return gate.error;
-      // #247 bootstrap create — grant the creator both verbs on the new
-      // slug BEFORE the engine call (#240 expand-first model: a failure
-      // after the grant leaves an inert entry for a slug that doesn't
-      // exist, never a lockout). Grant failure aborts the create — the
-      // engine hasn't been touched, and creating a draft the creator
-      // can't see would re-manifest the very bug this fixes.
-      let grantedFields: LanguageVerbRightsField[] = [];
-      if (gate.adminBootstrapCreate) {
-        try {
-          grantedFields = await grantLanguageSlugToUser(
-            env,
-            session.email,
-            languageName
-          );
-        } catch (err) {
-          console.error(
-            `bootstrap create: rights grant failed for ${session.email} ("${languageName}")`,
-            err
-          );
-          return errorResponse("Failed to grant creator rights", 502);
-        }
-      }
-      const engineRes = await proxyToEngine(
+      return proxyToEngine(
         request,
         env,
         `/api/v1/admin/orgs/${encodedOrg}/languages/${encodeURIComponent(languageName)}`,
         ["GET", "PUT", "DELETE"],
         gate.parsedBody
       );
-      // Compensate ONLY on a definitive engine rejection (4xx). A 5xx
-      // or transport failure is ambiguous — the create may have landed —
-      // so the grant superset is kept (same rule as the #240 rename
-      // compensation: ambiguity never contracts rights).
-      if (
-        grantedFields.length > 0 &&
-        engineRes.status >= 400 &&
-        engineRes.status < 500
-      ) {
-        await revokeLanguageSlugFromUser(
-          env,
-          session.email,
-          languageName,
-          grantedFields
-        );
-      }
-      // Tell the client the bootstrap grant happened so it can mirror
-      // the new rights into its session user without refetching /me
-      // (KV read-after-write) and without inferring the carve-out from
-      // its own rights snapshot — every inference variant broke under
-      // some shape (session skew, published:true creates; #256 rd-3).
-      if (gate.adminBootstrapCreate && engineRes.ok) {
-        const flagged = new Response(engineRes.body, engineRes);
-        flagged.headers.set("X-Bootstrap-Grant", "1");
-        return flagged;
-      }
-      return engineRes;
     }
     return proxyToEngine(
       request,

--- a/worker/rights-migration.ts
+++ b/worker/rights-migration.ts
@@ -1,4 +1,3 @@
-import { lazyMigrateLanguageRights } from "./auth";
 import type { Env } from "./helpers";
 import { listKvKeys } from "./helpers";
 import type { LanguageRights, StoredUser } from "./types";
@@ -49,22 +48,14 @@ export const MODE_RIGHTS_FIELDS = [
   "mode_publish_rights",
 ] as const satisfies readonly (keyof StoredUser)[];
 
-// A future language rename would add the legacy `language_rights` bit
-// here too (its undefined-means-full semantics differ from modes — the
-// expandRights passthrough is correct for it, but the consumer must
-// decide how "*"-equivalent legacy users interact with per-slug
-// migration). The two VERB fields below are declared because the #247
-// bootstrap auto-grant consumes them; the legacy field stays
-// undeclared until a rename consumer validates its semantics.
+// A future language rename would declare the language fields here too
+// (the legacy `language_rights` bit's undefined-means-full semantics
+// differ from modes — the expandRights passthrough is correct for it,
+// but the consumer must decide how "*"-equivalent legacy users interact
+// with per-slug migration). Nothing consumes language fields today: the
+// #247 bootstrap auto-grant that did was deleted in #249, where the
+// admin trump made creator grants unnecessary.
 export type RightsField = (typeof MODE_RIGHTS_FIELDS)[number];
-
-export const LANGUAGE_VERB_RIGHTS_FIELDS = [
-  "language_edit_rights",
-  "language_publish_rights",
-] as const satisfies readonly (keyof StoredUser)[];
-
-export type LanguageVerbRightsField =
-  (typeof LANGUAGE_VERB_RIGHTS_FIELDS)[number];
 
 // Add `to` wherever `from` is held. `"*"` and `undefined` pass through
 // untouched — wildcard resolves at gate time and needs no entry; for
@@ -85,106 +76,15 @@ export function expandRights(
   return [...rights, to];
 }
 
-// #247 — grant the creator both language verbs on a just-bootstrapped
-// slug. Follows the #240 expand-first model: the caller invokes this
-// BEFORE the engine create, so a crash between grant and create leaves
-// the user with an entry for a slug that doesn't exist — inert, and in
-// this case the "accidental shepherd" a future same-slug language would
-// inherit is the admin who was allowed to create it anyway. Throws on
-// read/write failure — the caller must abort the create (nothing has
-// touched the engine yet).
-//
-// The grant operates on the user's EFFECTIVE rights per the canonical
-// partner-aware rule (lazyMigrateLanguageRights, worker/auth.ts): the
-// legacy `language_rights` fallback applies only when BOTH verb fields
-// are unset; an explicit partner makes the unset field a deliberate
-// deny ([]), which the grant materializes as [slug] — never as legacy
-// entries. Getting this wrong in either direction is an authz bug: the
-// naive per-field `explicit ?? legacy` fallback both under-grants (an
-// unset-partner field reads as "full", so no grant is written while
-// every session sees [] — the creator is locked out of the draft they
-// just made) and over-grants (legacy entries materialize into a
-// partner-denied field, durably restoring access the rule had revoked).
-//
-// Concurrency: this is a whole-record read-modify-write over KV, which
-// has no CAS — two writes racing the same user record are last-write-
-// wins, the same acceptance as the #240 org-wide migration. The window
-// here is one admin's own record during their own create click; a lost
-// grant re-manifests as the (recoverable) read-only-draft symptom and
-// any admin can re-grant via the Users dialog now that the draft exists.
-//
-// Returns the fields actually modified, so definitive-failure
-// compensation operates only on what this grant touched and can never
-// strip a pre-existing entry (per-field recording, same rationale as
-// MigrationRecord).
-export async function grantLanguageSlugToUser(
-  env: Env,
-  email: string,
-  slug: string
-): Promise<LanguageVerbRightsField[]> {
-  const key = `user:${email}`;
-  const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
-  if (!user) {
-    throw new Error(`bootstrap grant: no stored user for ${key}`);
-  }
-  const effective = lazyMigrateLanguageRights(user);
-  const changed: LanguageVerbRightsField[] = [];
-  for (const field of LANGUAGE_VERB_RIGHTS_FIELDS) {
-    const rights = effective[field];
-    if (rights === undefined || rights === "*") continue;
-    if (rights.includes(slug)) continue;
-    user[field] = [...rights, slug];
-    changed.push(field);
-  }
-  if (changed.length > 0) {
-    await env.AUTH_KV.put(key, JSON.stringify(user));
-  }
-  return changed;
-}
-
-// #247 — compensate a bootstrap grant after a DEFINITIVE engine
-// rejection of the create (4xx). Best-effort by design, like
-// contractOrgModeRights: a failed removal leaves a harmless inert
-// entry (logged). Operates only on the fields the grant recorded.
-export async function revokeLanguageSlugFromUser(
-  env: Env,
-  email: string,
-  slug: string,
-  fields: LanguageVerbRightsField[]
-): Promise<void> {
-  const key = `user:${email}`;
-  try {
-    const user = await env.AUTH_KV.get<StoredUser>(key, { type: "json" });
-    if (!user) return;
-    let dirty = false;
-    for (const field of fields) {
-      const rights = user[field];
-      if (rights !== undefined && rights !== "*" && rights.includes(slug)) {
-        user[field] = rights.filter((s) => s !== slug);
-        dirty = true;
-      }
-    }
-    if (dirty) {
-      await env.AUTH_KV.put(key, JSON.stringify(user));
-    }
-  } catch (err) {
-    console.error(
-      `rights-migration: bootstrap grant compensation failed for ${key} (slug "${slug}") — stale entry remains`,
-      err
-    );
-  }
-}
-
 // #257 — clone auto-grant: give a single user MODE verbs on a
-// just-cloned slug. Sibling of grantLanguageSlugToUser (#247) with mode
-// semantics instead of language semantics: modes have NO legacy-rights
-// fallback and `undefined` means "no access" for non-admins (the
-// pre-#181 admin-only baseline), so an unset field simply materializes
-// as [slug] — there is no partner-aware or legacy rule to consult.
-// Wildcards pass through untouched. Same expand-first contract as the
-// language grant: call BEFORE the engine op; throws abort the clone;
-// the returned field list scopes definitive-failure compensation so a
-// pre-existing entry can never be stripped.
+// just-cloned slug. Modes have NO legacy-rights fallback and
+// `undefined` means "no access" for non-admins (the pre-#181 admin-only
+// baseline), so an unset field simply materializes as [slug] — there is
+// no partner-aware or legacy rule to consult. Wildcards pass through
+// untouched. Expand-first contract, as in the #240 rename migration:
+// call BEFORE the engine op; throws abort the clone; the returned field
+// list scopes definitive-failure compensation so a pre-existing entry
+// can never be stripped.
 //
 // `fields` names the verbs to grant — the caller passes the verbs the
 // cloner holds on the SOURCE mode, so cloning preserves the shepherd's
@@ -217,8 +117,9 @@ export async function grantModeSlugToUser(
 }
 
 // #257 — compensate a clone grant after a DEFINITIVE engine rejection
-// (4xx, e.g. the slug-collision 409). Best-effort, recorded-fields-only,
-// same contract as revokeLanguageSlugFromUser.
+// (4xx, e.g. the slug-collision 409). Best-effort by design, like
+// contractOrgModeRights: a failed removal leaves a harmless inert entry
+// (logged). Operates only on the fields the grant recorded.
 export async function revokeModeSlugFromUser(
   env: Env,
   email: string,


### PR DESCRIPTION
## What

Languages get **full mode parity for admins**, plus **org-wide read-only visibility** for everyone who can reach the page.

- **Admin trump (the security change, one line).** `gateConfigMutation` check 2 drops its `kind === "mode"` condition, so anyone with admin powers (`isAdmin` **or** `isSuperAdmin`) may edit, publish, delete and create any language in their own org — exactly as they always could for modes. Non-admin shepherds are untouched: checks 3–6, `rightsFor`, and the #209 `requires_group` edit-gating still decide every write they make.
- **Org-wide visibility.** The Languages dropdown is no longer rights-filtered. Every draft in the org is listed for anyone who can reach the page; rows the user holds no edit right on open **read-only** (editor `readOnly`, Save disabled, autosave gated, status reads "Read-only") instead of being hidden. This half is deliberately wider than modes, which still filter the dropdown for non-admin shepherds.
- **Zero-rights non-admins are unchanged** — no sidebar entry, `NoAccessState` on a deep link. Visibility qualifies on "any verb on any row" (Ian's Q2).

## Why

Languages were the one resource where per-row verb rights bound admins too (PR #185's review stance). That left drafts invisible *and* uneditable to the very people who administer the org — the #247 symptom Elsy hit ("where did the draft go?") — and produced a first-draft deadlock in any org whose users all hold explicit non-`"*"` rights. The asymmetry bought no security: an admin can self-grant any language right at will, so it was a workflow speed bump, not a boundary.

## Decision trail

- [Ian's pick — Option 4](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/249#issuecomment-5131042957), with answers to Q1–Q3 (per-language shepherd scoping stays the long-term model; visibility = any verb on the row; no sensitive-language flag for now).
- [Spec comment on #249](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/249#issuecomment-5143870999) — this PR implements it section by section.
- [Elsy's +1](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/249#issuecomment-5144365677), making it the joint pick Ian's comment delegated on.

## #247 carve-out deleted

The bootstrap carve-out (PR #256) existed only to tunnel *through* the missing trump, so it is deleted rather than extended:

- Gate: the `adminBootstrapCreate` flag on the return type, `adminLanguageCreatePath`, the early-deny exemption, the `zeroRightsOnRow` guard, and the probe-gated creation branch.
- Route arm: the grant / compensate / `X-Bootstrap-Grant` block on `languages/{name}` — it now collapses to gate → proxy, the same shape as the modes arm. **The mode-clone use of `X-Bootstrap-Grant` (#257/#258) is untouched**, header and tests included.
- `worker/rights-migration.ts`: `grantLanguageSlugToUser`, `revokeLanguageSlugFromUser`, `LANGUAGE_VERB_RIGHTS_FIELDS`, `LanguageVerbRightsField`. Mode siblings stay.
- Client: `PutLanguageResult`, `mirrorBootstrapGrant`, the create-success mirror block, the drop-unauthorized-selection effect, and the unreachable `EmptyState` branches.

Side effect worth naming: the trump returns before the PUT body parse and the existence/diff GET, so an **admin language PUT now costs one engine fetch instead of two** — the same shape admin mode PUTs have always had. Two surviving tests had their fetch-count assertions updated accordingly.

## Behavior delta (flagged deliberately)

**Admin creation no longer writes a creator auto-grant.** While the creator is an admin this is invisible — the trump covers everything. The one observable consequence: an admin *later demoted* to non-admin no longer retains rights on drafts they created. That is exact mode parity, and the alternative (keeping the whole grant/compensate/header pipeline as demotion insurance for a corner case modes don't cover either) costs far more than it buys. Reviewers can veto; see §8 of the spec.

Rows written by past #247 auto-grants stay in KV, inert while the user is an admin and meaningful again on demotion. No storage, KV, session, or engine changes; no re-login or backfill; rollback is a plain revert.

## Notes for review

- Rebased onto `main` after #267 (`requires_group` toggle). One textual conflict, in the gate's check-6 doc comment only — resolved preserving **both** #267's `requires_group` enumeration and #249's carve-out deletion. #267's `computeRequiredVerbsForPut` logic and its authz tests are untouched.
- `worker/auth.ts` and `worker/types.ts` are unchanged — rights fields stay load-bearing for non-admin shepherds and for the client's effective-rights mirror.
- `filterByAnyRights` remains exported and is still used by `modes.tsx`.
- README updated in three places (the `rights-migration.ts` blurb, the org-admin role description, and the endpoint table's languages row), plus a new "Language visibility" bullet.

## Testing

Run locally on the rebased head:

- `npm run typecheck` — clean.
- `npm run lint` — clean (zero warnings).
- `npm test` — **638 passed, 28 files.** `tests/config-authz.test.ts` alone: **171 passed.**
- `npm run build` — clean.
- **Negative control:** temporarily restoring `kind === "mode" &&` on the trump line fails **8 tests** (the 6 admin-path tests in the new `language admin trump (#249)` describe plus the 2 flipped cross-org tests), while the 3 non-admin denial tests stay green. Line restored; tree clean.

New/changed coverage:

- New `language admin trump (#249)` describe, 9 tests: admin PUT on an existing draft (200, single proxy fetch, no probe); admin DELETE (200 — the #247 carve-out was PUT-only); admin creates a missing draft (200, **KV rights unchanged**, no `X-Bootstrap-Grant`); admin publish flip without publish rights; super-admin without `isAdmin` (hasAdminPowers parity); the **#247 deadlock regression** (every user on explicit non-`"*"` rights, admin still creates draft one, rights unwritten); and three non-admin denials — PUT existing, PUT missing, DELETE — each 403 with **zero engine fetches**.
- `super-admin with ?org=<own org> + restricted language_rights` flipped 403 → 200 as a trump assertion. The self-referential-`?org=` discriminator it used to pin is still pinned by the surviving non-super test (`isAdmin: false`, 403, zero fetches).
- The test titled `no ?org= + non-super with restricted language_rights` had an `isAdmin: true` session contradicting its own name; rewritten with the non-admin session it always described (403, zero fetches).
- Deleted: the 19-test `#247 language bootstrap create` describe, the `grantLanguageSlugToUser` / `revokeLanguageSlugFromUser` describes, the `X-Bootstrap-Grant` surfacing test in `languages-api`, and the `mirrorBootstrapGrant` describe.
- Untouched and green: `#181 verb-perms (languages)` and `(modes)`, `#209 requires_group is edit-gated`, mode rename/clone/retire, `tests/language-bootstrap-gate.test.ts`.

Not yet done — staging verification of the four scenarios in spec §5 (admin with explicit-empty rights sees and edits every draft; publish-only shepherd sees all drafts with non-granted rows read-only and no autosave 403s; create-first-draft in a fresh org).

Closes #249
