### PR TITLE
chore: bump version 1.10.4 → 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-admin-portal",
-      "version": "1.10.4",
+      "version": "1.11.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps the displayed app version, which had been pinned at `1.10.4` since 2026-07-13 while six feature PRs landed on top of it (#258, #262, #265, #267, #268, #271). Today's production deploy shipped all six under that stale label — the in-app footer could not distinguish a July 13 build from the current one.

Minor rather than patch, since the interval added user-facing features: the read-only Resources panel, the MCP server visual map, the "Requires group chat" toggle, and org-wide language visibility.

The version reaches the UI through `vite.config.ts`'s `__APP_VERSION__` define (a build-time constant), consumed by `src/components/user-menu.tsx:68` and `src/app/pages/login.tsx:146`. `package-lock.json` is updated alongside `package.json` via `npm version --no-git-tag-version`.

Once this is on `main` I'll tag `v1.11.0` there and dispatch the production deploy. Release tagging had lapsed after `v1.5.1` in April; this restarts it.