### PR TITLE
chore: bump gitleaks-action to v3 — last Node-20 action runtime (follow-up to #91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,11 @@ jobs:
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest
-    # gitleaks-action@v2 ships `runs.using: node20` and has no v3 release.
-    # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 transitions it onto Node 24 ahead of
-    # GitHub's Sep 16 2026 Node 20 removal. Drop this when v3 ships.
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
Follow-up to #91 (closed 2026-05-13 by PR #131). PR #131 moved six of the seven distinct actions to Node-24 majors and left one documented escape hatch: `gitleaks/gitleaks-action@v2` (Node 20) forced onto Node 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"`, with a comment saying "drop this when v3 ships." v3.0.0 shipped 2026-05-30; this PR drops it.

## Changes

- `gitleaks/gitleaks-action` **v2 → v3** on the `secret-scan` job — v3 declares `using: "node24"` natively ([release notes](https://github.com/gitleaks/gitleaks-action/releases/tag/v3.0.0): runtime migration only, "no changes to inputs, outputs, or behavior"). `GITHUB_TOKEN` / `GITLEAKS_LICENSE` passthrough unchanged.
- Removed the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` job env — with no Node-20 action left to force, it's inert, and it stops working after GitHub's Sept 16 2026 runtime removal anyway.

That closes out the last Node-20 action runtime in the repo before the Sept 16 hard cutover.

## Verified, not assumed

Every runtime claim checked by reading `action.yml` at the pinned tag (`gh api repos/<r>/contents/action.yml?ref=<tag>`): checkout@v6, setup-node@v6, github-script@v8, upload-artifact@v6 all already `node24`; gitleaks-action v2 = `node20`, v3 = `node24`. Full inventory: 19 `uses:` refs / 7 distinct actions across all 5 workflows.

Deliberately **not** bumped: newer majors now exist (checkout v7, setup-node v7, github-script v9, upload-artifact v7) but add zero Node-24 benefit while importing documented breaking changes (github-script v9 ESM `require` break; upload-artifact v7 `archive: false`). Optional hygiene for another day, not deprecation work.

`node-version` inputs (runner Node, all `22`) untouched — the other of the two distinct "Node versions" in CI.

## Validation

- `actionlint` v1.7.7: zero findings on all 5 workflows
- Triggers, job lists, secrets usage, deploy logic unchanged
- Diff: 1 file, +1/−6
