### PR TITLE
feat(#277): per-mode resource prioritization via Tool Guidance block injection

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Download, Save } from "lucide-react";
+import { Download, ListOrdered, Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
@@ -65,6 +65,7 @@ import {
 import { MarkdownToc } from "@/components/markdown-toc";
 import { ModeSelector } from "@/components/mode-selector";
 import { PageHeader } from "@/components/page-header";
+import { ResourcePriorityPanel } from "@/components/resource-priority-panel";
 
 const AUTO_SAVE_DEBOUNCE_MS = 800;
 
@@ -74,6 +75,8 @@ const AUTO_SAVE_DEBOUNCE_MS = 800;
 const NO_EDIT_RIGHTS_REASON = "You don't have edit rights on this mode.";
 const REQUIRES_GROUP_HELP =
   "When on, this mode is only offered in group chats (Telegram groups) — hidden from WhatsApp, web, and DMs.";
+const RESOURCE_PRIORITIES_HELP =
+  "Rank the resources this mode answers from first. Written into the mode document, under Tool Guidance.";
 
 export function ModesPage() {
   const user = useAuthStore((s) => s.user);
@@ -383,6 +386,23 @@ export function ModesPage() {
     value: string | null;
   } | null>(null);
 
+  // #277 — the resource-priority panel. Open state lives here, not in the
+  // panel, so a failed apply-save leaves it exactly where the user left it.
+  // The error lives here for the same reason, one step further: Radix unmounts
+  // the sheet's subtree on close, so panel-local error state would let
+  // close-then-reopen silently forget that the draft is unsaved.
+  const [prioritiesOpen, setPrioritiesOpen] = useState(false);
+  const [priorityApplyError, setPriorityApplyError] = useState<string | null>(
+    null
+  );
+
+  // A stale apply failure is about another mode's draft the moment the
+  // selection moves; that mode's unsaved state is already reported by the
+  // ordinary save-status machinery.
+  useEffect(() => {
+    setPriorityApplyError(null);
+  }, [selectedMode]);
+
   // #260 — post-rename display-name sync prompt. Holds the rename
   // response (server truth for label/description/document/published) so
   // the follow-up label PUT never depends on refetch timing. Null =
@@ -576,6 +596,77 @@ export function ModesPage() {
     [
       applyLastSyncedFlags,
       draft,
+      saveMode,
+      selectedMode,
+      serverDescription,
+      serverLabel,
+      trackersOwn,
+    ]
+  );
+
+  // #277 — resource prioritization is a DOCUMENT edit, not a new field: the
+  // panel hands back the next document and this flushes it through the same
+  // save machinery as everything else on the page. No flags move, so the
+  // tracked pair is re-asserted verbatim (the worker has no partial update),
+  // and no new PUT body field is introduced anywhere. Serialized on the same
+  // synchronous lock as the flag toggles, and for the mirror-image reason:
+  // this PUT carries the whole document, so starting one mid-flight would
+  // ship a pre-flight document over whatever that write is landing.
+  const handleApplyResourcePriorities = useCallback(
+    async (nextDocument: string) => {
+      if (!selectedMode) return;
+      if (inFlightSavesRef.current > 0 || saveMode.isPending) {
+        setPriorityApplyError(
+          "Another save is in flight. Try again in a moment."
+        );
+        return;
+      }
+      const target = selectedMode;
+      const sent = lastSyncedFlagsRef.current;
+      // Show the edit immediately; the flush below is what persists it. On
+      // failure it stays in the draft as ordinary unsaved changes, which is
+      // what the Save button and the status chip already know how to report.
+      setDraft(nextDocument);
+      setPriorityApplyError(null);
+      inFlightSavesRef.current += 1;
+      try {
+        const saved = await saveMode.mutateAsync({
+          name: target,
+          body: {
+            label: serverLabel,
+            description: serverDescription,
+            document: nextDocument,
+            ...sent,
+          },
+        });
+        if (trackersOwn(target)) {
+          setLastSyncedDoc(nextDocument);
+          setLastFailedDoc(null);
+          applyLastSyncedFlags(reconcileModeFlags(sent, saved));
+        }
+        // Close only on success — a failed save keeps the panel open with the
+        // user's ordering intact and the failure reported inside the sheet.
+        setPrioritiesOpen(false);
+      } catch (err) {
+        // Unlike the flag toggles, this path CHANGED the draft. Without
+        // marking the failed document, the autosave effect would re-fire it
+        // on every isPending → false transition (the loop Frank flagged on
+        // PR #122). The user recovers with Apply again, Save, or by editing.
+        if (trackersOwn(target)) setLastFailedDoc(nextDocument);
+        // Recorded rather than rethrown: the promise contract with the panel
+        // is that it never rejects, so the error survives the sheet
+        // unmounting on close instead of dying with the panel's state.
+        setPriorityApplyError(
+          err instanceof Error && err.message
+            ? err.message
+            : "The ranking could not be saved."
+        );
+      } finally {
+        inFlightSavesRef.current -= 1;
+      }
+    },
+    [
+      applyLastSyncedFlags,
       saveMode,
       selectedMode,
       serverDescription,
@@ -799,6 +890,9 @@ export function ModesPage() {
   const requiresGroupHelp = canEditSelected
     ? REQUIRES_GROUP_HELP
     : `${REQUIRES_GROUP_HELP} ${NO_EDIT_RIGHTS_REASON}`;
+  const resourcePrioritiesHelp = canEditSelected
+    ? RESOURCE_PRIORITIES_HELP
+    : `${RESOURCE_PRIORITIES_HELP} ${NO_EDIT_RIGHTS_REASON}`;
 
   const saveStatus = useMemo(() => {
     if (isSaving) return "Saving…";
@@ -901,6 +995,26 @@ export function ModesPage() {
                 aria-live="polite"
               >
                 {saveStatus}
+              </span>
+              {/* #277 — opens the ranking panel. Gated by the same right
+                  the Save button and the group-chat switch are gated by; the
+                  panel itself refuses to apply without it as a backstop. */}
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setPrioritiesOpen(true)}
+                disabled={!canEditSelected}
+                title={resourcePrioritiesHelp}
+                aria-describedby="mode-resource-priorities-help"
+              >
+                <ListOrdered className="mr-1.5 size-3.5" />
+                Resource priorities
+              </Button>
+              {/* Same reason as the switch's sr-only span: a disabled control
+                  is out of the tab order and gets no hover on touch, so the
+                  denial has to exist in the accessibility tree too. */}
+              <span id="mode-resource-priorities-help" className="sr-only">
+                {resourcePrioritiesHelp}
               </span>
               <Button
                 size="sm"
@@ -1144,6 +1258,23 @@ export function ModesPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* #277 — per-mode resource prioritization. Reads the live draft and
+          emits the next document; saving stays this page's job. Unlike the
+          group-chat switch, a failure is not left to the saveError banner:
+          the sheet's modal overlay covers this page while it is open, so that
+          banner is dimmed and inert. The failure is recorded here in
+          priorityApplyError and rendered by the panel, inside the sheet,
+          where the user is. */}
+      <ResourcePriorityPanel
+        open={prioritiesOpen}
+        onOpenChange={setPrioritiesOpen}
+        document={draft}
+        canEdit={canEditSelected}
+        isSaving={isSaving}
+        onApply={handleApplyResourcePriorities}
+        applyError={priorityApplyError}
+      />
     </div>
   );
 }

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -280,6 +280,10 @@ export function ModesPage() {
             if (!trackersOwn(target)) return;
             setLastSyncedDoc(doc);
             setLastFailedDoc(null);
+            // Any successful document sync retires a stale priority-apply
+            // failure — the draft it complained about is now persisted, and a
+            // reopened panel must not claim otherwise.
+            setPriorityApplyError(null);
             applyLastSyncedFlags(reconcileModeFlags(sent, saved));
           },
           onError: () => {
@@ -396,10 +400,13 @@ export function ModesPage() {
     null
   );
 
-  // A stale apply failure is about another mode's draft the moment the
-  // selection moves; that mode's unsaved state is already reported by the
-  // ordinary save-status machinery.
+  // A stale apply failure — and an open panel — are about another mode's
+  // draft the moment the selection moves (rights revocation and org-context
+  // switches clear the selection out from under the modal sheet). Close both;
+  // the prior mode's unsaved state is already reported by the ordinary
+  // save-status machinery.
   useEffect(() => {
+    setPrioritiesOpen(false);
     setPriorityApplyError(null);
   }, [selectedMode]);
 
@@ -540,6 +547,7 @@ export function ModesPage() {
         });
         if (!trackersOwn(name)) return;
         setLastSyncedDoc(draft);
+        setPriorityApplyError(null);
         applyLastSyncedFlags(reconcileModeFlags(sent, saved));
       } finally {
         inFlightSavesRef.current -= 1;
@@ -588,6 +596,7 @@ export function ModesPage() {
         });
         if (!trackersOwn(target)) return;
         setLastSyncedDoc(draft);
+        setPriorityApplyError(null);
         applyLastSyncedFlags(reconcileModeFlags(sent, saved));
       } finally {
         inFlightSavesRef.current -= 1;
@@ -644,6 +653,10 @@ export function ModesPage() {
           setLastFailedDoc(null);
           applyLastSyncedFlags(reconcileModeFlags(sent, saved));
         }
+        // Unconditional: a second Apply click that lost the in-flight race
+        // recorded an error AFTER this attempt cleared it, and this success
+        // retires that too — reopening must not show a stale failure.
+        setPriorityApplyError(null);
         // Close only on success — a failed save keeps the panel open with the
         // user's ordering intact and the failure reported inside the sheet.
         setPrioritiesOpen(false);

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -637,12 +637,13 @@ export function ModesPage() {
   const handleApplyResourcePriorities = useCallback(
     async (nextDocument: string) => {
       if (!selectedMode) return;
-      if (inFlightSavesRef.current > 0 || saveMode.isPending) {
-        setPriorityApplyError(
-          "Another save is in flight. Try again in a moment."
-        );
-        return;
-      }
+      // Symmetry with flushSave: the button and the panel are already
+      // rights-gated, but the worker's gate deserves a local mirror.
+      if (!canEditSelected) return;
+      // Silent: the panel's controls are busy-disabled while a save is in
+      // flight, and an error here is about no document in particular — the
+      // draft-divergence effect below would clear it on the next paint anyway.
+      if (inFlightSavesRef.current > 0 || saveMode.isPending) return;
       const target = selectedMode;
       const sent = lastSyncedFlagsRef.current;
       // Show the edit immediately; the flush below is what persists it. On
@@ -701,6 +702,7 @@ export function ModesPage() {
     },
     [
       applyLastSyncedFlags,
+      canEditSelected,
       saveMode,
       selectedMode,
       serverDescription,

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -410,6 +410,19 @@ export function ModesPage() {
     setPriorityApplyError(null);
   }, [selectedMode]);
 
+  // The apply error is a claim about ONE document — the failed apply's
+  // `nextDocument`, which is exactly what `lastFailedDoc` holds after the
+  // catch below. The moment the draft diverges from it (the user edited away
+  // or undid the ranking, or any save landed and cleared `lastFailedDoc`),
+  // the banner's "your ranking is still here, apply again" story is false —
+  // retire it. This is the recovery path the per-save clears can't see:
+  // divergence without a save.
+  useEffect(() => {
+    if (priorityApplyError !== null && draft !== lastFailedDoc) {
+      setPriorityApplyError(null);
+    }
+  }, [draft, lastFailedDoc, priorityApplyError]);
+
   // #260 — post-rename display-name sync prompt. Holds the rename
   // response (server truth for label/description/document/published) so
   // the follow-up label PUT never depends on refetch timing. Null =
@@ -652,28 +665,36 @@ export function ModesPage() {
           setLastSyncedDoc(nextDocument);
           setLastFailedDoc(null);
           applyLastSyncedFlags(reconcileModeFlags(sent, saved));
+          // Also retires the error a second Apply click recorded after this
+          // attempt cleared it (the lost-the-in-flight-race case is same-mode
+          // by construction, so the ownership guard keeps it covered). Then
+          // close — but only on success: a failed save keeps the panel open
+          // with the user's ordering intact and the failure reported inside
+          // the sheet. Both stay ownership-gated so a save that outlives the
+          // selection can't close (or repaint) a panel now showing another
+          // mode; the selection-change effect already reset panel state.
+          setPriorityApplyError(null);
+          setPrioritiesOpen(false);
         }
-        // Unconditional: a second Apply click that lost the in-flight race
-        // recorded an error AFTER this attempt cleared it, and this success
-        // retires that too — reopening must not show a stale failure.
-        setPriorityApplyError(null);
-        // Close only on success — a failed save keeps the panel open with the
-        // user's ordering intact and the failure reported inside the sheet.
-        setPrioritiesOpen(false);
       } catch (err) {
         // Unlike the flag toggles, this path CHANGED the draft. Without
         // marking the failed document, the autosave effect would re-fire it
         // on every isPending → false transition (the loop Frank flagged on
         // PR #122). The user recovers with Apply again, Save, or by editing.
-        if (trackersOwn(target)) setLastFailedDoc(nextDocument);
-        // Recorded rather than rethrown: the promise contract with the panel
-        // is that it never rejects, so the error survives the sheet
-        // unmounting on close instead of dying with the panel's state.
-        setPriorityApplyError(
-          err instanceof Error && err.message
-            ? err.message
-            : "The ranking could not be saved."
-        );
+        if (trackersOwn(target)) {
+          setLastFailedDoc(nextDocument);
+          // Recorded rather than rethrown: the promise contract with the
+          // panel is that it never rejects, so the error survives the sheet
+          // unmounting on close instead of dying with the panel's state.
+          // Ownership-gated like every other write here — a failure from a
+          // save that outlived the selection must not be pinned on whatever
+          // mode the panel would now be showing.
+          setPriorityApplyError(
+            err instanceof Error && err.message
+              ? err.message
+              : "The ranking could not be saved."
+          );
+        }
       } finally {
         inFlightSavesRef.current -= 1;
       }
@@ -1016,7 +1037,7 @@ export function ModesPage() {
                 size="sm"
                 variant="outline"
                 onClick={() => setPrioritiesOpen(true)}
-                disabled={!canEditSelected}
+                disabled={!canEditSelected || isSaving}
                 title={resourcePrioritiesHelp}
                 aria-describedby="mode-resource-priorities-help"
               >
@@ -1281,7 +1302,13 @@ export function ModesPage() {
           where the user is. */}
       <ResourcePriorityPanel
         open={prioritiesOpen}
-        onOpenChange={setPrioritiesOpen}
+        onOpenChange={(open) => {
+          // The footer disables Cancel while a save is in flight, and Escape /
+          // overlay-click must keep the same promise — dismissing mid-PUT
+          // would unmount the panel's busy state while the save runs on.
+          if (!open && isSaving) return;
+          setPrioritiesOpen(open);
+        }}
         document={draft}
         canEdit={canEditSelected}
         isSaving={isSaving}

--- a/src/components/resource-priority-panel.tsx
+++ b/src/components/resource-priority-panel.tsx
@@ -1,0 +1,730 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Plus,
+  RotateCcw,
+  X,
+} from "lucide-react";
+
+import {
+  MAX_MODE_DOCUMENT_LENGTH,
+  buildPriorityEntries,
+  generatePriorityBlock,
+  mergeOrderWithLive,
+  parsePriorityDescriptions,
+  parsePriorityOrder,
+  splicePriorityBlock,
+  type MergedEntry,
+  type PriorityEntry,
+} from "@/lib/resource-priority";
+import { useUiStore } from "@/lib/ui-store";
+import { cn } from "@/lib/utils";
+import { useResources } from "@/hooks/use-resources";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+// Verbatim from #277 — the one thing every reader of this panel must
+// understand before they rank anything. Ranking biases retrieval; it does
+// not bind it, and promising otherwise would be a lie the prompt can't keep.
+const EXPECTATION_COPY =
+  "Ranking strongly increases the likelihood that BT Servant answers from higher-ranked sources first. It is not a guarantee — a lower-ranked source can still be used when it fits the question better.";
+const SCOPE_COPY = "Priorities apply to this mode in every language.";
+
+// Same sentence the Modes header uses for the same denial (see
+// NO_EDIT_RIGHTS_REASON in app/pages/modes.tsx). The header already gates the
+// button that opens this panel; this is the backstop, and it has to read
+// identically — one denial, one wording.
+const NO_EDIT_RIGHTS_REASON = "You don't have edit rights on this mode.";
+
+interface ResourcePriorityPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The current draft document — the panel splices into THIS, not the cache. */
+  document: string;
+  canEdit: boolean;
+  /**
+   * Emits the next document. The panel never fetches modes and never saves;
+   * the page saves and NEVER rejects this promise — a failure is recorded in
+   * `applyError` instead, so it survives the sheet unmounting on close.
+   */
+  onApply: (nextDocument: string) => void | Promise<void>;
+  /**
+   * The page's record of the last failed apply-save, rendered inside the
+   * sheet: the page's own error banner sits under the sheet's modal overlay,
+   * where a user mid-ranking can neither read it nor act on it. Page-owned
+   * state (not panel state) so that closing and reopening the sheet — which
+   * unmounts this subtree — can't silently forget that the draft is unsaved.
+   */
+  applyError: string | null;
+  /** A save is in flight somewhere on the page; Apply/Remove must wait it out. */
+  isSaving?: boolean;
+}
+
+/**
+ * Per-mode resource prioritization (#277).
+ *
+ * The ordering lives in the mode document as a generated block inside
+ * `## Tool Guidance` (see `lib/resource-priority.ts` for why). This panel is a
+ * thin projection of that lib: it reads the stored order out of the draft,
+ * merges it with the live aggregation for one language, lets the user reorder,
+ * and hands the next document back. The page owns saving and owns `open`, so a
+ * failed save keeps the panel exactly where the user left it.
+ */
+export function ResourcePriorityPanel(props: ResourcePriorityPanelProps) {
+  return (
+    <Sheet open={props.open} onOpenChange={props.onOpenChange}>
+      {/* Accent rail in the Modes brand color, mirroring the PageHeader's top
+          strip — the panel edits a mode document, and it should read that way
+          the moment it slides in. */}
+      <SheetContent
+        className="w-full gap-0 border-l-[3px] p-0 sm:max-w-xl"
+        style={{ borderLeftColor: "var(--brand-modes)" }}
+      >
+        {/* Radix unmounts this subtree when closed, which is exactly what keeps
+            the resources query from running on every Modes page load — and what
+            re-initialises the working order from the draft on each open. */}
+        <PanelBody {...props} />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function PanelBody({
+  document,
+  canEdit,
+  onApply,
+  onOpenChange,
+  applyError,
+  isSaving = false,
+}: ResourcePriorityPanelProps) {
+  const contextOrg = useUiStore((s) => s.contextOrg);
+
+  // The endpoint takes an IETF-style content-language code, not the org's
+  // tuning-language slugs — same free-text input as the Resources page, and
+  // the same query key, so the two share one cache.
+  const [languageInput, setLanguageInput] = useState("en");
+  const [language, setLanguage] = useState("en");
+  const resources = useResources(language, contextOrg);
+  const data = resources.data;
+
+  // What the document currently says. `null` = no block, `"corrupt"` = a block
+  // whose order line is unreadable (a hand-edit, or an opening marker whose
+  // closing marker was deleted); in both cases we start from an empty ranking
+  // rather than rewriting anything behind the user's back.
+  const parsed = useMemo(() => parsePriorityOrder(document), [document]);
+  const storedOrder = useMemo(
+    () => (Array.isArray(parsed) ? parsed : []),
+    [parsed]
+  );
+  const hasBlock = parsed !== null;
+  const isCorrupt = parsed === "corrupt";
+
+  // `null` until the user touches something, so the working order tracks the
+  // document (and a save that lands from elsewhere) until there is an edit to
+  // protect.
+  const [order, setOrder] = useState<string[] | null>(null);
+  const [applying, setApplying] = useState(false);
+  // Reordering is keyboard-first, and a keyboard-first control that only
+  // reports itself visually isn't finished: every mutation narrates where the
+  // row landed.
+  const [announcement, setAnnouncement] = useState("");
+
+  const liveEntries = useMemo<PriorityEntry[]>(
+    () => (data ? buildPriorityEntries(data) : []),
+    [data]
+  );
+  const entriesById = useMemo(
+    () => new Map(liveEntries.map((entry) => [entry.id, entry])),
+    [liveEntries]
+  );
+  // What the current block says about each ranked id — the fallback that lets
+  // a row (and its regenerated prompt line) keep its description when the
+  // aggregation being browsed doesn't list it: another language, a server
+  // outage. Without it, reopening the panel — which resets enumeration to
+  // "en" — would offer to rewrite a ranked list to raw ids, with Apply
+  // enabled and no user intent behind it.
+  const recoveredDescriptions = useMemo(
+    () => parsePriorityDescriptions(document),
+    [document]
+  );
+  // Two lists, one source of truth. `ranked` is the ordering itself — a sparse
+  // list of the resources someone deliberately ranked, and the ONLY thing that
+  // reaches the document. `unranked` is the rest of the catalog, offered as
+  // candidates; leaving a resource there is how a user says "no preference".
+  const merged = useMemo(
+    () =>
+      mergeOrderWithLive(
+        order ?? storedOrder,
+        liveEntries,
+        recoveredDescriptions
+      ),
+    [order, storedOrder, liveEntries, recoveredDescriptions]
+  );
+  const ranked = merged.ranked;
+  const unranked = merged.unranked;
+  const orderedIds = useMemo(() => ranked.map((row) => row.id), [ranked]);
+
+  const block = useMemo(
+    () => generatePriorityBlock(orderedIds, entriesById, recoveredDescriptions),
+    [orderedIds, entriesById, recoveredDescriptions]
+  );
+  const nextDocument = useMemo(
+    () => splicePriorityBlock(document, block),
+    [document, block]
+  );
+
+  // "Nothing to apply" is a question about the DOCUMENT, not about the id
+  // sequence: comparing the spliced result catches the cases a sequence
+  // comparison misses — a corrupt or orphaned block that this apply would
+  // repair, a duplicated stored id that it would normalize.
+  const unchanged = nextDocument === document;
+  const tooLong = nextDocument.length > MAX_MODE_DOCUMENT_LENGTH;
+  const busy = isSaving || applying;
+
+  // Applying before the aggregation lands would regenerate every line from an
+  // empty lookup — the ranked list would come back as raw ids badged "not
+  // currently listed". The order is intent, but the prose is only as good as
+  // the data behind it, so Apply waits for the data.
+  //
+  // `unchanged` stops blocking once an apply has failed: the page shows the
+  // edit in the draft before the PUT resolves, so after a failure the document
+  // this panel reads already matches the working order. Without the exception,
+  // the retry path would be disabled with "already matches what's saved" —
+  // which would be precisely backwards.
+  const applyBlockedReason = !canEdit
+    ? NO_EDIT_RIGHTS_REASON
+    : busy
+      ? "Another save is in flight. Try again in a moment."
+      : !data
+        ? "Load the resource list before applying an order."
+        : tooLong
+          ? "This mode document would exceed the 64,000-character limit."
+          : unchanged && applyError === null
+            ? "The order already matches what's saved."
+            : null;
+
+  const submitLanguage = (e: React.FormEvent) => {
+    e.preventDefault();
+    const next = languageInput.trim();
+    if (next) setLanguage(next);
+  };
+
+  // Saving — and recording a failed save — is the page's job (`applyError`
+  // comes back down as a prop). The await only scopes the local busy state;
+  // the page's contract is that this promise never rejects, and the catch is
+  // a belt-and-braces guard for that contract, not a reporting path.
+  const submitDocument = useCallback(
+    async (next: string) => {
+      setApplying(true);
+      try {
+        await onApply(next);
+      } catch {
+        // The page records and renders the failure via `applyError`.
+      } finally {
+        setApplying(false);
+      }
+    },
+    [onApply]
+  );
+
+  // Focus has to survive a reorder, or a keyboard user loses their place on
+  // every press. React keeps focus on the moved button (rows are keyed by id)
+  // except when that button becomes disabled — at the end of the list, or
+  // because the row moved between the two lists — so name the fallbacks and
+  // take the first one that can hold focus.
+  const buttons = useRef(new Map<string, HTMLButtonElement | null>());
+  const [pendingFocus, setPendingFocus] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    if (!pendingFocus) return;
+    for (const key of pendingFocus) {
+      const button = buttons.current.get(key);
+      if (button && !button.disabled) {
+        button.focus();
+        break;
+      }
+    }
+    setPendingFocus(null);
+  }, [pendingFocus]);
+
+  // Every mutation rebases on `orderedIds`, the list actually on screen —
+  // never on the `order` state, which is `null` before the first edit and can
+  // otherwise lag behind rows that arrived with a refetch.
+  const move = useCallback(
+    (index: number, dir: "up" | "down") => {
+      const to = dir === "up" ? index - 1 : index + 1;
+      if (to < 0 || to >= orderedIds.length) return;
+      const next = [...orderedIds];
+      const [moved] = next.splice(index, 1);
+      if (moved === undefined) return;
+      next.splice(to, 0, moved);
+
+      setOrder(next);
+      setAnnouncement(
+        `${ranked[index]?.label ?? moved} moved to position ${String(to + 1)} of ${String(next.length)}.`
+      );
+      setPendingFocus([
+        `${moved}:${dir}`,
+        `${moved}:${dir === "up" ? "down" : "up"}`,
+      ]);
+    },
+    [orderedIds, ranked]
+  );
+
+  const rank = useCallback(
+    (entry: MergedEntry) => {
+      if (orderedIds.includes(entry.id)) return;
+      const next = [...orderedIds, entry.id];
+
+      setOrder(next);
+      setAnnouncement(
+        `${entry.label} ranked at position ${String(next.length)} of ${String(next.length)}.`
+      );
+      setPendingFocus([`${entry.id}:unrank`, `${entry.id}:up`]);
+    },
+    [orderedIds]
+  );
+
+  const unrank = useCallback(
+    (entry: MergedEntry) => {
+      const next = orderedIds.filter((id) => id !== entry.id);
+
+      setOrder(next);
+      setAnnouncement(
+        `${entry.label} removed from the ranking. ${String(next.length)} ranked.`
+      );
+      setPendingFocus([`${entry.id}:rank`]);
+    },
+    [orderedIds]
+  );
+
+  // Note what is NOT reset: `applyError`. A failed save is a fact about the
+  // document, not about the working order — it is page state, and it stays on
+  // screen (with Apply enabled) until the next save attempt resolves it.
+  const reset = useCallback(() => {
+    setOrder(null);
+    setAnnouncement("Ranking reset to the saved order.");
+  }, []);
+
+  const degraded = (data?.servers ?? []).filter((s) => s.status !== "ok");
+
+  return (
+    <>
+      <SheetHeader className="border-b p-4 sm:px-5">
+        <SheetTitle className="text-base tracking-tight">
+          Resource priorities
+        </SheetTitle>
+        <SheetDescription>
+          Rank the sources this mode reaches for first. The ranking is written
+          into the mode document, under Tool Guidance.
+        </SheetDescription>
+      </SheetHeader>
+
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4 sm:px-5">
+        {/* Rendered unconditionally so assistive tech is already watching it
+            when the first move happens. */}
+        <span role="status" aria-live="polite" className="sr-only">
+          {announcement}
+        </span>
+
+        <div
+          className="bg-muted/40 rounded-r-md border-l-2 px-3 py-2.5"
+          style={{ borderLeftColor: "var(--brand-modes)" }}
+        >
+          <p className="text-foreground/90 text-xs leading-relaxed">
+            {EXPECTATION_COPY}
+          </p>
+          <p className="text-muted-foreground mt-1.5 text-xs leading-relaxed">
+            {SCOPE_COPY}
+          </p>
+        </div>
+
+        <form className="flex items-end gap-2" onSubmit={submitLanguage}>
+          <div className="space-y-1.5">
+            <Label htmlFor="priority-language" className="text-xs">
+              Content language
+            </Label>
+            <Input
+              id="priority-language"
+              value={languageInput}
+              onChange={(e) => setLanguageInput(e.target.value)}
+              placeholder="en"
+              className="h-8 w-28 text-sm"
+              aria-describedby="priority-language-hint"
+            />
+          </div>
+          <Button
+            type="submit"
+            size="sm"
+            variant="outline"
+            disabled={!languageInput.trim() || resources.isFetching}
+          >
+            Load
+          </Button>
+          <p
+            id="priority-language-hint"
+            className="text-muted-foreground pb-1.5 text-xs"
+          >
+            Enumerates the catalog — the ranking itself is language-independent.
+          </p>
+        </form>
+
+        {isCorrupt && (
+          <div
+            className="border-destructive bg-destructive/10 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-r-md border-l-2 px-3 py-2.5"
+            role="status"
+          >
+            <p className="text-destructive min-w-0 flex-1 text-xs leading-relaxed">
+              We couldn&rsquo;t read the saved ordering in this document — it
+              looks hand-edited. Nothing has been changed. Rank what you need
+              below and apply to rewrite the block, or remove the priorities
+              altogether.
+            </p>
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={reset}
+              className="shrink-0"
+            >
+              <RotateCcw />
+              Reset
+            </Button>
+          </div>
+        )}
+
+        {resources.error && (
+          <div
+            className="bg-destructive/10 text-destructive border-destructive rounded-r-md border-l-2 px-3 py-2.5 text-xs"
+            role="alert"
+          >
+            {resources.error.message}
+          </div>
+        )}
+
+        {degraded.length > 0 && (
+          <ul className="space-y-1">
+            {degraded.map((server) => (
+              <li
+                key={server.serverId}
+                className={cn(
+                  "flex flex-wrap items-center gap-x-1.5 text-[11px]",
+                  server.status === "error"
+                    ? "text-destructive"
+                    : "text-muted-foreground"
+                )}
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    "size-1.5 rounded-full",
+                    server.status === "error"
+                      ? "bg-destructive"
+                      : "bg-muted-foreground/40"
+                  )}
+                />
+                <span className="font-medium">{server.serverName}</span>
+                <span>
+                  {server.status === "error"
+                    ? "failed to respond, so its resources are missing from this list"
+                    : "doesn't list resources, so it can't be ranked"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {resources.isLoading ? (
+          <div className="text-muted-foreground flex flex-col items-center gap-2 py-12">
+            <FontAwesomeIcon
+              icon={faSpinnerThird}
+              className="size-4 animate-spin"
+            />
+            <p className="text-xs">Loading resources…</p>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-muted-foreground text-[10px] font-semibold tracking-[0.18em] uppercase">
+                Ranked order
+              </h3>
+              {order !== null && (
+                <Button size="xs" variant="ghost" onClick={reset}>
+                  <RotateCcw />
+                  Reset
+                </Button>
+              )}
+            </div>
+
+            {ranked.length === 0 ? (
+              <div className="bg-card rounded-xl border px-5 py-6 text-center">
+                <p className="text-foreground text-sm font-medium">
+                  Nothing ranked yet
+                </p>
+                <p className="text-muted-foreground mx-auto mt-1.5 max-w-xs text-xs leading-relaxed">
+                  Rank only the sources you want this mode to reach for first.
+                  Everything you leave out stays available — it just carries no
+                  preference.
+                </p>
+              </div>
+            ) : (
+              <div className="relative pl-4">
+                {/* Preference decays down the list, and the spine says so: full
+                    brand color at rank 1, faded to nothing at the bottom. */}
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute top-1 bottom-1 left-[5px] w-0.5 rounded-full"
+                  style={{
+                    background:
+                      "linear-gradient(to bottom, var(--brand-modes), transparent)",
+                  }}
+                />
+                <ol className="space-y-1">
+                  {ranked.map((row, index) => (
+                    <li
+                      key={row.id}
+                      className="bg-card hover:border-border/80 flex items-center gap-3 rounded-lg border border-transparent px-2.5 py-2 transition-colors"
+                    >
+                      <span className="text-muted-foreground w-5 shrink-0 text-right text-xs tabular-nums">
+                        {index + 1}
+                      </span>
+                      <RowIdentity row={row} />
+                      <div className="flex shrink-0 items-center gap-0.5">
+                        <div className="flex flex-col">
+                          {/* The rank lives in a sibling span the button never
+                              references, so it has to travel in the label too —
+                              otherwise the accessible name is identical before
+                              and after a move. */}
+                          <Button
+                            ref={(el) => {
+                              buttons.current.set(`${row.id}:up`, el);
+                            }}
+                            size="icon-xs"
+                            variant="ghost"
+                            className="size-5"
+                            disabled={!canEdit || index === 0}
+                            aria-label={`Move ${row.label} up (currently ${String(index + 1)} of ${String(ranked.length)})`}
+                            onClick={() => move(index, "up")}
+                          >
+                            <ChevronUp />
+                          </Button>
+                          <Button
+                            ref={(el) => {
+                              buttons.current.set(`${row.id}:down`, el);
+                            }}
+                            size="icon-xs"
+                            variant="ghost"
+                            className="size-5"
+                            disabled={!canEdit || index === ranked.length - 1}
+                            aria-label={`Move ${row.label} down (currently ${String(index + 1)} of ${String(ranked.length)})`}
+                            onClick={() => move(index, "down")}
+                          >
+                            <ChevronDown />
+                          </Button>
+                        </div>
+                        <Button
+                          ref={(el) => {
+                            buttons.current.set(`${row.id}:unrank`, el);
+                          }}
+                          size="icon-xs"
+                          variant="ghost"
+                          className="text-muted-foreground hover:text-destructive"
+                          disabled={!canEdit}
+                          aria-label={`Remove ${row.label} from the ranking`}
+                          title="Remove from the ranking"
+                          onClick={() => unrank(row)}
+                        >
+                          <X />
+                        </Button>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            )}
+
+            <div className="flex items-center justify-between gap-2 pt-1">
+              <h3 className="text-muted-foreground text-[10px] font-semibold tracking-[0.18em] uppercase">
+                Not ranked
+              </h3>
+              <span className="text-muted-foreground text-[11px] tabular-nums">
+                {unranked.length}
+              </span>
+            </div>
+
+            {unranked.length === 0 ? (
+              <p className="text-muted-foreground px-1 text-xs leading-relaxed">
+                {data
+                  ? ranked.length > 0
+                    ? "Every listed resource is ranked."
+                    : "The connected servers listed no resources for this language. Try another language code."
+                  : "Load a language to list the resources this org can draw on."}
+              </p>
+            ) : (
+              <ul className="space-y-1">
+                {unranked.map((row) => (
+                  <li
+                    key={row.id}
+                    className="hover:bg-card flex items-center gap-3 rounded-lg border border-transparent px-2.5 py-2 transition-colors"
+                  >
+                    <span aria-hidden className="w-5 shrink-0" />
+                    <RowIdentity row={row} muted />
+                    <Button
+                      ref={(el) => {
+                        buttons.current.set(`${row.id}:rank`, el);
+                      }}
+                      size="xs"
+                      variant="outline"
+                      className="shrink-0"
+                      disabled={!canEdit}
+                      aria-label={`Add ${row.label} to the ranking`}
+                      onClick={() => rank(row)}
+                    >
+                      <Plus />
+                      Rank
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
+
+      <SheetFooter className="gap-3 border-t p-4 sm:px-5">
+        <details className="bg-muted/30 group rounded-lg border">
+          <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-xs font-medium">
+            <ChevronRight className="size-3 transition-transform group-open:rotate-90" />
+            Preview what goes into the document
+          </summary>
+          <pre className="max-h-44 overflow-auto border-t px-3 py-2 font-mono text-[11px] leading-relaxed whitespace-pre-wrap">
+            {block ||
+              "Nothing to add — applying now would remove the ranking from the document."}
+          </pre>
+        </details>
+
+        {tooLong && (
+          <p
+            className="bg-destructive/10 text-destructive border-destructive rounded-r-md border-l-2 px-3 py-2 text-xs"
+            role="alert"
+          >
+            This ranking would push the mode document past the 64,000-character
+            limit. Rank fewer resources, or trim the document.
+          </p>
+        )}
+
+        {applyError && (
+          <p
+            className="bg-destructive/10 text-destructive border-destructive rounded-r-md border-l-2 px-3 py-2 text-xs"
+            role="alert"
+          >
+            <span className="font-medium">Save failed.</span> {applyError}{" "}
+            Nothing was saved — your ranking is still here, so you can apply
+            again.
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          {hasBlock && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              onClick={() => {
+                void submitDocument(splicePriorityBlock(document, null));
+              }}
+              disabled={!canEdit || busy}
+              title={canEdit ? undefined : NO_EDIT_RIGHTS_REASON}
+            >
+              Remove priorities
+            </Button>
+          )}
+          <Button
+            size="sm"
+            onClick={() => {
+              void submitDocument(nextDocument);
+            }}
+            disabled={applyBlockedReason !== null}
+            title={applyBlockedReason ?? undefined}
+            aria-describedby={
+              applyBlockedReason ? "resource-priority-apply-help" : undefined
+            }
+          >
+            {busy ? "Saving…" : "Apply"}
+          </Button>
+          {/* A disabled button is out of the tab order and gets no hover on
+              touch, so the title alone can't carry the reason. Same idiom the
+              Modes header uses for its gated switch. */}
+          {applyBlockedReason && (
+            <span id="resource-priority-apply-help" className="sr-only">
+              {applyBlockedReason}
+            </span>
+          )}
+        </div>
+      </SheetFooter>
+    </>
+  );
+}
+
+/** Label, badge and attribution — identical in both lists. */
+function RowIdentity({
+  row,
+  muted = false,
+}: {
+  row: MergedEntry;
+  muted?: boolean;
+}) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-baseline gap-2">
+        <span
+          className={cn(
+            "truncate text-sm font-medium",
+            muted && "text-foreground/80",
+            row.missing && "text-muted-foreground",
+            // Mono only when nothing but the raw id is known — a missing row
+            // whose description was recovered from the document reads like any
+            // other row, just muted and badged.
+            row.missing && row.label === row.id && "font-mono text-xs"
+          )}
+        >
+          {row.label}
+        </span>
+        {row.missing && (
+          <Badge
+            variant="outline"
+            className="shrink-0 px-1.5 py-0 text-[10px] font-normal"
+          >
+            not currently listed
+          </Badge>
+        )}
+      </div>
+      <p className="text-muted-foreground truncate text-[11px]">
+        {row.missing
+          ? "Kept from the saved order — no server listed it for this language"
+          : [row.serverName, row.subjectLabelText].filter(Boolean).join(" · ")}
+      </p>
+    </div>
+  );
+}

--- a/src/components/resource-priority-panel.tsx
+++ b/src/components/resource-priority-panel.tsx
@@ -93,6 +93,9 @@ export function ResourcePriorityPanel(props: ResourcePriorityPanelProps) {
       <SheetContent
         className="w-full gap-0 border-l-[3px] p-0 sm:max-w-xl"
         style={{ borderLeftColor: "var(--brand-modes)" }}
+        // The page refuses dismissal mid-save; hide the chrome X in that
+        // window so nothing on screen merely LOOKS dismissible.
+        showCloseButton={!props.isSaving}
       >
         {/* Radix unmounts this subtree when closed, which is exactly what keeps
             the resources query from running on every Modes page load — and what

--- a/src/lib/resource-priority.ts
+++ b/src/lib/resource-priority.ts
@@ -43,8 +43,12 @@ const PRIORITY_BLOCK_PROSE = [
 const MISSING_FROM_LIVE_SUFFIX = "not currently listed";
 
 // The machine-readable half of the block. The prose list is disposable — this
-// line is the only thing parse-back reads.
-const ORDER_COMMENT_RE = /<!--\s*order:\s*(\[[\s\S]*?\])\s*-->/;
+// line is the only thing parse-back reads. Emission is always a single line,
+// so the parse is line-anchored with a GREEDY capture to the line's last `]`:
+// a lazy match would stop at the first `]` inside an id (JSON.stringify emits
+// `["aquifer:Notes]"]` for an id containing one) and misreport a well-formed
+// block as corrupt — inviting the user to "repair" away a healthy ranking.
+const ORDER_COMMENT_RE = /^<!--\s*order:\s*(\[.*\])\s*-->[ \t\r]*$/m;
 
 /** One live resource, flattened out of the aggregated by-subject response. */
 export interface PriorityEntry {

--- a/src/lib/resource-priority.ts
+++ b/src/lib/resource-priority.ts
@@ -1,0 +1,627 @@
+// Per-mode resource prioritization (#277) — the ordering is persisted as a
+// generated, delimited markdown block spliced into the tail of the mode
+// document's `## Tool Guidance` section. The document IS the storage AND the
+// injection: the worker's `parseModeDocument` splits only on the seven exact
+// H2 slot labels, so a `### Resource priorities` sub-heading rides inside the
+// `tool_guidance` slot verbatim, and `buildSystemPrompt` places that slot
+// immediately before the MCP tool catalog — where tool-selection guidance
+// belongs. A structured `resourcePriority` field would be dropped by the
+// worker's `mergeExistingMode` whitelist, so this is the only zero-worker-
+// change path.
+//
+// Everything here is pure and DOM-free: it runs (and is tested) under the
+// workers-pool tsconfig, and the panel component is a thin projection of it.
+
+import { subjectLabel } from "@/lib/resource-subjects";
+import type { PromptSlot } from "@/types/prompt-override";
+import { PROMPT_SLOTS, SLOT_LABELS } from "@/types/prompt-override";
+import type {
+  AggregatedResourcesResponse,
+  ResourceItem,
+} from "@/types/resources";
+
+/** Opening marker of the generated block. Exact string — parse-back keys on it. */
+export const RESOURCE_PRIORITY_BEGIN = "<!-- bt:resource-priorities -->";
+/** Closing marker of the generated block. */
+export const RESOURCE_PRIORITY_END = "<!-- /bt:resource-priorities -->";
+
+/** Worker `MAX_MODE_DOCUMENT_LENGTH` — the whole document, block included. */
+export const MAX_MODE_DOCUMENT_LENGTH = 64000;
+
+const PRIORITY_BLOCK_HEADING = "### Resource priorities";
+
+// Wrapped exactly as the spec's block format shows it. The wrap points are
+// part of the generated text, so a regenerated block is byte-identical to the
+// one already in the document when nothing changed — which is what makes the
+// splice idempotent.
+const PRIORITY_BLOCK_PROSE = [
+  "When answering from resources, strongly prefer the sources below, in this order. Answer from the",
+  "highest-ranked source that covers the question; fall back to the next-ranked source only when the",
+  "higher one does not cover it. Use unranked resources only when none of the ranked sources apply.",
+].join("\n");
+
+const MISSING_FROM_LIVE_SUFFIX = "not currently listed";
+
+// The machine-readable half of the block. The prose list is disposable — this
+// line is the only thing parse-back reads.
+const ORDER_COMMENT_RE = /<!--\s*order:\s*(\[[\s\S]*?\])\s*-->/;
+
+/** One live resource, flattened out of the aggregated by-subject response. */
+export interface PriorityEntry {
+  /** Composite, and stable across languages: `"${serverId}:${name}"`. */
+  id: string;
+  /** `label ?? name` — what a human recognizes the resource by. */
+  label: string;
+  serverName: string;
+  /** Display form of the (open-set) subject slug. */
+  subjectLabelText: string;
+}
+
+/**
+ * A row of the working order: a live entry, or a stored id the current
+ * aggregation no longer lists. Stored order is intent, not a snapshot, so
+ * `missing` rows are kept, badged, and still emitted into the block.
+ */
+export interface MergedEntry extends PriorityEntry {
+  missing: boolean;
+}
+
+/** Composite identity — already the React key on the Resources page. */
+export function resourceEntryId(item: ResourceItem): string {
+  return `${item.serverId}:${item.name}`;
+}
+
+// How many times sanitization re-runs before giving up (see below).
+const SANITIZE_PASS_LIMIT = 16;
+
+/**
+ * Make server- and user-authored text safe to interpolate into the block.
+ *
+ * The block lands in a slot the worker rewrites at prompt time, and four of
+ * those rewrites can be triggered by ordinary-looking text:
+ *   - Ulysses stripping — `%%` truncates the rest of its line and a matched
+ *     `++…++` pair is deleted; either one can silently eat the ranked list.
+ *   - Template substitution rewrites `{{word}}` sequences.
+ *   - A line beginning `## ` is a slot boundary for `parseModeDocument`, so
+ *     interpolated text must never be able to open one.
+ *   - `<!--` and `-->` are THIS module's own delimiters, and labels, server
+ *     names and subject labels are untrusted MCP-server output. A resource
+ *     labelled `<!-- /bt:resource-priorities -->` would close the block early:
+ *     the next apply would rewrite only the truncated span and strand the
+ *     tail in the document, and no UI affordance could ever remove it again.
+ *     `isEmittableId` already guards the machine-readable half of the block
+ *     against exactly this; sanitization is the same guard for the prose half.
+ *
+ * Newlines collapse first, which is what reduces the third hazard to a
+ * start-of-string check.
+ */
+export function sanitizePromptText(text: string): string {
+  let out = text.replace(/[\r\n]+/g, " ");
+
+  // Removals can splice new tokens together ("%+++%" → "%%", "<!<!---->->" →
+  // "<!--"), and separating a brace pair can leave a fresh one behind ("{{{" →
+  // "{ {{"), so run to a fixed point rather than a single pass. Each removal
+  // consumes at least two characters permanently, so this terminates; the cap
+  // is belt-and-braces.
+  for (let pass = 0; pass < SANITIZE_PASS_LIMIT; pass += 1) {
+    const next = out
+      .replace(/%%/g, "")
+      .replace(/\+\+/g, "")
+      .replace(/<!--/g, "")
+      .replace(/-->/g, "")
+      .replace(/\{\{/g, "{ {");
+    if (next === out) break;
+    out = next;
+  }
+
+  // Leading hashes are dropped rather than escaped: a `\#\#` escape renders
+  // literally in the prompt, and the heading text is the part worth keeping.
+  return out.replace(/^\s*#+\s*/, "").trim();
+}
+
+/**
+ * Flatten the aggregated response into server-default order — the response's
+ * own subject-key order, and within a subject the worker's ascending-priority
+ * server concatenation. Both orderings are contract, not portal opinion (#230
+ * Q5), so iteration order is preserved verbatim and nothing is re-sorted.
+ *
+ * A resource is identified by `serverId:name`; the first occurrence wins if
+ * the same id somehow surfaces under two subjects, so ids stay unique keys.
+ */
+export function buildPriorityEntries(
+  response: AggregatedResourcesResponse
+): PriorityEntry[] {
+  const serverNames = new Map(
+    response.servers.map((server) => [server.serverId, server.serverName])
+  );
+  const entries: PriorityEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const [slug, items] of Object.entries(response.resources)) {
+    for (const item of items) {
+      const id = resourceEntryId(item);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      entries.push({
+        id,
+        label: item.label ?? item.name,
+        serverName: serverNames.get(item.serverId) ?? item.serverId,
+        subjectLabelText: subjectLabel(slug),
+      });
+    }
+  }
+
+  return entries;
+}
+
+/** The two halves of the working list — see `mergeOrderWithLive`. */
+export interface MergedOrder {
+  /**
+   * The ranking itself, in stored sequence: exactly the ids the order names,
+   * and nothing else. This is what gets emitted, so it stays sparse.
+   */
+  ranked: MergedEntry[];
+  /**
+   * Live resources the order doesn't mention, in server-default order. They
+   * are candidates, not ranking members: leaving a resource here is how a user
+   * says "no preference", which is what makes the block's own "use unranked
+   * resources only when none of the ranked sources apply" sentence mean
+   * something.
+   */
+  unranked: MergedEntry[];
+  /** `ranked` then `unranked` — the rendered list, top to bottom. */
+  entries: MergedEntry[];
+}
+
+/**
+ * Reconcile the stored order (intent) with the live aggregation (fact).
+ *
+ * Stored ids come first, in their stored sequence — including ids the current
+ * language or aggregation no longer lists, which are flagged `missing` rather
+ * than dropped, so a transient server outage or a language switch can't
+ * quietly erase someone's ranking. Live resources the order doesn't mention
+ * append at the bottom in server-default order (#277 decision 4).
+ *
+ * `recoveredDescriptions` (see `parsePriorityDescriptions`) gives a missing
+ * row the description it last carried in the document, so the panel can show
+ * "Swahili Literal Text — uW (Bible Translations)" instead of a raw id.
+ *
+ * The two halves are returned separately because the split is load-bearing:
+ * the stored order is INTENT, a sparse list of the resources someone actually
+ * ranked, so only `ranked` may be written back into the document. Emitting the
+ * union would freeze the whole catalog into the prompt on the first Apply and
+ * grow it again every time another language is enumerated.
+ */
+export function mergeOrderWithLive(
+  storedOrder: string[],
+  live: PriorityEntry[],
+  recoveredDescriptions?: Map<string, string>
+): MergedOrder {
+  const liveById = new Map(live.map((entry) => [entry.id, entry]));
+  const ranked: MergedEntry[] = [];
+  const unranked: MergedEntry[] = [];
+  const placed = new Set<string>();
+
+  for (const id of storedOrder) {
+    if (placed.has(id)) continue;
+    placed.add(id);
+    const entry = liveById.get(id);
+    ranked.push(
+      entry
+        ? { ...entry, missing: false }
+        : {
+            id,
+            // A resource nobody is listing keeps the description it last
+            // carried in the document; only an id the document never
+            // described renders raw.
+            label: recoveredDescriptions?.get(id) ?? id,
+            serverName: "",
+            subjectLabelText: "",
+            missing: true,
+          }
+    );
+  }
+
+  for (const entry of live) {
+    if (placed.has(entry.id)) continue;
+    placed.add(entry.id);
+    unranked.push({ ...entry, missing: false });
+  }
+
+  return { ranked, unranked, entries: [...ranked, ...unranked] };
+}
+
+// An id has to survive a round trip through an HTML comment: `-->` would end
+// the comment early and a newline would break the single-line parse, so such
+// an id is dropped rather than allowed to corrupt the block. No real server id
+// or resource name contains either.
+function isEmittableId(id: string): boolean {
+  return id.length > 0 && !id.includes("-->") && !/[\r\n]/.test(id);
+}
+
+function describeEntry(entry: PriorityEntry): string {
+  const label = sanitizePromptText(entry.label);
+  const server = sanitizePromptText(entry.serverName);
+  const subject = sanitizePromptText(entry.subjectLabelText);
+  const attribution = [server, subject && `(${subject})`]
+    .filter((part) => part.length > 0)
+    .join(" ");
+  return attribution ? `${label} — ${attribution}` : label;
+}
+
+/**
+ * Render the block for `orderedIds`. The prose list is regenerated from live
+ * data on every apply — only the `<!-- order: [...] -->` line is authoritative,
+ * so a hand-edit to the interior is overwritten by design.
+ *
+ * An id the live lookup can't resolve keeps the description it already has in
+ * the document (`recoveredDescriptions`, from `parsePriorityDescriptions`).
+ * That matters twice over: the prompt keeps saying "Swahili Literal Text — uW"
+ * instead of degrading to a raw id when the panel is enumerating some other
+ * language (or a server is down), and the regenerated block stays
+ * byte-identical to the stored one in that situation — which is what keeps
+ * Apply honestly disabled when there is nothing to change. Only an id the
+ * document never described renders raw and badged.
+ *
+ * An empty order has no block: callers pass `null` to `splicePriorityBlock`
+ * (which removes it), and this returns `""` to make that path hard to get
+ * wrong.
+ */
+export function generatePriorityBlock(
+  orderedIds: string[],
+  entriesById: Map<string, PriorityEntry>,
+  recoveredDescriptions?: Map<string, string>
+): string {
+  const ids: string[] = [];
+  for (const id of orderedIds) {
+    if (isEmittableId(id) && !ids.includes(id)) ids.push(id);
+  }
+  if (ids.length === 0) return "";
+
+  const lines = [
+    RESOURCE_PRIORITY_BEGIN,
+    `<!-- order: ${JSON.stringify(ids)} -->`,
+    PRIORITY_BLOCK_HEADING,
+    PRIORITY_BLOCK_PROSE,
+  ];
+
+  ids.forEach((id, index) => {
+    const entry = entriesById.get(id);
+    const rank = `${String(index + 1)}.`;
+    if (entry) {
+      lines.push(`${rank} ${describeEntry(entry)}`);
+      return;
+    }
+    const recovered = recoveredDescriptions?.get(id);
+    lines.push(
+      recovered
+        ? // Re-sanitized because the document is hand-editable; on text this
+          // module emitted, sanitization is a byte-identical no-op.
+          `${rank} ${sanitizePromptText(recovered)}`
+        : `${rank} ${sanitizePromptText(id)} — ${MISSING_FROM_LIVE_SUFFIX}`
+    );
+  });
+
+  lines.push(RESOURCE_PRIORITY_END);
+  return lines.join("\n");
+}
+
+// Every line this module can emit between the two markers. An orphaned
+// opening marker is repaired by replacing the marker AND whatever generated
+// body still trails it, and "generated" is judged byte-for-byte against this
+// vocabulary — so the repair can never swallow a line a human wrote.
+const GENERATED_BODY_LINES = new Set<string>([
+  PRIORITY_BLOCK_HEADING,
+  ...PRIORITY_BLOCK_PROSE.split("\n"),
+]);
+const ORDER_COMMENT_LINE_RE = /^<!--\s*order:.*-->$/;
+const RANKED_LIST_LINE_RE = /^\d+\.\s/;
+
+/**
+ * End of the generated body that trails an orphaned opening marker at `from`.
+ *
+ * Consumes whole lines while each one is something this module emits, and
+ * stops at the first line that isn't — a blank line, hand-written prose, a
+ * heading. That keeps the stale half-block out of the prompt (two contradictory
+ * ranked lists would be worse than one) while making it impossible to delete
+ * anything a human typed. When the order comment survived the hand-edit it is
+ * inside these bounds too, so the ranking itself is recovered rather than
+ * reported corrupt.
+ *
+ * A numbered line only counts as generated once a distinctive block line (the
+ * heading, the order comment, or a prose line) has been seen: `1. anything`
+ * matches the ranked-list shape, and a user who kept the leftover marker but
+ * hand-wrote their own list directly beneath it must not have it absorbed.
+ */
+function orphanRemnantEnd(document: string, from: number): number {
+  let cursor = from;
+  let blockBodySeen = false;
+  while (cursor < document.length) {
+    const lineBreak = /^(\r\n|\n|\r)/.exec(document.slice(cursor));
+    if (!lineBreak?.[0]) break;
+    const lineStart = cursor + lineBreak[0].length;
+    const newlineAt = document.indexOf("\n", lineStart);
+    const lineEnd = newlineAt === -1 ? document.length : newlineAt;
+    const line = document.slice(lineStart, lineEnd).replace(/\r$/, "");
+    if (GENERATED_BODY_LINES.has(line) || ORDER_COMMENT_LINE_RE.test(line)) {
+      blockBodySeen = true;
+    } else if (!blockBodySeen || !RANKED_LIST_LINE_RE.test(line)) {
+      break;
+    }
+    cursor = lineEnd;
+  }
+  return cursor;
+}
+
+/** Bounds of the generated block, `end` exclusive so the pair is slice-ready. */
+export interface PriorityBlockBounds {
+  start: number;
+  end: number;
+  /**
+   * The opening marker had no closing marker in its own section, so the span
+   * covers the leftover marker plus whatever generated body still trails it.
+   * See `findPriorityBlock`.
+   */
+  orphan: boolean;
+}
+
+/**
+ * Char offsets of the block in `document`, markers included. The markers are
+ * single-line literals, so a CRLF document needs no special handling. Only the
+ * first block is recognized — a document with two is already hand-mangled, and
+ * rewriting the first keeps behavior predictable.
+ *
+ * The closing marker is searched only as far as the next slot heading. A `## `
+ * label is where the worker's parser stops too, so a stray closing marker left
+ * in a later section can never make the bounds swallow the sections between.
+ *
+ * An opening marker with no closing marker in that window is an ORPHAN — what
+ * a user produces by selecting from inside the block through the closing
+ * marker and deleting it in the markdown editor. Reporting "no block" there
+ * would be a data-loss trap: the next apply would nest a SECOND block below
+ * the orphan, and the apply after that would replace everything from the
+ * orphan to the new block's closing marker — silently eating whatever
+ * hand-written Tool Guidance sat between them. So the orphan marker and the
+ * generated lines still trailing it are the extent (see `orphanRemnantEnd`):
+ * the next write replaces only text this module itself emitted, never prose,
+ * and the document comes back well-formed.
+ */
+export function findPriorityBlock(
+  document: string
+): PriorityBlockBounds | null {
+  const start = document.indexOf(RESOURCE_PRIORITY_BEGIN);
+  if (start === -1) return null;
+
+  const searchFrom = start + RESOURCE_PRIORITY_BEGIN.length;
+  const limit = nextSlotHeadingStart(document, searchFrom);
+  const endMarker = document.indexOf(RESOURCE_PRIORITY_END, searchFrom);
+  if (endMarker === -1 || endMarker >= limit) {
+    return { start, end: orphanRemnantEnd(document, searchFrom), orphan: true };
+  }
+  return {
+    start,
+    end: endMarker + RESOURCE_PRIORITY_END.length,
+    orphan: false,
+  };
+}
+
+/**
+ * The stored order, or `null` when the document has no block at all.
+ *
+ * `"corrupt"` means a block is there but the order line isn't readable — a
+ * hand-edit, most likely, including an orphaned opening marker whose order
+ * line went with the closing one. (When the order line survived, it is inside
+ * the orphan's bounds and the ranking is recovered normally.) The caller
+ * treats corrupt as unconfigured but must NOT rewrite the document behind the
+ * user's back: the panel surfaces a "couldn't read the saved ordering" notice
+ * offering Reset instead, and the next deliberate apply repairs the block.
+ */
+export function parsePriorityOrder(
+  document: string
+): string[] | null | "corrupt" {
+  const bounds = findPriorityBlock(document);
+  if (!bounds) return null;
+
+  const match = ORDER_COMMENT_RE.exec(document.slice(bounds.start, bounds.end));
+  if (!match?.[1]) return "corrupt";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    return "corrupt";
+  }
+  if (!Array.isArray(parsed)) return "corrupt";
+  if (!parsed.every((id): id is string => typeof id === "string")) {
+    return "corrupt";
+  }
+  return parsed;
+}
+
+/**
+ * The description each ranked id currently carries in the document's block,
+ * keyed by id — what lets a regeneration preserve the human-readable line for
+ * an id the live aggregation can't resolve (see `generatePriorityBlock`).
+ *
+ * Ids and list lines pair by position, and only when they pair exactly: a
+ * hand-edit that broke the 1:1 correspondence recovers nothing rather than
+ * risk attributing one resource's description to another.
+ */
+export function parsePriorityDescriptions(
+  document: string
+): Map<string, string> {
+  const recovered = new Map<string, string>();
+  const bounds = findPriorityBlock(document);
+  if (!bounds) return recovered;
+  const order = parsePriorityOrder(document);
+  if (!Array.isArray(order)) return recovered;
+
+  const descriptions = document
+    .slice(bounds.start, bounds.end)
+    .split(/\r?\n/)
+    .map((line) => /^\d+\.\s+(.*)$/.exec(line)?.[1]?.trim())
+    .filter((text): text is string => text !== undefined && text.length > 0);
+  if (descriptions.length !== order.length) return recovered;
+
+  order.forEach((id, index) => {
+    const text = descriptions[index];
+    if (text) recovered.set(id, text);
+  });
+  return recovered;
+}
+
+// The worker's parser splits on the seven exact `## <label>` lines and nothing
+// else, so those — and only those — are section boundaries here too. A
+// `## Notes` heading someone added inside Tool Guidance is section content,
+// and the block has to land after it.
+const SLOT_HEADING_LABELS = new Set(
+  PROMPT_SLOTS.map((slot) => SLOT_LABELS[slot])
+);
+
+// Where a synthesized `## Tool Guidance` heading goes when the document has
+// none: immediately before the first of the slots that follow it, so the block
+// keeps its prompt position instead of landing after the closing.
+const HEADINGS_AFTER_TOOL_GUIDANCE: PromptSlot[] = [
+  "instructions",
+  "client_instructions",
+  "memory_instructions",
+  "closing",
+];
+
+const SLOT_HEADING_RE = /^##[ \t]+(.+?)[ \t\r]*$/gm;
+
+interface SlotHeading {
+  label: string;
+  /** Char offset of the `#` that opens the line. */
+  start: number;
+}
+
+/**
+ * Offset of the first slot heading at or after `from`, or the end of the
+ * document. This is the horizon for anything that scans forward from inside a
+ * section: the worker's parser treats these lines as hard boundaries, so we
+ * must not reach across one either.
+ */
+function nextSlotHeadingStart(document: string, from: number): number {
+  for (const heading of findSlotHeadings(document)) {
+    if (heading.start >= from) return heading.start;
+  }
+  return document.length;
+}
+
+function findSlotHeadings(document: string): SlotHeading[] {
+  const headings: SlotHeading[] = [];
+  SLOT_HEADING_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SLOT_HEADING_RE.exec(document)) !== null) {
+    const label = match[1];
+    if (label && SLOT_HEADING_LABELS.has(label)) {
+      headings.push({ label, start: match.index });
+    }
+  }
+  return headings;
+}
+
+/** Match the document's own line endings, so a CRLF document stays CRLF. */
+function newlineOf(document: string): string {
+  return document.includes("\r\n") ? "\r\n" : "\n";
+}
+
+/**
+ * Join `content` between `head` and `tail`, separated from each by exactly one
+ * blank line — the same spacing the removal path collapses back to, which is
+ * what lets a configure-then-remove round trip return the original document.
+ */
+function joinAround(
+  head: string,
+  content: string,
+  tail: string,
+  newline: string
+): string {
+  const body = newline === "\n" ? content : content.replace(/\n/g, newline);
+  const parts: string[] = [];
+  if (head) parts.push(head, newline, newline);
+  parts.push(body);
+  parts.push(tail ? `${newline}${newline}${tail}` : newline);
+  return parts.join("");
+}
+
+function insertAt(
+  document: string,
+  pos: number,
+  content: string,
+  newline: string
+): string {
+  return joinAround(
+    document.slice(0, pos).replace(/[ \t\r\n]+$/, ""),
+    content,
+    document.slice(pos).replace(/^[ \t\r\n]+/, ""),
+    newline
+  );
+}
+
+/**
+ * Write `block` into `document`, or remove the block when `block` is `null`.
+ *
+ * An existing block is replaced where it stands, which is what makes the
+ * operation idempotent: `splice(splice(d, b), b) === splice(d, b)`. An
+ * orphaned opening marker counts as an existing block bounded to the marker
+ * itself, so writing over it repairs the document instead of nesting a second
+ * block below it. A first write lands at the END of the `## Tool Guidance`
+ * section — after whatever hand-written guidance is already there, before the
+ * next slot heading. When the document has no Tool Guidance section the
+ * heading is synthesized, since the worker discards anything ahead of the
+ * first recognized heading.
+ *
+ * Removal collapses the surrounding blank lines back to one, so a
+ * configure-then-remove round trip returns the canonical scaffold unchanged.
+ */
+export function splicePriorityBlock(
+  document: string,
+  block: string | null
+): string {
+  const newline = newlineOf(document);
+  const existing = findPriorityBlock(document);
+
+  if (existing) {
+    const head = document.slice(0, existing.start).replace(/[ \t\r\n]+$/, "");
+    const tail = document.slice(existing.end).replace(/^[ \t\r\n]+/, "");
+    if (block === null || block.length === 0) {
+      if (!head) return tail;
+      return tail ? `${head}${newline}${newline}${tail}` : `${head}${newline}`;
+    }
+    return joinAround(head, block, tail, newline);
+  }
+
+  if (block === null || block.length === 0) return document;
+
+  const headings = findSlotHeadings(document);
+  const toolGuidanceIndex = headings.findIndex(
+    (heading) => heading.label === SLOT_LABELS.tool_guidance
+  );
+
+  if (toolGuidanceIndex !== -1) {
+    const next = headings[toolGuidanceIndex + 1];
+    return insertAt(
+      document,
+      next ? next.start : document.length,
+      block,
+      newline
+    );
+  }
+
+  // No Tool Guidance section: synthesize the heading with the block under it.
+  const withHeading = `## ${SLOT_LABELS.tool_guidance}\n\n${block}`;
+  const successorLabels = new Set(
+    HEADINGS_AFTER_TOOL_GUIDANCE.map((slot) => SLOT_LABELS[slot])
+  );
+  const successor = headings.find((heading) =>
+    successorLabels.has(heading.label)
+  );
+  return insertAt(
+    document,
+    successor ? successor.start : document.length,
+    withHeading,
+    newline
+  );
+}

--- a/tests/resource-priority.test.ts
+++ b/tests/resource-priority.test.ts
@@ -1,0 +1,735 @@
+import { describe, expect, it } from "vitest";
+
+import { MODE_DOCUMENT_SCAFFOLD } from "../src/lib/mode-scaffold";
+import {
+  RESOURCE_PRIORITY_BEGIN,
+  RESOURCE_PRIORITY_END,
+  buildPriorityEntries,
+  findPriorityBlock,
+  generatePriorityBlock,
+  mergeOrderWithLive,
+  parsePriorityDescriptions,
+  parsePriorityOrder,
+  resourceEntryId,
+  sanitizePromptText,
+  splicePriorityBlock,
+} from "../src/lib/resource-priority";
+import type { PriorityEntry } from "../src/lib/resource-priority";
+import type {
+  AggregatedResourcesResponse,
+  ResourceItem,
+  ResourceServerReport,
+} from "../src/types/resources";
+
+function entry(
+  id: string,
+  label: string,
+  serverName: string,
+  subjectLabelText = "Bible Translations"
+): PriorityEntry {
+  return { id, label, serverName, subjectLabelText };
+}
+
+function byId(entries: PriorityEntry[]): Map<string, PriorityEntry> {
+  return new Map(entries.map((e) => [e.id, e]));
+}
+
+const ULT = entry(
+  "translation-helps:en_ult",
+  "unfoldingWord Literal Text",
+  "translation-helps"
+);
+const STUDY_NOTES = entry(
+  "aquifer:BiblicaStudyNotes",
+  "Biblica Study Notes",
+  "aquifer",
+  "Study Notes"
+);
+const ORDER = [ULT.id, STUDY_NOTES.id];
+const BLOCK = generatePriorityBlock(ORDER, byId([ULT, STUDY_NOTES]));
+
+function server(serverId: string, serverName: string): ResourceServerReport {
+  return { serverId, serverName, status: "ok" };
+}
+
+function item(
+  serverId: string,
+  name: string,
+  subject: string,
+  label?: string
+): ResourceItem {
+  return { serverId, name, subject, label };
+}
+
+function response(
+  servers: ResourceServerReport[],
+  resources: Record<string, ResourceItem[]>
+): AggregatedResourcesResponse {
+  return { org: "uw", language: "en", servers, resources };
+}
+
+describe("resourceEntryId", () => {
+  it("composes the server-scoped identity used as the React key", () => {
+    expect(resourceEntryId(item("aquifer", "BiblicaStudyNotes", "bible"))).toBe(
+      "aquifer:BiblicaStudyNotes"
+    );
+  });
+});
+
+describe("sanitizePromptText", () => {
+  it("removes Ulysses paragraph-comment markers", () => {
+    // `%%` truncates the rest of its line at prompt time — a resource label
+    // carrying one would silently delete every entry after it.
+    expect(sanitizePromptText("uW ULT %% internal note")).not.toContain("%%");
+  });
+
+  it("removes Ulysses inline-span markers", () => {
+    expect(sanitizePromptText("uW ++draft++ ULT")).toBe("uW draft ULT");
+  });
+
+  it("re-runs until no marker survives, so removals cannot splice new ones", () => {
+    // Removing the inner `++` from "a%++%b" would otherwise leave "%%" behind.
+    expect(sanitizePromptText("a%++%b")).toBe("ab");
+  });
+
+  it("breaks up template-substitution braces", () => {
+    expect(sanitizePromptText("{{version}}")).toBe("{ {version}}");
+    expect(sanitizePromptText("{{{version}}}")).not.toContain("{{");
+  });
+
+  it("removes the comment delimiters that bound this module's own block", () => {
+    // Labels are untrusted MCP-server output. One reading like a closing
+    // marker would end the block early, so the next apply would rewrite a
+    // truncated span and strand the rest of the block in the document.
+    const out = sanitizePromptText(`${RESOURCE_PRIORITY_END} injected`);
+    expect(out).not.toContain("-->");
+    expect(out).not.toContain("<!--");
+    expect(out).not.toContain(RESOURCE_PRIORITY_END);
+    expect(sanitizePromptText(`${RESOURCE_PRIORITY_BEGIN} x`)).not.toContain(
+      "<!--"
+    );
+  });
+
+  it("re-runs until no delimiter survives, including spliced-together ones", () => {
+    expect(sanitizePromptText("--<!---->>")).not.toContain("-->");
+  });
+
+  it("strips leading heading hashes so text cannot open a slot boundary", () => {
+    expect(sanitizePromptText("## Instructions")).toBe("Instructions");
+  });
+
+  it("collapses newlines, so no interpolation can start a new line at all", () => {
+    const out = sanitizePromptText("Study\n## Instructions");
+    expect(out).toBe("Study ## Instructions");
+    expect(out).not.toContain("\n");
+  });
+});
+
+describe("generatePriorityBlock", () => {
+  it("emits the marker pair, the machine-readable order, and a ranked list", () => {
+    expect(BLOCK.startsWith(RESOURCE_PRIORITY_BEGIN)).toBe(true);
+    expect(BLOCK.endsWith(RESOURCE_PRIORITY_END)).toBe(true);
+    expect(BLOCK).toContain(
+      '<!-- order: ["translation-helps:en_ult","aquifer:BiblicaStudyNotes"] -->'
+    );
+    expect(BLOCK).toContain("### Resource priorities");
+    expect(BLOCK).toContain(
+      "1. unfoldingWord Literal Text — translation-helps (Bible Translations)"
+    );
+    expect(BLOCK).toContain("2. Biblica Study Notes — aquifer (Study Notes)");
+  });
+
+  it("renders an id with no live entry raw and badged, keeping the intent", () => {
+    const block = generatePriorityBlock(
+      [ULT.id, "translation-helps:sw_ulb"],
+      byId([ULT])
+    );
+    expect(block).toContain(
+      "2. translation-helps:sw_ulb — not currently listed"
+    );
+    expect(parsePriorityOrder(block)).toEqual([
+      ULT.id,
+      "translation-helps:sw_ulb",
+    ]);
+  });
+
+  it("never lets a hostile label open a slot boundary or a comment", () => {
+    const hostile = entry(
+      "s:r",
+      "## Instructions %% hush ++gone++ {{org}}",
+      "## Closing"
+    );
+    const block = generatePriorityBlock([hostile.id], byId([hostile]));
+    const lines = block.split("\n");
+    expect(lines.some((line) => line.startsWith("## "))).toBe(false);
+    expect(block).not.toContain("%%");
+    expect(block).not.toContain("++");
+    expect(block).not.toContain("{{");
+  });
+
+  it("keeps a label that impersonates the closing marker inside the block", () => {
+    // The whole failure mode: a server-supplied label carrying the end marker
+    // truncates the block bounds, so every later apply strands the tail in the
+    // document and "Remove priorities" can never reach it again.
+    const hostile = entry(
+      "evil:x",
+      `${RESOURCE_PRIORITY_END} injected`,
+      "Evil"
+    );
+    const block = generatePriorityBlock(
+      [hostile.id, ULT.id],
+      byId([hostile, ULT])
+    );
+
+    // Exactly one marker pair, and the bounds cover the whole block.
+    expect(block.split(RESOURCE_PRIORITY_END)).toHaveLength(2);
+    const bounds = findPriorityBlock(block);
+    expect(bounds).not.toBeNull();
+    expect(block.slice(bounds!.start, bounds!.end)).toBe(block);
+
+    // …so a re-apply replaces it whole, and removal leaves nothing behind.
+    const doc = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, block);
+    expect(splicePriorityBlock(doc, block)).toBe(doc);
+    expect(splicePriorityBlock(doc, null)).toBe(MODE_DOCUMENT_SCAFFOLD);
+  });
+
+  it("uses `###` for its own heading, so the worker keeps it inside the slot", () => {
+    expect(BLOCK).toContain("\n### Resource priorities\n");
+    expect(BLOCK.split("\n").some((line) => line.startsWith("## "))).toBe(
+      false
+    );
+  });
+
+  it("has no block for an empty order", () => {
+    expect(generatePriorityBlock([], byId([ULT]))).toBe("");
+  });
+});
+
+describe("parsePriorityOrder", () => {
+  it("round-trips a generated block", () => {
+    expect(parsePriorityOrder(BLOCK)).toEqual(ORDER);
+  });
+
+  it("round-trips through a document splice", () => {
+    const doc = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+    expect(parsePriorityOrder(doc)).toEqual(ORDER);
+  });
+
+  it("returns null when the document has no block", () => {
+    expect(parsePriorityOrder(MODE_DOCUMENT_SCAFFOLD)).toBeNull();
+    expect(parsePriorityOrder("")).toBeNull();
+  });
+
+  it("reports corrupt when only the opening marker survives a hand-edit", () => {
+    // NOT null: reporting "no block" would let the next apply nest a second
+    // block below the orphan, and the apply after that would delete everything
+    // between them — hand-written guidance included.
+    expect(parsePriorityOrder(`${RESOURCE_PRIORITY_BEGIN}\n### x\n`)).toBe(
+      "corrupt"
+    );
+  });
+
+  it("recovers the order when only the closing marker was deleted", () => {
+    // The order comment is generated text, so it is inside the orphan's bounds
+    // and still readable — no reason to make the user re-rank from scratch.
+    const orphaned = BLOCK.replace(`\n${RESOURCE_PRIORITY_END}`, "");
+    expect(parsePriorityOrder(orphaned)).toEqual(ORDER);
+  });
+
+  it("reports corrupt when the order line is missing", () => {
+    const doc = `${RESOURCE_PRIORITY_BEGIN}\n### Resource priorities\n1. something\n${RESOURCE_PRIORITY_END}`;
+    expect(parsePriorityOrder(doc)).toBe("corrupt");
+  });
+
+  it("reports corrupt when the order line is not valid JSON", () => {
+    const doc = `${RESOURCE_PRIORITY_BEGIN}\n<!-- order: [oops] -->\n${RESOURCE_PRIORITY_END}`;
+    expect(parsePriorityOrder(doc)).toBe("corrupt");
+  });
+
+  it("reports corrupt when the JSON is not a list of ids", () => {
+    const notArray = `${RESOURCE_PRIORITY_BEGIN}\n<!-- order: ["a" -->\n${RESOURCE_PRIORITY_END}`;
+    const notStrings = `${RESOURCE_PRIORITY_BEGIN}\n<!-- order: [1,2] -->\n${RESOURCE_PRIORITY_END}`;
+    expect(parsePriorityOrder(notArray)).toBe("corrupt");
+    expect(parsePriorityOrder(notStrings)).toBe("corrupt");
+  });
+});
+
+describe("findPriorityBlock", () => {
+  it("bounds the block by its markers, slice-ready", () => {
+    const doc = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+    const bounds = findPriorityBlock(doc);
+    expect(bounds).not.toBeNull();
+    expect(bounds!.orphan).toBe(false);
+    expect(doc.slice(bounds!.start, bounds!.end)).toBe(BLOCK);
+  });
+
+  it("never reaches past a slot heading for the closing marker", () => {
+    // A stray closing marker in a later section must not make the bounds
+    // swallow the sections in between.
+    const doc = [
+      "## Tool Guidance",
+      "",
+      RESOURCE_PRIORITY_BEGIN,
+      "",
+      "## Instructions",
+      "",
+      "Be brief.",
+      "",
+      RESOURCE_PRIORITY_END,
+      "",
+    ].join("\n");
+
+    const bounds = findPriorityBlock(doc);
+    expect(bounds).not.toBeNull();
+    expect(bounds!.orphan).toBe(true);
+    expect(doc.slice(bounds!.start, bounds!.end)).toBe(RESOURCE_PRIORITY_BEGIN);
+  });
+
+  it("absorbs the generated remnant of an orphan, and nothing else", () => {
+    const doc = [
+      RESOURCE_PRIORITY_BEGIN,
+      "### Resource priorities",
+      "1. stale line",
+      "",
+      "Always cite the passage reference before quoting.",
+      "",
+    ].join("\n");
+
+    const bounds = findPriorityBlock(doc);
+    expect(doc.slice(bounds!.start, bounds!.end)).toBe(
+      `${RESOURCE_PRIORITY_BEGIN}\n### Resource priorities\n1. stale line`
+    );
+  });
+});
+
+describe("splicePriorityBlock", () => {
+  it("lands at the end of Tool Guidance in the canonical scaffold", () => {
+    const doc = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+    expect(doc).toBe(
+      `## Identity\n\n## Teaching Methodology\n\n## Tool Guidance\n\n${BLOCK}\n\n## Instructions\n\n## Client Instructions\n\n## Memory Instructions\n\n## Closing\n\n`
+    );
+  });
+
+  it("keeps hand-written guidance above it, and non-slot `##` headings inside the section", () => {
+    // Only the seven exact slot labels are boundaries for the worker's
+    // parser, so a `## Notes` heading is Tool Guidance content — the block
+    // belongs after it, not before.
+    const doc = [
+      "## Tool Guidance",
+      "",
+      "Prefer the search tool.",
+      "",
+      "## Notes",
+      "",
+      "Scratch notes.",
+      "",
+      "## Instructions",
+      "",
+      "Be brief.",
+      "",
+    ].join("\n");
+
+    const out = splicePriorityBlock(doc, BLOCK);
+    expect(out).toBe(
+      [
+        "## Tool Guidance",
+        "",
+        "Prefer the search tool.",
+        "",
+        "## Notes",
+        "",
+        "Scratch notes.",
+        "",
+        BLOCK,
+        "",
+        "## Instructions",
+        "",
+        "Be brief.",
+        "",
+      ].join("\n")
+    );
+  });
+
+  it("appends at document end when Tool Guidance is the last section", () => {
+    const doc = "## Identity\n\nWho.\n\n## Tool Guidance\n\nPrefer search.\n";
+    expect(splicePriorityBlock(doc, BLOCK)).toBe(
+      `## Identity\n\nWho.\n\n## Tool Guidance\n\nPrefer search.\n\n${BLOCK}\n`
+    );
+  });
+
+  it("synthesizes the heading before the first following slot when Tool Guidance is missing", () => {
+    // Content before the first recognized heading is discarded by the worker,
+    // so the block always arrives under a heading of its own.
+    const doc = "## Identity\n\nWho.\n\n## Instructions\n\nBe brief.\n";
+    expect(splicePriorityBlock(doc, BLOCK)).toBe(
+      `## Identity\n\nWho.\n\n## Tool Guidance\n\n${BLOCK}\n\n## Instructions\n\nBe brief.\n`
+    );
+  });
+
+  it("synthesizes the heading at the end when no following slot is present either", () => {
+    const doc = "## Identity\n\nWho.\n";
+    expect(splicePriorityBlock(doc, BLOCK)).toBe(
+      `## Identity\n\nWho.\n\n## Tool Guidance\n\n${BLOCK}\n`
+    );
+  });
+
+  it("is idempotent — a re-applied identical block replaces itself in place", () => {
+    const once = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+    expect(splicePriorityBlock(once, BLOCK)).toBe(once);
+  });
+
+  it("replaces an existing block where it stands rather than adding a second", () => {
+    const once = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+    const reordered = generatePriorityBlock(
+      [STUDY_NOTES.id, ULT.id],
+      byId([ULT, STUDY_NOTES])
+    );
+    const out = splicePriorityBlock(once, reordered);
+
+    expect(out.indexOf(RESOURCE_PRIORITY_BEGIN)).toBe(
+      once.indexOf(RESOURCE_PRIORITY_BEGIN)
+    );
+    expect(out.split(RESOURCE_PRIORITY_BEGIN)).toHaveLength(2);
+    expect(parsePriorityOrder(out)).toEqual([STUDY_NOTES.id, ULT.id]);
+  });
+
+  it("regenerates a hand-edited interior wholesale on the next apply", () => {
+    const once = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+    const tampered = once.replace(
+      "### Resource priorities",
+      "### Hand edited\n\nnonsense someone typed"
+    );
+    expect(tampered).not.toBe(once);
+
+    const out = splicePriorityBlock(tampered, BLOCK);
+    expect(out).not.toContain("nonsense someone typed");
+    expect(out).toBe(once);
+  });
+
+  it("repairs an orphaned opening marker instead of nesting a second block", () => {
+    // Reachable by selecting from inside the block through the closing marker
+    // and deleting it in the markdown editor: the opening marker survives.
+    const mangled = [
+      "## Tool Guidance",
+      "",
+      RESOURCE_PRIORITY_BEGIN,
+      "### Resource priorities",
+      "1. stale line",
+      "",
+      "Always cite the passage reference before quoting.",
+      "",
+      "## Instructions",
+      "",
+      "Be brief.",
+      "",
+    ].join("\n");
+
+    const repaired = splicePriorityBlock(mangled, BLOCK);
+
+    // One block, the user's prose intact, and stable from here on.
+    expect(repaired.split(RESOURCE_PRIORITY_BEGIN)).toHaveLength(2);
+    expect(repaired.split(RESOURCE_PRIORITY_END)).toHaveLength(2);
+    expect(repaired).toContain(
+      "Always cite the passage reference before quoting."
+    );
+    expect(repaired).not.toContain("1. stale line");
+    expect(parsePriorityOrder(repaired)).toEqual(ORDER);
+    expect(splicePriorityBlock(repaired, BLOCK)).toBe(repaired);
+  });
+
+  it("removes an orphaned opening marker without touching the prose", () => {
+    const mangled = [
+      "## Tool Guidance",
+      "",
+      RESOURCE_PRIORITY_BEGIN,
+      "",
+      "Always cite the passage reference before quoting.",
+      "",
+    ].join("\n");
+
+    expect(splicePriorityBlock(mangled, null)).toBe(
+      "## Tool Guidance\n\nAlways cite the passage reference before quoting.\n"
+    );
+  });
+
+  it("removes the block and collapses the blank lines it sat between", () => {
+    const once = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+    expect(splicePriorityBlock(once, null)).toBe(MODE_DOCUMENT_SCAFFOLD);
+    // An empty generated block (empty order) is the same instruction.
+    expect(splicePriorityBlock(once, "")).toBe(MODE_DOCUMENT_SCAFFOLD);
+  });
+
+  it("removes a block that is the whole document without leaving stray blank lines", () => {
+    expect(splicePriorityBlock(BLOCK, null)).toBe("");
+    expect(splicePriorityBlock(`${BLOCK}\n`, null)).toBe("");
+  });
+
+  it("leaves a document with no block untouched on removal", () => {
+    expect(splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, null)).toBe(
+      MODE_DOCUMENT_SCAFFOLD
+    );
+  });
+
+  it("keeps a CRLF document on CRLF, both writing and removing", () => {
+    const crlf = MODE_DOCUMENT_SCAFFOLD.replace(/\n/g, "\r\n");
+    const out = splicePriorityBlock(crlf, BLOCK);
+
+    // Every LF is part of a CRLF pair — no mixed endings were introduced.
+    expect(out.split("\n")).toHaveLength(out.split("\r\n").length);
+    expect(parsePriorityOrder(out)).toEqual(ORDER);
+    expect(out.indexOf(RESOURCE_PRIORITY_BEGIN)).toBeGreaterThan(
+      out.indexOf("## Tool Guidance")
+    );
+    expect(out.indexOf(RESOURCE_PRIORITY_END)).toBeLessThan(
+      out.indexOf("## Instructions")
+    );
+    expect(splicePriorityBlock(out, BLOCK)).toBe(out);
+    expect(splicePriorityBlock(out, null)).toBe(crlf);
+  });
+});
+
+describe("buildPriorityEntries", () => {
+  it("flattens the by-subject map in response order, resolving names and labels", () => {
+    const entries = buildPriorityEntries(
+      response(
+        [
+          server("translation-helps", "Translation Helps"),
+          server("aquifer", "Aquifer"),
+        ],
+        {
+          bible: [
+            item("translation-helps", "en_ult", "bible"),
+            item("aquifer", "NIV", "bible", "New International Version"),
+          ],
+          "study-notes": [
+            item(
+              "aquifer",
+              "BiblicaStudyNotes",
+              "study-notes",
+              "Biblica Study Notes"
+            ),
+          ],
+        }
+      )
+    );
+
+    expect(entries.map((e) => e.id)).toEqual([
+      "translation-helps:en_ult",
+      "aquifer:NIV",
+      "aquifer:BiblicaStudyNotes",
+    ]);
+    // `label ?? name`, and the subject's display form, not the raw slug.
+    expect(entries[0]!.label).toBe("en_ult");
+    expect(entries[0]!.serverName).toBe("Translation Helps");
+    expect(entries[0]!.subjectLabelText).toBe("Bible Translations");
+    expect(entries[1]!.label).toBe("New International Version");
+    expect(entries[2]!.subjectLabelText).toBe("Study Notes");
+  });
+
+  it("humanizes an unknown subject slug rather than dropping the resource", () => {
+    // The canonical subject set is open by contract (worker#257).
+    const entries = buildPriorityEntries(
+      response([server("fia", "FIA")], {
+        "prayer-guides": [item("fia", "guide", "prayer-guides")],
+      })
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.subjectLabelText).toBe("Prayer Guides");
+  });
+
+  it("falls back to the server id when no report names the server", () => {
+    const entries = buildPriorityEntries(
+      response([], { bible: [item("orphan", "x", "bible")] })
+    );
+    expect(entries[0]!.serverName).toBe("orphan");
+  });
+
+  it("keeps the first occurrence when an id surfaces under two subjects", () => {
+    const entries = buildPriorityEntries(
+      response([server("a", "A")], {
+        bible: [item("a", "dup", "bible")],
+        dictionary: [item("a", "dup", "dictionary")],
+      })
+    );
+    expect(entries.map((e) => e.subjectLabelText)).toEqual([
+      "Bible Translations",
+    ]);
+  });
+});
+
+describe("mergeOrderWithLive", () => {
+  const live = [ULT, STUDY_NOTES, entry("aquifer:Images", "Images", "aquifer")];
+
+  it("preserves the stored sequence and appends new live resources at the bottom", () => {
+    const { entries } = mergeOrderWithLive([STUDY_NOTES.id, ULT.id], live);
+    expect(entries.map((e) => e.id)).toEqual([
+      STUDY_NOTES.id,
+      ULT.id,
+      "aquifer:Images",
+    ]);
+    expect(entries.every((e) => !e.missing)).toBe(true);
+  });
+
+  it("keeps every live resource when nothing is stored yet, in server-default order", () => {
+    const { entries } = mergeOrderWithLive([], live);
+    expect(entries.map((e) => e.id)).toEqual(live.map((e) => e.id));
+  });
+
+  it("flags a stored id the live response no longer lists, without dropping it", () => {
+    // Stored order is intent, not a snapshot: a language switch or a server
+    // outage must not silently erase someone's ranking.
+    const { entries } = mergeOrderWithLive(
+      ["translation-helps:sw_ulb", ULT.id],
+      [ULT]
+    );
+    expect(entries.map((e) => e.id)).toEqual([
+      "translation-helps:sw_ulb",
+      ULT.id,
+    ]);
+    expect(entries[0]!.missing).toBe(true);
+    expect(entries[0]!.label).toBe("translation-helps:sw_ulb");
+    expect(entries[1]!.missing).toBe(false);
+  });
+
+  it("carries an unknown-subject live entry through untouched", () => {
+    const odd = entry("fia:guide", "Prayer Guide", "FIA", "Prayer Guides");
+    const { entries } = mergeOrderWithLive([odd.id], [odd]);
+    expect(entries).toEqual([{ ...odd, missing: false }]);
+  });
+
+  it("splits the ranking from the rest of the catalog", () => {
+    // The stored order is INTENT — a sparse list. Only `ranked` may be written
+    // back, or one Apply would freeze the whole catalog into the prompt and
+    // every language switch would grow it again.
+    const { ranked, unranked, entries } = mergeOrderWithLive([ULT.id], live);
+    expect(ranked.map((e) => e.id)).toEqual([ULT.id]);
+    expect(unranked.map((e) => e.id)).toEqual([
+      STUDY_NOTES.id,
+      "aquifer:Images",
+    ]);
+    expect(entries).toEqual([...ranked, ...unranked]);
+  });
+
+  it("ranks nothing when the order is empty, whatever is live", () => {
+    const { ranked, unranked } = mergeOrderWithLive([], live);
+    expect(ranked).toEqual([]);
+    expect(unranked.map((e) => e.id)).toEqual(live.map((e) => e.id));
+  });
+
+  it("keeps a missing stored id in the ranking, not in the candidates", () => {
+    const { ranked, unranked } = mergeOrderWithLive(
+      ["translation-helps:sw_ulb"],
+      [ULT]
+    );
+    expect(ranked.map((e) => e.id)).toEqual(["translation-helps:sw_ulb"]);
+    expect(ranked[0]!.missing).toBe(true);
+    expect(unranked.map((e) => e.id)).toEqual([ULT.id]);
+  });
+
+  it("ignores a duplicated stored id rather than ranking it twice", () => {
+    const { entries } = mergeOrderWithLive([ULT.id, ULT.id], [ULT]);
+    expect(entries.map((e) => e.id)).toEqual([ULT.id]);
+  });
+});
+
+describe("parsePriorityDescriptions", () => {
+  const doc = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+
+  it("recovers each ranked id's description line from the block", () => {
+    const recovered = parsePriorityDescriptions(doc);
+    expect(recovered.get(ULT.id)).toBe(
+      "unfoldingWord Literal Text — translation-helps (Bible Translations)"
+    );
+    expect(recovered.get(STUDY_NOTES.id)).toBe(
+      "Biblica Study Notes — aquifer (Study Notes)"
+    );
+  });
+
+  it("recovers nothing from a document without a block", () => {
+    expect(parsePriorityDescriptions(MODE_DOCUMENT_SCAFFOLD).size).toBe(0);
+  });
+
+  it("recovers nothing from a corrupt block", () => {
+    const broken = doc.replace(/<!-- order:.*-->/, "<!-- order: nonsense -->");
+    expect(parsePriorityOrder(broken)).toBe("corrupt");
+    expect(parsePriorityDescriptions(broken).size).toBe(0);
+  });
+
+  it("recovers nothing when a hand-edit broke the id-to-line pairing", () => {
+    // Pairing is positional; guessing over a mismatch could attribute one
+    // resource's description to another, which is worse than recovering none.
+    const oneLineGone = doc.replace(
+      "2. Biblica Study Notes — aquifer (Study Notes)\n",
+      ""
+    );
+    expect(parsePriorityDescriptions(oneLineGone).size).toBe(0);
+  });
+});
+
+describe("generatePriorityBlock with recovered descriptions", () => {
+  const doc = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, BLOCK);
+  const recovered = parsePriorityDescriptions(doc);
+
+  it("keeps a missing id's stored description instead of degrading to a raw id", () => {
+    // The panel enumerating another language (or a server outage) must not
+    // rewrite the prompt's ranked list to raw ids the moment someone applies
+    // for an unrelated reason.
+    const regenerated = generatePriorityBlock(ORDER, new Map(), recovered);
+    expect(regenerated).toContain(
+      "1. unfoldingWord Literal Text — translation-helps (Bible Translations)"
+    );
+    expect(regenerated).not.toContain("not currently listed");
+  });
+
+  it("regenerates byte-identically when nothing is live, so Apply stays disabled", () => {
+    // `unchanged` is document equality on the page: this identity is what
+    // keeps a freshly reopened panel (which resets enumeration to "en") from
+    // offering a destructive rewrite with zero user intent behind it.
+    const regenerated = generatePriorityBlock(ORDER, new Map(), recovered);
+    expect(splicePriorityBlock(doc, regenerated)).toBe(doc);
+  });
+
+  it("falls back to the raw id when the document never described it", () => {
+    const regenerated = generatePriorityBlock(
+      ["fia:new-guide"],
+      new Map(),
+      recovered
+    );
+    expect(regenerated).toContain("1. fia:new-guide — not currently listed");
+  });
+});
+
+describe("mergeOrderWithLive with recovered descriptions", () => {
+  it("labels a missing row with its stored description, not its raw id", () => {
+    const recovered = new Map([
+      ["translation-helps:sw_ulb", "Swahili ULB — translation-helps (Bible)"],
+    ]);
+    const { ranked } = mergeOrderWithLive(
+      ["translation-helps:sw_ulb"],
+      [],
+      recovered
+    );
+    expect(ranked[0]!.missing).toBe(true);
+    expect(ranked[0]!.label).toBe("Swahili ULB — translation-helps (Bible)");
+  });
+});
+
+describe("orphan repair vs hand-written lists", () => {
+  it("does not absorb a hand-written numbered list sitting directly under a leftover marker", () => {
+    // A user who deleted everything generated EXCEPT the marker, then wrote
+    // their own list beneath it, must not have that list eaten by the repair.
+    const doc = `## Tool Guidance\n\n${RESOURCE_PRIORITY_BEGIN}\n1. My own hand-written step\n2. Another hand-written step\n\n## Instructions\n\nBe brief.\n`;
+    const bounds = findPriorityBlock(doc);
+    expect(bounds?.orphan).toBe(true);
+    const repaired = splicePriorityBlock(doc, BLOCK);
+    expect(repaired).toContain("1. My own hand-written step");
+    expect(repaired).toContain("2. Another hand-written step");
+  });
+
+  it("still absorbs generated list lines once a block body line was seen", () => {
+    const doc = `## Tool Guidance\n\n${RESOURCE_PRIORITY_BEGIN}\n### Resource priorities\n1. stale generated line\n\nKeep me.\n\n## Instructions\n\nBe brief.\n`;
+    const repaired = splicePriorityBlock(doc, BLOCK);
+    expect(repaired).not.toContain("stale generated line");
+    expect(repaired).toContain("Keep me.");
+  });
+});

--- a/tests/resource-priority.test.ts
+++ b/tests/resource-priority.test.ts
@@ -714,6 +714,36 @@ describe("mergeOrderWithLive with recovered descriptions", () => {
   });
 });
 
+describe("order parse with hostile ids", () => {
+  it("round-trips an id containing a closing bracket", () => {
+    // JSON.stringify emits `["aquifer:Notes]"]` — a lazy regex would capture
+    // through the FIRST `]`, misreport the block as corrupt, and invite the
+    // user to "repair" away a healthy ranking.
+    const bracketed = entry("aquifer:Notes]", "Notes", "aquifer");
+    const ids = [bracketed.id, ULT.id];
+    const block = generatePriorityBlock(ids, byId([bracketed, ULT]));
+    const doc = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, block);
+    expect(parsePriorityOrder(doc)).toEqual(ids);
+  });
+
+  it("round-trips an id containing a quote", () => {
+    const quoted = entry('aquifer:"Notes"', "Notes", "aquifer");
+    const block = generatePriorityBlock([quoted.id], byId([quoted]));
+    const doc = splicePriorityBlock(MODE_DOCUMENT_SCAFFOLD, block);
+    expect(parsePriorityOrder(doc)).toEqual([quoted.id]);
+  });
+
+  it("round-trips in a CRLF document", () => {
+    const bracketed = entry("aquifer:Notes]", "Notes", "aquifer");
+    const block = generatePriorityBlock([bracketed.id], byId([bracketed]));
+    const doc = splicePriorityBlock(
+      MODE_DOCUMENT_SCAFFOLD.replace(/\n/g, "\r\n"),
+      block
+    );
+    expect(parsePriorityOrder(doc)).toEqual([bracketed.id]);
+  });
+});
+
 describe("orphan repair vs hand-written lists", () => {
   it("does not absorb a hand-written numbered list sitting directly under a leftover marker", () => {
     // A user who deleted everything generated EXCEPT the marker, then wrote


### PR DESCRIPTION
## Summary

Implements #277's ordering UI + system-prompt injection in one mechanism: the ranking is persisted as a **generated, delimited markdown block spliced into the tail of the mode document's `## Tool Guidance` section**. The document is both the storage and the injection — the worker's `parseModeDocument` carries the block into the `tool_guidance` slot, which `buildSystemPrompt` places immediately before the MCP tool catalog.

**Tracks #277** (deliberately not auto-closing: the issue's accuracy-testing item remains after merge). Design rationale + deltas from the #230 Q6 contract are on the issue ([design comment](https://github.com/unfoldingWord/bt-servant-admin-portal/issues/277#issuecomment-5242134570)).

## Why document-block injection

- The worker's `mergeExistingMode` whitelists mode fields — a structured `resourcePriority` field is silently dropped on the next PUT of an existing mode, and `toMarkdownView` never returns it (worker#257 item 2 is a single unused type stub). Document-block is the only zero-worker-change implementation of the 08-06 meeting's decision 5.
- Precedent: worker#306 already ships source-prioritization guidance to prod through the `tool_guidance` slot.
- Consequences exploited: **no new PromptMode field, no BFF authz change** (document edits already require the `edit` verb via `docChanged` — nothing new for `computeRequiredVerbsForPut` to model), **no export change** (the document rides along in export).

## What's in the box

- **`src/lib/resource-priority.ts`** (pure, DOM-free): block generate/parse/splice/merge. Sanitizes untrusted server output against the worker's prompt-time rewrites (Ulysses `%%`/`++` stripping, `{{ }}` template substitution), slot-boundary injection (leading `##`), and this module's own HTML-comment delimiters. Stored order is **intent** — a sparse id list in an `<!-- order: [...] -->` line; prose regenerates from live data, with descriptions recovered from the document for ids the current enumeration can't resolve (language switch / server outage never degrades the prompt or enables a no-intent Apply). Orphaned-marker repair absorbs only text the module itself emitted.
- **`src/components/resource-priority-panel.tsx`**: Sheet panel on the Modes page — Ranked/Not-ranked zones, keyboard-first reordering with aria-live narration and focus handoff, verbatim #277 expectation copy (no toggles anywhere), generated-block preview, honest degraded states per server.
- **`src/app/pages/modes.tsx`**: header button gated by edit rights (same sr-only denial idiom as the group-chat switch); Apply flushes through the existing save machinery on the same synchronous in-flight lock as the flag toggles; failed applies are recorded page-side (`priorityApplyError`) so closing the sheet can't forget an unsaved draft.
- **`tests/resource-priority.test.ts`**: 51 pure-lib tests — round-trip, both splice fallback arms, idempotence, CRLF, hostile-label sanitization, orphan repair vs hand-written lists, merge semantics, description recovery.

## Review pipeline already applied

Built through a multi-agent pipeline: two implement lanes → two adversarial review lenses (**8 confirmed findings fixed**, including two document-corruption paths: orphaned-marker data loss, and a server label smuggling the closing marker) → fix lane → independent re-verify (all 8 confirmed fixed) → manual pass resolving the re-verify's 4 residual findings (description recovery for missing ids, orphan list-line guard, page-owned apply error, comment fixes).

## Test plan

- `npm run lint` / `typecheck` / `build`: clean, zero warnings
- `vitest`: 29 files, **700/700** (+51 new in `tests/resource-priority.test.ts`)
- Manual (per-PR worker deploy): rank/reorder/unrank on a mode, Apply, verify the block lands under Tool Guidance in the editor; re-open panel → Apply disabled; Remove priorities restores the prior document; non-edit shepherd sees disabled button with reason