### PR TITLE
feat(#286): org default language — BFF pair + Languages-page control (worker#236 contract)

### DIFF
--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -5,7 +5,10 @@ import { Save } from "lucide-react";
 import { useBlocker } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
-import { decideContextChange } from "@/lib/context-org-guard";
+import {
+  contextSwitchReason,
+  decideContextChange,
+} from "@/lib/context-org-guard";
 import { computeLanguageDefaultState } from "@/lib/language-default-state";
 import {
   isDefaultBlockedDeleteError,
@@ -105,7 +108,7 @@ export function LanguagesPage() {
   // Queries / mutations
   const languagesQuery = useLanguages(contextOrg);
   const languageQuery = useLanguage(selectedLanguage, contextOrg);
-  const saveLanguage = useSaveLanguage(contextOrg);
+  const saveLanguage = useSaveLanguage();
   const deleteLanguage = useDeleteLanguage();
   const scaffoldQuery = useLanguageScaffold(contextOrg);
   // #286 — org default. Its own query rather than the list's
@@ -193,6 +196,8 @@ export function LanguagesPage() {
       saveLanguage.mutate(
         {
           name: selectedLanguage,
+          // Org pinned at call time — see handleSetDefault.
+          org: contextOrg,
           body: {
             label: serverLabel,
             document: doc,
@@ -211,7 +216,13 @@ export function LanguagesPage() {
         }
       );
     },
-    [lastSyncedPublished, saveLanguage, selectedLanguage, serverLabel]
+    [
+      contextOrg,
+      lastSyncedPublished,
+      saveLanguage,
+      selectedLanguage,
+      serverLabel,
+    ]
   );
 
   // Auto-save when debouncedDraft diverges from what we last saved.
@@ -316,6 +327,14 @@ export function LanguagesPage() {
     ]
   );
 
+  // Captured from the state that TRIGGERED the dialog would be ideal, but
+  // the flags are stable while it's open (the switch is blocked, so no new
+  // writes start), so reading them live is equivalent and simpler.
+  const contextSwitchCause = contextSwitchReason(
+    isDirty,
+    isSaving || setOrgDefault.isPending || deleteLanguage.isPending
+  );
+
   const confirmContextSwitch = useCallback(() => {
     if (!pendingContextOrg) return;
     setContextOrg(pendingContextOrg.value);
@@ -340,6 +359,7 @@ export function LanguagesPage() {
       saveLanguage.mutate(
         {
           name,
+          org: contextOrg,
           body: {
             label: label || undefined,
             document: scaffold.document,
@@ -356,7 +376,7 @@ export function LanguagesPage() {
         }
       );
     },
-    [saveLanguage, scaffoldQuery.data, setSelectedLanguage]
+    [contextOrg, saveLanguage, scaffoldQuery.data, setSelectedLanguage]
   );
 
   const handleSetPublished = useCallback(
@@ -373,6 +393,7 @@ export function LanguagesPage() {
       const doc = isSelected ? draft : (languageQuery.data?.document ?? "");
       await saveLanguage.mutateAsync({
         name,
+        org: contextOrg,
         body: { label: serverLabel, document: doc, published },
       });
       if (isSelected) {
@@ -380,7 +401,14 @@ export function LanguagesPage() {
         setLastSyncedPublished(published);
       }
     },
-    [draft, languageQuery.data, saveLanguage, selectedLanguage, serverLabel]
+    [
+      contextOrg,
+      draft,
+      languageQuery.data,
+      saveLanguage,
+      selectedLanguage,
+      serverLabel,
+    ]
   );
 
   // #286 — set (`name`) or clear (`null`) the org default. mutateAsync so
@@ -688,11 +716,38 @@ export function LanguagesPage() {
           <AlertDialogHeader>
             <AlertDialogTitle>Switch org context?</AlertDialogTitle>
             <AlertDialogDescription>
-              You have unsaved edits to{" "}
-              <span className="text-foreground font-medium">
-                &ldquo;{selectedLanguage}&rdquo;
-              </span>
-              . Switching org context will discard them.
+              {/* #286 rd-2 P3: the guard now also fires for an in-flight
+                  org-scoped write (setting the default, deleting), which
+                  is not an unsaved edit. Saying "you have unsaved edits"
+                  to someone who hasn't typed anything is a false alarm,
+                  and false alarms train people to click through. */}
+              {contextSwitchCause === "pending-write" ? (
+                <>
+                  A change to this org is still saving. Switching now leaves it
+                  to finish against{" "}
+                  <span className="text-foreground font-medium">
+                    {contextOrg ?? "your own org"}
+                  </span>{" "}
+                  while you look at another org.
+                </>
+              ) : contextSwitchCause === "both" ? (
+                <>
+                  You have unsaved edits to{" "}
+                  <span className="text-foreground font-medium">
+                    &ldquo;{selectedLanguage}&rdquo;
+                  </span>{" "}
+                  and a change that is still saving. Switching org context will
+                  discard the edits.
+                </>
+              ) : (
+                <>
+                  You have unsaved edits to{" "}
+                  <span className="text-foreground font-medium">
+                    &ldquo;{selectedLanguage}&rdquo;
+                  </span>
+                  . Switching org context will discard them.
+                </>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -6,7 +6,11 @@ import { useBlocker } from "react-router";
 
 import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
-import { LanguageForbiddenError } from "@/lib/languages-api";
+import { computeLanguageDefaultState } from "@/lib/language-default-state";
+import {
+  LanguageForbiddenError,
+  LanguageIsDefaultError,
+} from "@/lib/languages-api";
 import {
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
@@ -21,7 +25,9 @@ import {
   useDeleteLanguage,
   useLanguage,
   useLanguages,
+  useOrgDefaultLanguage,
   useSaveLanguage,
+  useSetOrgDefaultLanguage,
 } from "@/hooks/use-languages";
 import { useLanguageScaffold } from "@/hooks/use-language-scaffold";
 import type { MarkdownHeading } from "@/types/markdown";
@@ -88,6 +94,12 @@ export function LanguagesPage() {
   const canPublishSelected =
     selectedLanguage !== null && hasRights(publishRights, selectedLanguage);
   const canDeleteSelected = canEditSelected && canPublishSelected;
+  // #286 — the org default is one pointer shared by the whole org, so it
+  // is admin-only rather than per-row (the worker's PUT gate on
+  // /api/config/languages-default enforces the same rule; this is the UI
+  // mirror). Cross-org context is super-admin-only, so it carries admin
+  // powers by construction.
+  const canSetDefault = isAdmin || isCrossOrg;
 
   // Queries / mutations
   const languagesQuery = useLanguages(contextOrg);
@@ -95,6 +107,13 @@ export function LanguagesPage() {
   const saveLanguage = useSaveLanguage(contextOrg);
   const deleteLanguage = useDeleteLanguage(contextOrg);
   const scaffoldQuery = useLanguageScaffold(contextOrg);
+  // #286 — org default. Its own query rather than the list's
+  // `defaultLanguage` echo, because only the dedicated endpoint can tell
+  // "no default set" apart from "this worker predates worker#236"; the
+  // query resolves (never rejects) on that 404, so a portal running ahead
+  // of the worker shows no control instead of an error on page load.
+  const orgDefaultQuery = useOrgDefaultLanguage(contextOrg);
+  const setOrgDefault = useSetOrgDefaultLanguage(contextOrg);
 
   // Every keystroke re-renders this page (the editor draft lives in
   // component state), so the raw-name list for the create-dialog
@@ -355,6 +374,26 @@ export function LanguagesPage() {
     [draft, languageQuery.data, saveLanguage, selectedLanguage, serverLabel]
   );
 
+  // #286 — set (`name`) or clear (`null`) the org default. mutateAsync so
+  // the selector's clear-confirmation dialog can await it and render its
+  // failure inline (#102 pattern), and so the set path can surface its own
+  // message without a page-level banner.
+  const handleSetDefault = useCallback(
+    async (name: string | null) => {
+      await setOrgDefault.mutateAsync(name);
+    },
+    [setOrgDefault]
+  );
+
+  const defaultState = useMemo(
+    () =>
+      computeLanguageDefaultState(
+        orgDefaultQuery.data,
+        languagesQuery.data?.languages
+      ),
+    [orgDefaultQuery.data, languagesQuery.data]
+  );
+
   const handleDeleteLanguage = useCallback(
     async (name: string) => {
       await deleteLanguage.mutateAsync(name);
@@ -446,6 +485,10 @@ export function LanguagesPage() {
               isScaffoldReady={scaffoldQuery.isSuccess}
               scaffoldError={scaffoldQuery.isError}
               takenNames={takenNames}
+              defaultState={defaultState}
+              canSetDefault={canSetDefault}
+              onSetDefault={handleSetDefault}
+              isSettingDefault={setOrgDefault.isPending}
             />
           </div>
 
@@ -490,7 +533,13 @@ export function LanguagesPage() {
           role="alert"
           aria-live="polite"
         >
-          Save failed: {genericMutationError.message}
+          {/* #286 — the org-default 409 already reads as an instruction
+              ("set a different default first"); prefixing it with "Save
+              failed" would misdescribe a delete that was refused for a
+              reason the user can act on. */}
+          {genericMutationError instanceof LanguageIsDefaultError
+            ? genericMutationError.message
+            : `Save failed: ${genericMutationError.message}`}
         </div>
       )}
 

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -115,14 +115,6 @@ export function LanguagesPage() {
   const orgDefaultQuery = useOrgDefaultLanguage(contextOrg);
   const setOrgDefault = useSetOrgDefaultLanguage(contextOrg);
 
-  // Every keystroke re-renders this page (the editor draft lives in
-  // component state), so the raw-name list for the create-dialog
-  // collision check must keep a stable identity between data changes.
-  const takenNames = useMemo(
-    () => languagesQuery.data?.languages.map((l) => l.name) ?? [],
-    [languagesQuery.data]
-  );
-
   // Local document draft (auto-save target).
   //
   // We track `lastSyncedDoc` separately from React Query's cache so that:
@@ -484,7 +476,6 @@ export function LanguagesPage() {
               canDeleteSelected={canDeleteSelected}
               isScaffoldReady={scaffoldQuery.isSuccess}
               scaffoldError={scaffoldQuery.isError}
-              takenNames={takenNames}
               defaultState={defaultState}
               canSetDefault={canSetDefault}
               onSetDefault={handleSetDefault}

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -8,9 +8,10 @@ import { useAuthStore } from "@/lib/auth-store";
 import { decideContextChange } from "@/lib/context-org-guard";
 import { computeLanguageDefaultState } from "@/lib/language-default-state";
 import {
-  LanguageForbiddenError,
-  LanguageIsDefaultError,
-} from "@/lib/languages-api";
+  isDefaultBlockedDeleteError,
+  selectLanguageMutationBanner,
+} from "@/lib/language-error-surface";
+import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
@@ -105,7 +106,7 @@ export function LanguagesPage() {
   const languagesQuery = useLanguages(contextOrg);
   const languageQuery = useLanguage(selectedLanguage, contextOrg);
   const saveLanguage = useSaveLanguage(contextOrg);
-  const deleteLanguage = useDeleteLanguage(contextOrg);
+  const deleteLanguage = useDeleteLanguage();
   const scaffoldQuery = useLanguageScaffold(contextOrg);
   // #286 — org default. Its own query rather than the list's
   // `defaultLanguage` echo, because only the dedicated endpoint can tell
@@ -113,7 +114,7 @@ export function LanguagesPage() {
   // query resolves (never rejects) on that 404, so a portal running ahead
   // of the worker shows no control instead of an error on page load.
   const orgDefaultQuery = useOrgDefaultLanguage(contextOrg);
-  const setOrgDefault = useSetOrgDefaultLanguage(contextOrg);
+  const setOrgDefault = useSetOrgDefaultLanguage();
 
   // Local document draft (auto-save target).
   //
@@ -288,7 +289,16 @@ export function LanguagesPage() {
 
   const handleRequestContextChange = useCallback(
     (next: string | null) => {
-      const outcome = decideContextChange(contextOrg, next, isDirty, isSaving);
+      // In-flight org-scoped writes count as "saving": switching context
+      // under one would strand the write's result in another org's view
+      // (#286 review P2-3). The hooks pin their target org too, so this
+      // guard is the user-visible half of a two-layer fix.
+      const outcome = decideContextChange(
+        contextOrg,
+        next,
+        isDirty,
+        isSaving || setOrgDefault.isPending || deleteLanguage.isPending
+      );
       if (outcome === "no-op") return;
       if (outcome === "confirm") {
         setPendingContextOrg({ value: next });
@@ -296,7 +306,14 @@ export function LanguagesPage() {
       }
       setContextOrg(next);
     },
-    [contextOrg, isDirty, isSaving, setContextOrg]
+    [
+      contextOrg,
+      deleteLanguage.isPending,
+      isDirty,
+      isSaving,
+      setContextOrg,
+      setOrgDefault.isPending,
+    ]
   );
 
   const confirmContextSwitch = useCallback(() => {
@@ -372,9 +389,20 @@ export function LanguagesPage() {
   // message without a page-level banner.
   const handleSetDefault = useCallback(
     async (name: string | null) => {
-      await setOrgDefault.mutateAsync(name);
+      // `org` is pinned HERE, at click time, and travels with the request:
+      // the hook must not read an ambient key when the mutation settles,
+      // or an org-context switch mid-flight lands org A's result in org
+      // B's cache (#286 review P2-3).
+      await setOrgDefault.mutateAsync({ name, org: contextOrg });
+      // The delete dialog's 409 ("may be the org default") is exactly the
+      // failure this action fixes. Leaving the mutation error in place
+      // would keep asserting the block after the block is gone — the
+      // sticky-banner path the review found.
+      if (isDefaultBlockedDeleteError(deleteLanguage.error)) {
+        deleteLanguage.reset();
+      }
     },
-    [setOrgDefault]
+    [contextOrg, deleteLanguage, setOrgDefault]
   );
 
   // Both queries feed the state machine, loading flags included: "no
@@ -401,10 +429,11 @@ export function LanguagesPage() {
 
   const handleDeleteLanguage = useCallback(
     async (name: string) => {
-      await deleteLanguage.mutateAsync(name);
+      // Org pinned at click time — same reason as handleSetDefault.
+      await deleteLanguage.mutateAsync({ name, org: contextOrg });
       if (name === selectedLanguage) setSelectedLanguage(null);
     },
-    [deleteLanguage, selectedLanguage, setSelectedLanguage]
+    [contextOrg, deleteLanguage, selectedLanguage, setSelectedLanguage]
   );
 
   const handleJumpToLine = useCallback((line: number) => {
@@ -432,15 +461,14 @@ export function LanguagesPage() {
   // Surface non-forbidden save / delete failures so the user can see *why* a
   // save didn't stick — previously these were silently swallowed, leaving the
   // "Unsaved changes" chip stuck without any explanation.
-  const genericMutationError = useMemo<Error | null>(() => {
-    if (saveError && !(saveError instanceof LanguageForbiddenError)) {
-      return saveError;
-    }
-    if (deleteError && !(deleteError instanceof LanguageForbiddenError)) {
-      return deleteError;
-    }
-    return null;
-  }, [saveError, deleteError]);
+  // One surface per failure. The org-default 409 is deliberately NOT
+  // folded in here: the delete dialog renders it inline and stays open to
+  // do so, and a page banner would both duplicate it and outlive it — see
+  // src/lib/language-error-surface.ts for the rule and its tests.
+  const genericMutationError = useMemo<Error | null>(
+    () => selectLanguageMutationBanner(saveError, deleteError),
+    [saveError, deleteError]
+  );
 
   // #249 — with the dropdown listing every draft in the org, opening a
   // row you can't edit is an ordinary state rather than an error, so
@@ -537,13 +565,7 @@ export function LanguagesPage() {
           role="alert"
           aria-live="polite"
         >
-          {/* #286 — the org-default 409 already reads as an instruction
-              ("set a different default first"); prefixing it with "Save
-              failed" would misdescribe a delete that was refused for a
-              reason the user can act on. */}
-          {genericMutationError instanceof LanguageIsDefaultError
-            ? genericMutationError.message
-            : `Save failed: ${genericMutationError.message}`}
+          Save failed: {genericMutationError.message}
         </div>
       )}
 

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -377,13 +377,26 @@ export function LanguagesPage() {
     [setOrgDefault]
   );
 
+  // Both queries feed the state machine, loading flags included: "no
+  // default is set" and "the default points at nothing" are claims about
+  // the org, and an unresolved read is not evidence for either. `isError`
+  // is threaded separately because 404/501 RESOLVE as unsupported — a
+  // rejection here is a real failure and must not masquerade as "this
+  // worker doesn't have the feature".
   const defaultState = useMemo(
     () =>
-      computeLanguageDefaultState(
-        orgDefaultQuery.data,
-        languagesQuery.data?.languages
-      ),
-    [orgDefaultQuery.data, languagesQuery.data]
+      computeLanguageDefaultState({
+        orgDefault: orgDefaultQuery.data,
+        isPending: orgDefaultQuery.isPending,
+        isError: orgDefaultQuery.isError,
+        languages: languagesQuery.data?.languages,
+      }),
+    [
+      orgDefaultQuery.data,
+      orgDefaultQuery.isPending,
+      orgDefaultQuery.isError,
+      languagesQuery.data,
+    ]
   );
 
   const handleDeleteLanguage = useCallback(

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -58,9 +58,12 @@ interface LanguageSelectorProps {
   showDrafts: boolean;
   onToggleShowDrafts: (showDrafts: boolean) => void;
   // #181 verb-perms capabilities, replacing the old `isAdmin` flag.
-  // Languages do NOT carry an admin trump (PR #185 enforced per-row
-  // even for super-admins), so these are pure verb-perm reads computed
-  // by the parent against the user's effective edit/publish rights:
+  // Computed by the parent against the user's EFFECTIVE edit/publish
+  // rights, which for anyone with admin powers — and for a super-admin
+  // viewing another org — are "*": #249 gave admins a trump over per-row
+  // language rights (the earlier PR #185 rule, per-row even for
+  // super-admins, is gone). So these flags are already trump-aware and
+  // this component never reasons about admin-ness itself:
   //
   //   canCreate         = user has some edit rights on this org
   //   canPublishSelected = hasRights(publishRights, selectedLanguage)
@@ -74,13 +77,6 @@ interface LanguageSelectorProps {
       before the scaffold arrives would silently save a blank document. */
   isScaffoldReady: boolean;
   scaffoldError: boolean;
-  /** ALL language names in the org — unfiltered, unlike `languagesData`
-      (which the parent pre-filters to rows the user holds a verb on).
-      #247: admins can create drafts without holding rights on existing
-      rows, so their filtered list can be empty while names are taken; a
-      collision would otherwise surface as a bare worker 403 from an
-      affordance the UI offered. */
-  takenNames: string[];
   /** #286 — org default language, already reduced to a renderable state by
       the page (`computeLanguageDefaultState`). `kind: "unsupported"` covers
       both "the query hasn't answered" and "this worker predates
@@ -118,7 +114,6 @@ export function LanguageSelector({
   canDeleteSelected,
   isScaffoldReady,
   scaffoldError,
-  takenNames,
   defaultState,
   canSetDefault,
   onSetDefault,
@@ -127,7 +122,6 @@ export function LanguageSelector({
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
   const [newLabel, setNewLabel] = useState("");
-  const [createError, setCreateError] = useState<string | null>(null);
 
   // Destructive-confirmation dialogs are controlled so we can keep them
   // open on async failure and render the error inline (#102). Closing on
@@ -227,27 +221,17 @@ export function LanguageSelector({
       .replace(/[^a-z0-9\-_]/g, "")
       .replace(/^-+|-+$/g, "");
     if (!slug) return;
-    // Collision check against the UNFILTERED org list, but only for
-    // names HIDDEN from this user: rows they hold no verb on still own
-    // their names, and the worker will 403 a PUT against them — without
-    // this, the create affordance hands an admin with an empty filtered
-    // list a bare "Forbidden". Names in the user's own (filtered) list
-    // pass through: a rights-holding shepherd re-creating their own
-    // language is the pre-existing PUT-over-existing re-scaffold flow,
-    // not a permission error (#256 rd-3). Client-side only — the
-    // worker's gate remains the enforcement.
-    if (takenNames.includes(slug) && !languages.some((l) => l.name === slug)) {
-      setCreateError(
-        `A language named "${slug}" already exists in this org, but you don't have access to it. Pick a different name, or ask a shepherd or admin for access.`
-      );
-      return;
-    }
+    // #272: no hidden-name collision check any more. It guarded the case
+    // where a name was taken by a row the user couldn't see, which #249
+    // removed — the dropdown now lists the org's whole catalog, so a taken
+    // name is always a name in `languages`, and re-creating one is the
+    // deliberate PUT-over-existing re-scaffold flow (#256 rd-3) rather
+    // than an error. The worker's gate remains the enforcement either way.
     onCreateLanguage(slug, newLabel.trim());
     setNewName("");
     setNewLabel("");
     setShowCreate(false);
-    setCreateError(null);
-  }, [newName, newLabel, onCreateLanguage, takenNames, languages]);
+  }, [newName, newLabel, onCreateLanguage]);
 
   return (
     <div className="space-y-3">
@@ -584,10 +568,7 @@ export function LanguageSelector({
               <Input
                 id="lang-name"
                 value={newName}
-                onChange={(e) => {
-                  setNewName(e.target.value);
-                  setCreateError(null);
-                }}
+                onChange={(e) => setNewName(e.target.value)}
                 placeholder="e.g. arabic"
                 className="h-8 text-sm"
               />
@@ -605,11 +586,6 @@ export function LanguageSelector({
               />
             </div>
           </div>
-          {createError && (
-            <p className="text-destructive mt-3 text-xs" role="alert">
-              {createError}
-            </p>
-          )}
           {!isScaffoldReady && (
             <p
               className={
@@ -629,10 +605,7 @@ export function LanguageSelector({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => {
-                setShowCreate(false);
-                setCreateError(null);
-              }}
+              onClick={() => setShowCreate(false)}
             >
               Cancel
             </Button>

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -18,7 +18,10 @@ import {
   isDefaultControlAvailable,
   type LanguageDefaultState,
 } from "@/lib/language-default-state";
-import { describeLanguageDeleteError } from "@/lib/language-error-surface";
+import {
+  describeLanguageDeleteError,
+  shouldOfferDefaultRecovery,
+} from "@/lib/language-error-surface";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import { cn } from "@/lib/utils";
 import type { Language, OrgLanguages } from "@/types/language";
@@ -132,7 +135,12 @@ export function LanguageSelector({
   const [unpublishOpen, setUnpublishOpen] = useState(false);
   const [unpublishError, setUnpublishError] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
+  // The delete failure is kept as the thrown VALUE, not as a message
+  // string: the dialog needs its class to decide both the wording (role-
+  // aware) and whether to offer the inline recovery action (#286 review
+  // rd-2 P2-1). `recoveryError` is the recovery attempt's own failure.
+  const [deleteFailure, setDeleteFailure] = useState<unknown>(null);
+  const [recoveryError, setRecoveryError] = useState<string | null>(null);
   // The set path has no dialog to render into, so its failure lands in the
   // notice row beneath the toolbar.
   const [setDefaultError, setSetDefaultError] = useState<string | null>(null);
@@ -147,22 +155,49 @@ export function LanguageSelector({
     );
   }, [onSetPublished, selectedLanguage]);
 
-  const handleConfirmDelete = useCallback(() => {
+  // Not `runConfirmedAction` (unlike its siblings): this dialog needs the
+  // error CLASS, not just its message — the 409 both selects role-aware
+  // copy and unlocks the inline recovery action below. Same contract
+  // otherwise: stay open on failure, close only on success (#102).
+  const handleConfirmDelete = useCallback(async () => {
     if (selectedLanguage === null) return;
-    return runConfirmedAction(
-      // The 409 "this is the org default" copy is composed HERE rather
-      // than in the API layer, because the recovery step depends on the
-      // viewer: deleting needs per-row edit+publish, changing the org
-      // default needs admin powers (#286 review P2-2).
-      () =>
-        onDeleteLanguage(selectedLanguage).catch((err: unknown) => {
-          throw new Error(describeLanguageDeleteError(err, canSetDefault));
-        }),
-      setDeleteError,
-      () => setDeleteOpen(false),
-      "Failed to delete language."
-    );
-  }, [canSetDefault, onDeleteLanguage, selectedLanguage]);
+    setDeleteFailure(null);
+    setRecoveryError(null);
+    try {
+      await onDeleteLanguage(selectedLanguage);
+      setDeleteOpen(false);
+    } catch (err: unknown) {
+      setDeleteFailure(err);
+    }
+  }, [onDeleteLanguage, selectedLanguage]);
+
+  // Inline recovery from the 409, offered inside the delete dialog itself.
+  // Deliberately independent of `defaultState`: when the languages-default
+  // GET is failing, the state machine withholds the toolbar Set/Clear
+  // controls, yet the server still HAS a default and still 409s the
+  // delete — which left the admin reading an instruction pointing at
+  // controls that weren't on screen (#286 review rd-2 P2-1). Clearing is
+  // a write; it doesn't need a successful read to be legal.
+  const handleRecoverClearDefault = useCallback(() => {
+    setRecoveryError(null);
+    onSetDefault(null)
+      .then(() => {
+        // The block is gone — drop the stale 409 and its recovery
+        // affordance so the dialog shows a plain, retryable Delete
+        // (#286 review rd-2 P3: the dialog-local error outliving the
+        // recovery is reachable now that the recovery happens INSIDE the
+        // open dialog).
+        setDeleteFailure(null);
+        setRecoveryError(null);
+      })
+      .catch((err: unknown) => {
+        setRecoveryError(
+          err instanceof Error
+            ? err.message
+            : "Failed to clear the default language."
+        );
+      });
+  }, [onSetDefault]);
 
   const handleSetDefault = useCallback(() => {
     if (selectedLanguage === null) return;
@@ -214,6 +249,19 @@ export function LanguageSelector({
   // leave the button live — disabling it would offer no recovery at all,
   // and the 409 they get carries the "ask an admin" copy.
   const deleteBlockedByDefault = selectedIsDefault && canSetDefault;
+  // Recovery is offered from the ERROR, never from `defaultState`: the
+  // state machine withholds the toolbar controls while the
+  // languages-default GET is failing, but the server still has a default
+  // and still 409s the delete.
+  const deleteErrorMessage =
+    recoveryError ??
+    (deleteFailure === null
+      ? null
+      : describeLanguageDeleteError(deleteFailure, canSetDefault));
+  const offerDefaultRecovery = shouldOfferDefaultRecovery(
+    deleteFailure,
+    canSetDefault
+  );
 
   const handleCreate = useCallback(() => {
     const slug = newName
@@ -434,7 +482,10 @@ export function LanguageSelector({
                 open={deleteOpen}
                 onOpenChange={(next) => {
                   setDeleteOpen(next);
-                  if (!next) setDeleteError(null);
+                  if (!next) {
+                    setDeleteFailure(null);
+                    setRecoveryError(null);
+                  }
                 }}
               >
                 <AlertDialogTrigger asChild>
@@ -464,10 +515,31 @@ export function LanguageSelector({
                       ? This action cannot be undone.
                     </AlertDialogDescription>
                   </AlertDialogHeader>
-                  {deleteError && (
-                    <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
-                      {deleteError}
-                    </p>
+                  {deleteErrorMessage && (
+                    <div className="bg-destructive/10 border-destructive space-y-2 border-l-2 px-3 py-2">
+                      <p className="text-destructive text-sm">
+                        {deleteErrorMessage}
+                      </p>
+                      {/* The recovery the copy prescribes, right where the
+                          user reads it — and reachable even when the
+                          org-default READ is failing, which is exactly
+                          when the toolbar control is withheld. Shepherds
+                          don't get it: their copy says "ask an admin"
+                          because the worker's PUT is admin-only. */}
+                      {offerDefaultRecovery && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleRecoverClearDefault}
+                          disabled={isSettingDefault}
+                        >
+                          <StarOff className="mr-1.5 size-3.5" />
+                          {isSettingDefault
+                            ? "Clearing…"
+                            : "Clear the org default"}
+                        </Button>
+                      )}
+                    </div>
                   )}
                   <AlertDialogFooter>
                     <AlertDialogCancel disabled={isDeleting}>

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -18,6 +18,7 @@ import {
   isDefaultControlAvailable,
   type LanguageDefaultState,
 } from "@/lib/language-default-state";
+import { describeLanguageDeleteError } from "@/lib/language-error-surface";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import { cn } from "@/lib/utils";
 import type { Language, OrgLanguages } from "@/types/language";
@@ -132,10 +133,6 @@ export function LanguageSelector({
   const [unpublishError, setUnpublishError] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [clearDefaultOpen, setClearDefaultOpen] = useState(false);
-  const [clearDefaultError, setClearDefaultError] = useState<string | null>(
-    null
-  );
   // The set path has no dialog to render into, so its failure lands in the
   // notice row beneath the toolbar.
   const [setDefaultError, setSetDefaultError] = useState<string | null>(null);
@@ -153,23 +150,19 @@ export function LanguageSelector({
   const handleConfirmDelete = useCallback(() => {
     if (selectedLanguage === null) return;
     return runConfirmedAction(
-      () => onDeleteLanguage(selectedLanguage),
+      // The 409 "this is the org default" copy is composed HERE rather
+      // than in the API layer, because the recovery step depends on the
+      // viewer: deleting needs per-row edit+publish, changing the org
+      // default needs admin powers (#286 review P2-2).
+      () =>
+        onDeleteLanguage(selectedLanguage).catch((err: unknown) => {
+          throw new Error(describeLanguageDeleteError(err, canSetDefault));
+        }),
       setDeleteError,
       () => setDeleteOpen(false),
       "Failed to delete language."
     );
-  }, [onDeleteLanguage, selectedLanguage]);
-
-  const handleConfirmClearDefault = useCallback(
-    () =>
-      runConfirmedAction(
-        () => onSetDefault(null),
-        setClearDefaultError,
-        () => setClearDefaultOpen(false),
-        "Failed to clear the default language."
-      ),
-    [onSetDefault]
-  );
+  }, [canSetDefault, onDeleteLanguage, selectedLanguage]);
 
   const handleSetDefault = useCallback(() => {
     if (selectedLanguage === null) return;
@@ -211,10 +204,16 @@ export function LanguageSelector({
   // at all?" decision comes from the state machine, so an unresolved read
   // renders nothing at all rather than a claim about the org.
   const defaultName = defaultLanguageName(defaultState);
-  const defaultNotice = describeLanguageDefault(defaultState);
+  const defaultNotice = describeLanguageDefault(defaultState, canSetDefault);
   const defaultControlAvailable = isDefaultControlAvailable(defaultState);
   const selectedIsDefault =
     selectedLanguage !== null && selectedLanguage === defaultName;
+  // #286 — deleting the org default is a guaranteed upstream 409. For a
+  // viewer who can fix that (admins), block the click and say why; for a
+  // shepherd who holds delete rights but cannot touch the org default,
+  // leave the button live — disabling it would offer no recovery at all,
+  // and the 409 they get carries the "ask an admin" copy.
+  const deleteBlockedByDefault = selectedIsDefault && canSetDefault;
 
   const handleCreate = useCallback(() => {
     const slug = newName
@@ -308,6 +307,19 @@ export function LanguageSelector({
           </Button>
         )}
 
+        {/* #286 — drift recovery. The dangling slug isn't in the dropdown,
+            so the per-row control below can never reach it; this is the
+            only Clear an admin can press to fix the state the notice is
+            warning about. Rendered outside the selection cluster because
+            it is deliberately independent of what's selected. */}
+        {canSetDefault && defaultState.kind === "missing" && (
+          <ClearDefaultControl
+            onSetDefault={onSetDefault}
+            isSettingDefault={isSettingDefault}
+            drift
+          />
+        )}
+
         {selectedLanguage !== null && selectedData && (
           <div className="border-border flex items-center gap-2 sm:border-l sm:pl-3">
             <Badge
@@ -323,57 +335,10 @@ export function LanguageSelector({
             {canSetDefault &&
               defaultControlAvailable &&
               (selectedIsDefault ? (
-                <AlertDialog
-                  open={clearDefaultOpen}
-                  onOpenChange={(next) => {
-                    setClearDefaultOpen(next);
-                    if (!next) setClearDefaultError(null);
-                  }}
-                >
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      disabled={isSettingDefault}
-                    >
-                      <StarOff className="mr-1.5 size-3.5" />
-                      Clear default
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>
-                        Clear the org default language?
-                      </AlertDialogTitle>
-                      <AlertDialogDescription>
-                        End users will stop receiving this language&rsquo;s
-                        tuning automatically — after this, tuning only applies
-                        when they ask for a language with{" "}
-                        <span className="text-foreground font-medium">
-                          @language
-                        </span>
-                        . The language itself is not changed.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    {clearDefaultError && (
-                      <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
-                        {clearDefaultError}
-                      </p>
-                    )}
-                    <AlertDialogFooter>
-                      <AlertDialogCancel disabled={isSettingDefault}>
-                        Cancel
-                      </AlertDialogCancel>
-                      {/* Plain Button — see comment in Unpublish dialog. */}
-                      <Button
-                        onClick={handleConfirmClearDefault}
-                        disabled={isSettingDefault}
-                      >
-                        {isSettingDefault ? "Clearing…" : "Clear default"}
-                      </Button>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                <ClearDefaultControl
+                  onSetDefault={onSetDefault}
+                  isSettingDefault={isSettingDefault}
+                />
               ) : (
                 <Button
                   variant="ghost"
@@ -476,7 +441,12 @@ export function LanguageSelector({
                   <Button
                     variant="ghost"
                     size="sm"
-                    disabled={isDeleting}
+                    disabled={isDeleting || deleteBlockedByDefault}
+                    title={
+                      deleteBlockedByDefault
+                        ? "Clear or change the org default first"
+                        : undefined
+                    }
                     className="text-destructive hover:text-destructive"
                   >
                     <Trash2 className="mr-1.5 size-3.5" />
@@ -634,5 +604,104 @@ export function LanguageSelector({
         </div>
       )}
     </div>
+  );
+}
+
+interface ClearDefaultControlProps {
+  /** Must reject on error — the dialog stays open and renders it inline. */
+  onSetDefault: (name: string | null) => Promise<void>;
+  isSettingDefault: boolean;
+  /** The org default points at a slug that isn't in the org's list. That
+      row can't be selected (it isn't in the dropdown), so this instance is
+      the ONLY way to reach Clear — without it the drift notice prescribes
+      a recovery the UI can't perform (#286 review P3-5). */
+  drift?: boolean;
+}
+
+// Extracted so the selected-row control and the drift-recovery control are
+// the same affordance with the same confirmation semantics, rather than
+// two dialogs that could drift apart. Owns its open/error state: each
+// instance is independently dismissable, and #102's rule (plain Button,
+// close only on success) holds for both.
+function ClearDefaultControl({
+  onSetDefault,
+  isSettingDefault,
+  drift = false,
+}: ClearDefaultControlProps) {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = useCallback(
+    () =>
+      runConfirmedAction(
+        () => onSetDefault(null),
+        setError,
+        () => setOpen(false),
+        "Failed to clear the default language."
+      ),
+    [onSetDefault]
+  );
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setError(null);
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={isSettingDefault}
+          className={cn(
+            drift && "text-amber-700 hover:text-amber-700 dark:text-amber-400"
+          )}
+        >
+          <StarOff className="mr-1.5 size-3.5" />
+          Clear default
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Clear the org default language?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {drift ? (
+              <>
+                The org default points at a language that isn&rsquo;t in this
+                org&rsquo;s list, so nothing resolves it. Clearing removes the
+                dangling pointer — end users keep getting tuning only when they
+                ask for a language with{" "}
+                <span className="text-foreground font-medium">@language</span>.
+              </>
+            ) : (
+              <>
+                End users will stop receiving this language&rsquo;s tuning
+                automatically — after this, tuning only applies when they ask
+                for a language with{" "}
+                <span className="text-foreground font-medium">@language</span>.
+                The language itself is not changed.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && (
+          <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+            {error}
+          </p>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSettingDefault}>
+            Cancel
+          </AlertDialogCancel>
+          {/* Plain Button — AlertDialogAction auto-closes before onError
+              can render the inline message (#102). */}
+          <Button onClick={handleConfirm} disabled={isSettingDefault}>
+            {isSettingDefault ? "Clearing…" : "Clear default"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -1,9 +1,24 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { faLanguage } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Eye, EyeOff, Plus, Send, SendHorizontal, Trash2 } from "lucide-react";
+import {
+  Eye,
+  EyeOff,
+  Plus,
+  Send,
+  SendHorizontal,
+  Star,
+  StarOff,
+  Trash2,
+} from "lucide-react";
 
+import {
+  defaultLanguageName,
+  describeLanguageDefault,
+  type LanguageDefaultState,
+} from "@/lib/language-default-state";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
+import { cn } from "@/lib/utils";
 import type { Language, OrgLanguages } from "@/types/language";
 import {
   AlertDialog,
@@ -66,6 +81,20 @@ interface LanguageSelectorProps {
       collision would otherwise surface as a bare worker 403 from an
       affordance the UI offered. */
   takenNames: string[];
+  /** #286 — org default language, already reduced to a renderable state by
+      the page (`computeLanguageDefaultState`). `kind: "unsupported"` covers
+      both "the query hasn't answered" and "this worker predates
+      worker#236"; the control renders nothing but a quiet admin-only note
+      in that case. */
+  defaultState: LanguageDefaultState;
+  /** Setting/clearing the org default is admin-only — it's one org-wide
+      pointer, not a per-row right (mirror of the worker's PUT gate on
+      /api/config/languages-default). */
+  canSetDefault: boolean;
+  /** Must reject on error — the set path renders the message inline and the
+      clear path keeps its confirmation dialog open (#102 pattern). */
+  onSetDefault: (name: string | null) => Promise<void>;
+  isSettingDefault: boolean;
 }
 
 function isPublished(lang: Pick<Language, "published">): boolean {
@@ -90,6 +119,10 @@ export function LanguageSelector({
   isScaffoldReady,
   scaffoldError,
   takenNames,
+  defaultState,
+  canSetDefault,
+  onSetDefault,
+  isSettingDefault,
 }: LanguageSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -104,6 +137,13 @@ export function LanguageSelector({
   const [unpublishError, setUnpublishError] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [clearDefaultOpen, setClearDefaultOpen] = useState(false);
+  const [clearDefaultError, setClearDefaultError] = useState<string | null>(
+    null
+  );
+  // The set path has no dialog to render into, so its failure lands in the
+  // notice row beneath the toolbar.
+  const [setDefaultError, setSetDefaultError] = useState<string | null>(null);
 
   const handleConfirmUnpublish = useCallback(() => {
     if (selectedLanguage === null) return;
@@ -125,6 +165,36 @@ export function LanguageSelector({
     );
   }, [onDeleteLanguage, selectedLanguage]);
 
+  const handleConfirmClearDefault = useCallback(
+    () =>
+      runConfirmedAction(
+        () => onSetDefault(null),
+        setClearDefaultError,
+        () => setClearDefaultOpen(false),
+        "Failed to clear the default language."
+      ),
+    [onSetDefault]
+  );
+
+  const handleSetDefault = useCallback(() => {
+    if (selectedLanguage === null) return;
+    setSetDefaultError(null);
+    onSetDefault(selectedLanguage).catch((err: unknown) => {
+      setSetDefaultError(
+        err instanceof Error
+          ? err.message
+          : "Failed to set the default language."
+      );
+    });
+  }, [onSetDefault, selectedLanguage]);
+
+  // A set-default failure describes an attempt on one row; switching rows
+  // makes it stale. (The set path has no dialog whose dismissal would
+  // otherwise clear it.)
+  useEffect(() => {
+    setSetDefaultError(null);
+  }, [selectedLanguage]);
+
   // Memoized: handleCreate's collision check depends on this, and the
   // `?? []` fallback would otherwise mint a fresh array identity every
   // render (react-hooks/exhaustive-deps).
@@ -139,6 +209,15 @@ export function LanguageSelector({
   const visibleLanguages = languages.filter(
     (l) => showDrafts || isPublished(l) || l.name === selectedLanguage
   );
+
+  // #286 org default. `defaultName` drives the per-row badge; the notice
+  // carries the three end-user-facing states (healthy / draft-warning /
+  // none) plus the drift case.
+  const defaultName = defaultLanguageName(defaultState);
+  const defaultNotice = describeLanguageDefault(defaultState);
+  const defaultUnsupported = defaultState.kind === "unsupported";
+  const selectedIsDefault =
+    selectedLanguage !== null && selectedLanguage === defaultName;
 
   const handleCreate = useCallback(() => {
     const slug = newName
@@ -204,6 +283,15 @@ export function LanguageSelector({
                           Draft
                         </Badge>
                       )}
+                      {l.name === defaultName && (
+                        <Badge
+                          variant="secondary"
+                          className="gap-1 px-1.5 py-0 text-[10px]"
+                        >
+                          <Star className="size-2.5 fill-current" />
+                          Default
+                        </Badge>
+                      )}
                     </span>
                   </SelectItem>
                 ))
@@ -241,6 +329,80 @@ export function LanguageSelector({
             >
               {selectedIsPublished ? "Published" : "Draft"}
             </Badge>
+
+            {/* #286 — set/clear the org default for the selected language.
+                Admin-only (the worker's PUT gate is admin-only too), and
+                absent entirely on a worker without the route pair. */}
+            {canSetDefault &&
+              !defaultUnsupported &&
+              (selectedIsDefault ? (
+                <AlertDialog
+                  open={clearDefaultOpen}
+                  onOpenChange={(next) => {
+                    setClearDefaultOpen(next);
+                    if (!next) setClearDefaultError(null);
+                  }}
+                >
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={isSettingDefault}
+                    >
+                      <StarOff className="mr-1.5 size-3.5" />
+                      Clear default
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        Clear the org default language?
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        End users will stop receiving this language&rsquo;s
+                        tuning automatically — after this, tuning only applies
+                        when they ask for a language with{" "}
+                        <span className="text-foreground font-medium">
+                          @language
+                        </span>
+                        . The language itself is not changed.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    {clearDefaultError && (
+                      <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+                        {clearDefaultError}
+                      </p>
+                    )}
+                    <AlertDialogFooter>
+                      <AlertDialogCancel disabled={isSettingDefault}>
+                        Cancel
+                      </AlertDialogCancel>
+                      {/* Plain Button — see comment in Unpublish dialog. */}
+                      <Button
+                        onClick={handleConfirmClearDefault}
+                        disabled={isSettingDefault}
+                      >
+                        {isSettingDefault ? "Clearing…" : "Clear default"}
+                      </Button>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={isSettingDefault}
+                  onClick={handleSetDefault}
+                  title={
+                    defaultName === null
+                      ? "Make this the language end users get without asking"
+                      : `Replace "${defaultName}" as the org default`
+                  }
+                >
+                  <Star className="mr-1.5 size-3.5" />
+                  Set as default
+                </Button>
+              ))}
 
             {canPublishSelected &&
               (selectedIsPublished ? (
@@ -369,6 +531,41 @@ export function LanguageSelector({
           </div>
         )}
       </div>
+
+      {/* #286 — one line that says what end users actually get. Rendered
+          for every viewer (shepherds included: whether their draft is the
+          org default changes what "publish" means for them), while the
+          set/clear control above stays admin-only. */}
+      {defaultUnsupported
+        ? canSetDefault && (
+            <p className="text-muted-foreground text-xs" aria-live="polite">
+              Setting an org default language isn&rsquo;t available on this
+              org&rsquo;s worker yet.
+            </p>
+          )
+        : defaultNotice && (
+            <p
+              className={cn(
+                "flex items-center gap-1.5 text-xs",
+                defaultNotice.tone === "warning"
+                  ? "rounded-r-md border-l-2 border-amber-500 bg-amber-500/10 px-3 py-2 text-amber-700 dark:text-amber-400"
+                  : "text-muted-foreground"
+              )}
+              role={defaultNotice.tone === "warning" ? "status" : undefined}
+              aria-live="polite"
+            >
+              {defaultNotice.tone === "healthy" && (
+                <Star className="size-3 shrink-0 fill-current" />
+              )}
+              {defaultNotice.message}
+            </p>
+          )}
+
+      {setDefaultError && (
+        <p className="text-destructive text-xs" role="alert">
+          {setDefaultError}
+        </p>
+      )}
 
       {showCreate && (
         <div className="bg-card animate-in fade-in slide-in-from-bottom-4 rounded-xl border p-4 shadow-sm duration-200">

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -15,6 +15,7 @@ import {
 import {
   defaultLanguageName,
   describeLanguageDefault,
+  isDefaultControlAvailable,
   type LanguageDefaultState,
 } from "@/lib/language-default-state";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
@@ -78,10 +79,10 @@ interface LanguageSelectorProps {
   isScaffoldReady: boolean;
   scaffoldError: boolean;
   /** #286 — org default language, already reduced to a renderable state by
-      the page (`computeLanguageDefaultState`). `kind: "unsupported"` covers
-      both "the query hasn't answered" and "this worker predates
-      worker#236"; the control renders nothing but a quiet admin-only note
-      in that case. */
+      the page (`computeLanguageDefaultState`), loading and failure states
+      included. This component renders what the state says and never infers
+      readiness itself: `pending` renders nothing, `unsupported` renders a
+      quiet admin-only note, `error` renders a real error. */
   defaultState: LanguageDefaultState;
   /** Setting/clearing the org default is admin-only — it's one org-wide
       pointer, not a per-row right (mirror of the worker's PUT gate on
@@ -189,9 +190,9 @@ export function LanguageSelector({
     setSetDefaultError(null);
   }, [selectedLanguage]);
 
-  // Memoized: handleCreate's collision check depends on this, and the
-  // `?? []` fallback would otherwise mint a fresh array identity every
-  // render (react-hooks/exhaustive-deps).
+  // Memoized: the `?? []` fallback would otherwise mint a fresh array
+  // identity every render, and this page re-renders on every keystroke
+  // (the editor draft lives in the parent's state).
   const languages = useMemo(
     () => languagesData?.languages ?? [],
     [languagesData]
@@ -206,10 +207,12 @@ export function LanguageSelector({
 
   // #286 org default. `defaultName` drives the per-row badge; the notice
   // carries the three end-user-facing states (healthy / draft-warning /
-  // none) plus the drift case.
+  // none) plus the drift and read-failure cases. Every "should this render
+  // at all?" decision comes from the state machine, so an unresolved read
+  // renders nothing at all rather than a claim about the org.
   const defaultName = defaultLanguageName(defaultState);
   const defaultNotice = describeLanguageDefault(defaultState);
-  const defaultUnsupported = defaultState.kind === "unsupported";
+  const defaultControlAvailable = isDefaultControlAvailable(defaultState);
   const selectedIsDefault =
     selectedLanguage !== null && selectedLanguage === defaultName;
 
@@ -318,7 +321,7 @@ export function LanguageSelector({
                 Admin-only (the worker's PUT gate is admin-only too), and
                 absent entirely on a worker without the route pair. */}
             {canSetDefault &&
-              !defaultUnsupported &&
+              defaultControlAvailable &&
               (selectedIsDefault ? (
                 <AlertDialog
                   open={clearDefaultOpen}
@@ -519,8 +522,15 @@ export function LanguageSelector({
       {/* #286 — one line that says what end users actually get. Rendered
           for every viewer (shepherds included: whether their draft is the
           org default changes what "publish" means for them), while the
-          set/clear control above stays admin-only. */}
-      {defaultUnsupported
+          set/clear control above stays admin-only.
+
+          Three renders are deliberately distinct, because they were one
+          line in the first draft and that conflated a slow network with a
+          missing feature:
+            pending     → nothing (no text, no layout shift)
+            unsupported → the quiet admin-only note below
+            error       → a real error notice, never "not available" */}
+      {defaultState.kind === "unsupported"
         ? canSetDefault && (
             <p className="text-muted-foreground text-xs" aria-live="polite">
               Setting an org default language isn&rsquo;t available on this
@@ -531,11 +541,15 @@ export function LanguageSelector({
             <p
               className={cn(
                 "flex items-center gap-1.5 text-xs",
-                defaultNotice.tone === "warning"
-                  ? "rounded-r-md border-l-2 border-amber-500 bg-amber-500/10 px-3 py-2 text-amber-700 dark:text-amber-400"
-                  : "text-muted-foreground"
+                defaultNotice.tone === "warning" &&
+                  "rounded-r-md border-l-2 border-amber-500 bg-amber-500/10 px-3 py-2 text-amber-700 dark:text-amber-400",
+                defaultNotice.tone === "error" &&
+                  "bg-destructive/10 text-destructive border-destructive rounded-r-md border-l-2 px-3 py-2",
+                (defaultNotice.tone === "healthy" ||
+                  defaultNotice.tone === "info") &&
+                  "text-muted-foreground"
               )}
-              role={defaultNotice.tone === "warning" ? "status" : undefined}
+              role={defaultNotice.tone === "error" ? "alert" : undefined}
               aria-live="polite"
             >
               {defaultNotice.tone === "healthy" && (

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -42,22 +42,32 @@ export function useLanguage(name: string | null, org?: string | null) {
   });
 }
 
-export function useSaveLanguage(org?: string | null) {
-  const qc = useQueryClient();
-  const key = normalize(org);
-  return useMutation({
-    mutationFn: ({
-      name,
-      body,
-    }: {
-      name: string;
-      body: { label?: string; document: string; published?: boolean };
-    }) => languagesApi.putLanguage(name, body, undefined, key),
-    onSuccess: (_data, { name }) => {
-      void qc.invalidateQueries({ queryKey: keys.languages(key) });
-      void qc.invalidateQueries({ queryKey: keys.language(name, key) });
+export interface LanguageSaveTarget {
+  name: string;
+  body: { label?: string; document: string; published?: boolean };
+  org: string | null;
+}
+
+// Org pinned in the VARIABLES, same rule as the delete/default mutations
+// (#286 review rd-2 P2-2). The org-context switch dialog offers "Discard
+// and switch" while a save is in flight, so this is a reachable path, not
+// a theoretical one: the PUT for org A settles after the ambient key has
+// become B, and a closure-read key would invalidate B while leaving A's
+// cache holding the pre-save document — a completed save looking lost,
+// and the next edit from that stale base overwriting it for real.
+export function languageSaveMutationOptions(qc: QueryClient) {
+  return {
+    mutationFn: ({ name, body, org }: LanguageSaveTarget) =>
+      languagesApi.putLanguage(name, body, undefined, org),
+    onSuccess: (_data: unknown, { name, org }: LanguageSaveTarget) => {
+      void qc.invalidateQueries({ queryKey: keys.languages(org) });
+      void qc.invalidateQueries({ queryKey: keys.language(name, org) });
     },
-  });
+  };
+}
+
+export function useSaveLanguage() {
+  return useMutation(languageSaveMutationOptions(useQueryClient()));
 }
 
 // Note: publish/unpublish flows through useSaveLanguage with the full body

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -1,6 +1,12 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 
 import * as languagesApi from "@/lib/languages-api";
+import type { OrgDefaultLanguage } from "@/types/language";
 
 // Org is part of every key so a super-admin's cross-org view doesn't collide
 // with the same-org cache. `null` is the canonical same-org placeholder.
@@ -69,9 +75,7 @@ export function useDeleteLanguage(org?: string | null) {
   return useMutation({
     mutationFn: (name: string) =>
       languagesApi.deleteLanguage(name, undefined, key),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: keys.languages(key) });
-    },
+    onSuccess: () => applyLanguageDeletionToCache(qc, key),
   });
 }
 
@@ -95,18 +99,58 @@ export function useOrgDefaultLanguage(org?: string | null) {
 
 // Set (`name`) or clear (`null`) the org default. Writes the server's echo
 // straight into the cache so the badge and the notice flip immediately —
-// the list invalidation that follows only refreshes the published flags the
-// notice reads, and waiting for it would leave the control looking inert
-// for a round-trip.
+// waiting for a refetch would leave the control looking inert for a round
+// trip — and THEN invalidates, so the optimistic value is reconciled
+// against the server rather than trusted indefinitely. Order matters:
+// setQueryData first (instant paint), invalidate second (the correction,
+// including for the echo-shape guess in `setOrgDefaultLanguage`).
 export function useSetOrgDefaultLanguage(org?: string | null) {
   const qc = useQueryClient();
   const key = normalize(org);
   return useMutation({
     mutationFn: (name: string | null) =>
       languagesApi.setOrgDefaultLanguage(name, undefined, key),
-    onSuccess: (data) => {
-      qc.setQueryData(keys.orgDefault(key), data);
-      void qc.invalidateQueries({ queryKey: keys.languages(key) });
-    },
+    onSuccess: (data) => applyOrgDefaultToCache(qc, key, data),
   });
 }
+
+// Cache effects of the two mutations that can move the org default, split
+// out of the hooks so they're unit-testable against a real QueryClient
+// (same convention as the mode-list helpers in use-prompt-config.ts).
+// `org` is the normalized key, never a raw prop.
+
+export function applyOrgDefaultToCache(
+  qc: QueryClient,
+  org: string | null,
+  data: OrgDefaultLanguage
+): void {
+  // Paint first…
+  qc.setQueryData(keys.orgDefault(org), data);
+  // …then reconcile. The optimistic value can be a GUESS: worker#236 pins
+  // the request shape but not the response envelope, so an unrecognized
+  // 2xx body makes `setOrgDefaultLanguage` fall back to the slug we asked
+  // for. Without this invalidation that guess would stand until the next
+  // page load.
+  void qc.invalidateQueries({ queryKey: keys.orgDefault(org) });
+  // The notice reads `published` off the collection, so refresh it too — a
+  // default set on a row published in another tab would otherwise keep
+  // warning "still a draft".
+  void qc.invalidateQueries({ queryKey: keys.languages(org) });
+}
+
+export function applyLanguageDeletionToCache(
+  qc: QueryClient,
+  org: string | null
+): void {
+  void qc.invalidateQueries({ queryKey: keys.languages(org) });
+  // #286 — a delete that SUCCEEDS proves this language was not the org
+  // default (upstream 409s otherwise). That makes a cached default naming
+  // it provably stale: another admin cleared or repointed the default
+  // since our last read, and keeping our copy would render the drift
+  // warning as a pure cache artifact against a language we just deleted.
+  void qc.invalidateQueries({ queryKey: keys.orgDefault(org) });
+}
+
+// Exported for unit tests (tests/use-languages-cache.test.ts) so the
+// key-collision rule above is asserted, not just commented.
+export const languageQueryKeys = keys;

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -8,6 +8,11 @@ const keys = {
   languages: (org: string | null) => ["languages", org] as const,
   language: (name: string, org: string | null) =>
     ["languages", name, org] as const,
+  // NOT ["languages", "default", org]: `default` is a legal language slug,
+  // so that key would collide with the per-language key for a language
+  // literally named "default" — the same collision worker#236 avoided by
+  // naming the route `languages-default` instead of `languages/default`.
+  orgDefault: (org: string | null) => ["languages-default", org] as const,
 };
 
 function normalize(org?: string | null): string | null {
@@ -65,6 +70,42 @@ export function useDeleteLanguage(org?: string | null) {
     mutationFn: (name: string) =>
       languagesApi.deleteLanguage(name, undefined, key),
     onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: keys.languages(key) });
+    },
+  });
+}
+
+// Org default language (#286). Read through its own endpoint rather than
+// off the collection's `defaultLanguage` echo: the collection can't
+// distinguish "no default" from "this worker predates worker#236", and the
+// control must hide itself in the second case instead of asserting the org
+// has no default.
+//
+// `retry: false` — the graceful-absence path already resolves (404/501 →
+// `{ supported: false }`), so a rejection here is a genuine failure and
+// retrying it three times only delays the panel.
+export function useOrgDefaultLanguage(org?: string | null) {
+  const key = normalize(org);
+  return useQuery({
+    queryKey: keys.orgDefault(key),
+    queryFn: ({ signal }) => languagesApi.getOrgDefaultLanguage(signal, key),
+    retry: false,
+  });
+}
+
+// Set (`name`) or clear (`null`) the org default. Writes the server's echo
+// straight into the cache so the badge and the notice flip immediately —
+// the list invalidation that follows only refreshes the published flags the
+// notice reads, and waiting for it would leave the control looking inert
+// for a round-trip.
+export function useSetOrgDefaultLanguage(org?: string | null) {
+  const qc = useQueryClient();
+  const key = normalize(org);
+  return useMutation({
+    mutationFn: (name: string | null) =>
+      languagesApi.setOrgDefaultLanguage(name, undefined, key),
+    onSuccess: (data) => {
+      qc.setQueryData(keys.orgDefault(key), data);
       void qc.invalidateQueries({ queryKey: keys.languages(key) });
     },
   });

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -69,14 +69,34 @@ export function useSaveLanguage(org?: string | null) {
 // either (a) loosening the engine PUT contract to make `document` optional
 // or (b) introducing optimistic concurrency via etag/version.
 
-export function useDeleteLanguage(org?: string | null) {
-  const qc = useQueryClient();
-  const key = normalize(org);
-  return useMutation({
-    mutationFn: (name: string) =>
-      languagesApi.deleteLanguage(name, undefined, key),
-    onSuccess: () => applyLanguageDeletionToCache(qc, key),
-  });
+// The org travels in the mutation VARIABLES, not in a closure over the
+// hook's argument (#286 review): TanStack updates a live mutation's
+// options on every re-render, so an org-context switch made while a write
+// is in flight would hand the settled callback the NEW org's cache key —
+// applying one org's outcome to another org's data. Pinning the target at
+// mutate time makes that structurally impossible; the page's dirty-guard
+// (which now also gates on these mutations being pending) is the first
+// line of defense, this is the second.
+export interface LanguageMutationTarget {
+  name: string;
+  org: string | null;
+}
+
+// Built as a standalone options object (and exported) so a test can drive
+// the exact wiring the hook uses — proving the request target and the
+// cache write both come from the VARIABLES, with no ambient key anywhere
+// in the path.
+export function languageDeleteMutationOptions(qc: QueryClient) {
+  return {
+    mutationFn: ({ name, org }: LanguageMutationTarget) =>
+      languagesApi.deleteLanguage(name, undefined, org),
+    onSuccess: (_data: void, { org }: LanguageMutationTarget) =>
+      applyLanguageDeletionToCache(qc, org),
+  };
+}
+
+export function useDeleteLanguage() {
+  return useMutation(languageDeleteMutationOptions(useQueryClient()));
 }
 
 // Org default language (#286). Read through its own endpoint rather than
@@ -104,14 +124,27 @@ export function useOrgDefaultLanguage(org?: string | null) {
 // against the server rather than trusted indefinitely. Order matters:
 // setQueryData first (instant paint), invalidate second (the correction,
 // including for the echo-shape guess in `setOrgDefaultLanguage`).
-export function useSetOrgDefaultLanguage(org?: string | null) {
-  const qc = useQueryClient();
-  const key = normalize(org);
-  return useMutation({
-    mutationFn: (name: string | null) =>
-      languagesApi.setOrgDefaultLanguage(name, undefined, key),
-    onSuccess: (data) => applyOrgDefaultToCache(qc, key, data),
-  });
+// Same mutate-time pinning as useDeleteLanguage, and for a sharper
+// reason: this mutation WRITES to the cache. A super admin who hits "Set
+// as default" on org A and switches context to org B before the PUT
+// resolves would otherwise see A's result painted into B's cache — B
+// showing a default it doesn't have, A never showing the write it made.
+export interface OrgDefaultMutationTarget {
+  name: string | null;
+  org: string | null;
+}
+
+export function orgDefaultMutationOptions(qc: QueryClient) {
+  return {
+    mutationFn: ({ name, org }: OrgDefaultMutationTarget) =>
+      languagesApi.setOrgDefaultLanguage(name, undefined, org),
+    onSuccess: (data: OrgDefaultLanguage, { org }: OrgDefaultMutationTarget) =>
+      applyOrgDefaultToCache(qc, org, data),
+  };
+}
+
+export function useSetOrgDefaultLanguage() {
+  return useMutation(orgDefaultMutationOptions(useQueryClient()));
 }
 
 // Cache effects of the two mutations that can move the org default, split

--- a/src/lib/context-org-guard.ts
+++ b/src/lib/context-org-guard.ts
@@ -22,3 +22,18 @@ export function decideContextChange(
   if (isDirty || isSaving) return "confirm";
   return "apply";
 }
+
+// Why the confirmation opened. #286 widened the guard to cover in-flight
+// org-scoped writes (a set/clear of the org default, a delete), which are
+// NOT "unsaved edits" — telling a user their typing is at risk when they
+// haven't typed anything is a false alarm that teaches them to click
+// through the dialog. The page picks its copy from this.
+export type ContextSwitchReason = "dirty" | "pending-write" | "both";
+
+export function contextSwitchReason(
+  isDirty: boolean,
+  hasPendingWrite: boolean
+): ContextSwitchReason {
+  if (isDirty && hasPendingWrite) return "both";
+  return isDirty ? "dirty" : "pending-write";
+}

--- a/src/lib/language-default-state.ts
+++ b/src/lib/language-default-state.ts
@@ -1,10 +1,18 @@
 // Pure state machine for the Languages page's org-default control (#286).
 //
 // The panel has to say one of a small number of things, and each one is a
-// different *operational* claim about what end users get:
+// different *operational* claim about what end users get. Two of them are
+// claims about the ORG and must never be made from an unresolved read:
 //
+//   pending     → we don't know yet (either query still in flight). Render
+//                 nothing: no notice, no control, no toolbar shift.
 //   unsupported → the worker has no languages-default route (worker#236
-//                 hasn't shipped); we say nothing about defaults at all.
+//                 hasn't shipped). Admins get a quiet note; nobody else
+//                 sees anything.
+//   error       → the read genuinely failed (404/501 resolve as
+//                 `unsupported`, so this is a 5xx or a network fault).
+//                 Say so — silently claiming the feature doesn't exist
+//                 would be a lie the user can't diagnose.
 //   none        → no default set: end users only get tuning when they
 //                 type `@language`.
 //   healthy     → default points at a published language: end users get
@@ -18,39 +26,76 @@
 //                 state — worth saying out loud rather than mislabelling
 //                 it as "unpublished".
 //
-// Keeping this out of the component means the wording and the severity are
+// `missing` is the reason this function takes the collection's loading
+// state rather than a plain array: the default payload is tiny and always
+// lands before the catalog, so treating an unresolved list as an empty one
+// would fire the drift warning on every page load and every org switch —
+// and permanently if the collection query fails.
+//
+// Keeping all of this out of the component means the wording, the
+// severity, and the "should anything render at all?" decision are
 // unit-testable without a DOM.
 
 import type { Language, OrgDefaultLanguage } from "@/types/language";
 
 export type LanguageDefaultState =
+  | { kind: "pending" }
   | { kind: "unsupported" }
+  | { kind: "error" }
   | { kind: "none" }
   | { kind: "healthy"; name: string; label?: string }
   | { kind: "unpublished"; name: string; label?: string }
   | { kind: "missing"; name: string };
 
-export type LanguageDefaultTone = "healthy" | "warning" | "info";
+export type LanguageDefaultTone = "healthy" | "warning" | "info" | "error";
 
 export interface LanguageDefaultNotice {
   tone: LanguageDefaultTone;
   message: string;
 }
 
+export interface LanguageDefaultInputs {
+  /** Resolved payload of the org-default query. `undefined` while the
+      query is pending OR after it rejected — which is why the two flags
+      below are separate inputs and not inferred from it. */
+  orgDefault: OrgDefaultLanguage | undefined;
+  /** Org-default query still in flight. */
+  isPending: boolean;
+  /** Org-default query rejected. 404/501 RESOLVE as
+      `{ supported: false }` (src/lib/languages-api.ts), so reaching here
+      means a real failure — a 5xx, a network fault, a malformed body. */
+  isError: boolean;
+  /** The org's languages, or `undefined` while the collection query is
+      unresolved. Only a RESOLVED list can prove a default is dangling. */
+  languages: Pick<Language, "name" | "label" | "published">[] | undefined;
+}
+
 export function computeLanguageDefaultState(
-  orgDefault: OrgDefaultLanguage | undefined,
-  languages: Pick<Language, "name" | "label" | "published">[] | undefined
+  inputs: LanguageDefaultInputs
 ): LanguageDefaultState {
-  // `undefined` = the query hasn't answered yet. Treat it exactly like an
-  // absent endpoint: render nothing rather than flashing "no default set"
-  // (which is a claim, not a loading state) on every page load.
-  if (orgDefault === undefined || orgDefault.supported !== true) {
-    return { kind: "unsupported" };
-  }
+  const { orgDefault, isPending, isError, languages } = inputs;
+
+  // Error before pending: TanStack reports `isPending: false` once a query
+  // settles, including when it settled as a failure, but a caller passing
+  // a stale `isPending: true` alongside an error must still surface the
+  // error rather than spin forever.
+  if (isError) return { kind: "error" };
+  // `orgDefault === undefined` covers the honest gap where a caller hasn't
+  // wired isPending (and the very first render, before the flag flips).
+  if (isPending || orgDefault === undefined) return { kind: "pending" };
+  if (orgDefault.supported !== true) return { kind: "unsupported" };
+
   const name = orgDefault.name;
   if (name === null) return { kind: "none" };
 
-  const entry = (languages ?? []).find((l) => l.name === name);
+  // A default exists but the catalog hasn't landed: we know there IS a
+  // default and nothing else. Stay quiet instead of guessing at published
+  // (would understate) or dangling (would slander). If the collection
+  // query is what failed, the page's own list-error banner is already
+  // saying so — this control has nothing to add.
+  if (languages === undefined) return { kind: "pending" };
+
+  const entry = languages.find((l) => l.name === name);
   if (entry === undefined) return { kind: "missing", name };
   return {
     kind: entry.published === true ? "healthy" : "unpublished",
@@ -59,14 +104,21 @@ export function computeLanguageDefaultState(
   };
 }
 
-// Human-readable rendering of a state. `null` means "render nothing" —
-// only the unsupported state, which the control hides itself for.
+// Human-readable rendering of a state. `null` means "render no notice" —
+// the states with nothing truthful to say yet.
 export function describeLanguageDefault(
   state: LanguageDefaultState
 ): LanguageDefaultNotice | null {
   switch (state.kind) {
+    case "pending":
     case "unsupported":
       return null;
+    case "error":
+      return {
+        tone: "error",
+        message:
+          "Couldn't load this org's default language. Reload the page to try again — the default itself is unchanged.",
+      };
     case "none":
       return {
         tone: "info",
@@ -88,6 +140,23 @@ export function describeLanguageDefault(
         tone: "warning",
         message: `The org default points at "${state.name}", which isn't in this org's language list. Pick a new default.`,
       };
+  }
+}
+
+// May the set/clear control render at all? Only once we know the org's
+// actual default state — offering "Set as default" against an unknown
+// current value invites a write the admin can't predict the effect of.
+// (Whether the VIEWER may use it is a separate, admin-only gate.)
+export function isDefaultControlAvailable(
+  state: LanguageDefaultState
+): boolean {
+  switch (state.kind) {
+    case "pending":
+    case "unsupported":
+    case "error":
+      return false;
+    default:
+      return true;
   }
 }
 

--- a/src/lib/language-default-state.ts
+++ b/src/lib/language-default-state.ts
@@ -1,0 +1,111 @@
+// Pure state machine for the Languages page's org-default control (#286).
+//
+// The panel has to say one of a small number of things, and each one is a
+// different *operational* claim about what end users get:
+//
+//   unsupported → the worker has no languages-default route (worker#236
+//                 hasn't shipped); we say nothing about defaults at all.
+//   none        → no default set: end users only get tuning when they
+//                 type `@language`.
+//   healthy     → default points at a published language: end users get
+//                 that language's tuning without asking.
+//   unpublished → default points at a DRAFT. Deliberately legal (stage →
+//                 test via the admin draft bypass → publish), but until
+//                 it's published end users get nothing.
+//   missing     → default points at a slug that isn't in the org's list.
+//                 Upstream 409s on deleting the current default, so this
+//                 is drift (direct KV edit, or a race), not a normal
+//                 state — worth saying out loud rather than mislabelling
+//                 it as "unpublished".
+//
+// Keeping this out of the component means the wording and the severity are
+// unit-testable without a DOM.
+
+import type { Language, OrgDefaultLanguage } from "@/types/language";
+
+export type LanguageDefaultState =
+  | { kind: "unsupported" }
+  | { kind: "none" }
+  | { kind: "healthy"; name: string; label?: string }
+  | { kind: "unpublished"; name: string; label?: string }
+  | { kind: "missing"; name: string };
+
+export type LanguageDefaultTone = "healthy" | "warning" | "info";
+
+export interface LanguageDefaultNotice {
+  tone: LanguageDefaultTone;
+  message: string;
+}
+
+export function computeLanguageDefaultState(
+  orgDefault: OrgDefaultLanguage | undefined,
+  languages: Pick<Language, "name" | "label" | "published">[] | undefined
+): LanguageDefaultState {
+  // `undefined` = the query hasn't answered yet. Treat it exactly like an
+  // absent endpoint: render nothing rather than flashing "no default set"
+  // (which is a claim, not a loading state) on every page load.
+  if (orgDefault === undefined || orgDefault.supported !== true) {
+    return { kind: "unsupported" };
+  }
+  const name = orgDefault.name;
+  if (name === null) return { kind: "none" };
+
+  const entry = (languages ?? []).find((l) => l.name === name);
+  if (entry === undefined) return { kind: "missing", name };
+  return {
+    kind: entry.published === true ? "healthy" : "unpublished",
+    name,
+    ...(entry.label === undefined ? {} : { label: entry.label }),
+  };
+}
+
+// Human-readable rendering of a state. `null` means "render nothing" —
+// only the unsupported state, which the control hides itself for.
+export function describeLanguageDefault(
+  state: LanguageDefaultState
+): LanguageDefaultNotice | null {
+  switch (state.kind) {
+    case "unsupported":
+      return null;
+    case "none":
+      return {
+        tone: "info",
+        message:
+          "No default language is set — end users only get tuning when they ask for a language with @language.",
+      };
+    case "healthy":
+      return {
+        tone: "healthy",
+        message: `${displayName(state)} is the org default — end users get its tuning without asking.`,
+      };
+    case "unpublished":
+      return {
+        tone: "warning",
+        message: `${displayName(state)} is the org default but is still a draft — end users get no tuning until it's published.`,
+      };
+    case "missing":
+      return {
+        tone: "warning",
+        message: `The org default points at "${state.name}", which isn't in this org's language list. Pick a new default.`,
+      };
+  }
+}
+
+// The slug the default currently points at, or null. Convenience for the
+// per-row "Default" badge so components don't re-destructure the union.
+export function defaultLanguageName(
+  state: LanguageDefaultState
+): string | null {
+  switch (state.kind) {
+    case "healthy":
+    case "unpublished":
+    case "missing":
+      return state.name;
+    default:
+      return null;
+  }
+}
+
+function displayName(state: { name: string; label?: string }): string {
+  return `"${state.label ?? state.name}"`;
+}

--- a/src/lib/language-default-state.ts
+++ b/src/lib/language-default-state.ts
@@ -106,8 +106,16 @@ export function computeLanguageDefaultState(
 
 // Human-readable rendering of a state. `null` means "render no notice" —
 // the states with nothing truthful to say yet.
+//
+// `canSetDefault` (admin powers — the worker's PUT gate on
+// /api/config/languages-default) only ever changes copy that PRESCRIBES an
+// action. A shepherd holding edit+publish on the default language can see
+// every one of these states, but cannot act on the ones that require
+// writing the org default, so telling them to "pick a new default" sends
+// them at a button they will never be shown.
 export function describeLanguageDefault(
-  state: LanguageDefaultState
+  state: LanguageDefaultState,
+  canSetDefault: boolean
 ): LanguageDefaultNotice | null {
   switch (state.kind) {
     case "pending":
@@ -138,7 +146,11 @@ export function describeLanguageDefault(
     case "missing":
       return {
         tone: "warning",
-        message: `The org default points at "${state.name}", which isn't in this org's language list. Pick a new default.`,
+        message: `The org default points at "${state.name}", which isn't in this org's language list. ${
+          canSetDefault
+            ? "Pick a new default, or clear it."
+            : "Ask an admin to pick a new default."
+        }`,
       };
   }
 }

--- a/src/lib/language-error-surface.ts
+++ b/src/lib/language-error-surface.ts
@@ -25,6 +25,23 @@ export function isDefaultBlockedDeleteError(error: unknown): boolean {
   return error instanceof LanguageIsDefaultError;
 }
 
+// Should the delete dialog offer an inline "clear the org default" action
+// alongside the 409?
+//
+// Deliberately does NOT consult `LanguageDefaultState`: when the
+// languages-default GET is failing, that state machine withholds the
+// toolbar Set/Clear controls (correctly — it can't say what the default
+// currently is), but the SERVER still has a default and still refuses the
+// delete. Keying the recovery off the read would leave an admin holding a
+// 409 whose instructions name controls that aren't on screen. Clearing is
+// a write; it doesn't require a successful read to be legal.
+export function shouldOfferDefaultRecovery(
+  deleteError: unknown,
+  canSetDefault: boolean
+): boolean {
+  return canSetDefault && isDefaultBlockedDeleteError(deleteError);
+}
+
 // The error the page-level "Save failed:" banner should render, or null.
 // Forbidden errors have their own dedicated banner; the org-default 409
 // belongs to the delete dialog alone.

--- a/src/lib/language-error-surface.ts
+++ b/src/lib/language-error-surface.ts
@@ -1,0 +1,65 @@
+// Where a language mutation's failure is allowed to appear, and in whose
+// words (#286 review). Two rules, both pure so they can be pinned by
+// tests instead of by inspection of a component tree.
+//
+// Rule 1 — ONE surface per failure. The delete dialog stays open on
+// rejection and renders the message inline (#102), so any error a dialog
+// owns must not ALSO reach the page banner: while the failure is current
+// the second copy is redundant, and after the user fixes it the banner
+// keeps asserting a block that no longer exists. (modes.tsx applies the
+// same policy to its clone/retire dialogs.)
+//
+// Rule 2 — copy that PRESCRIBES an action depends on who is reading. The
+// API layer knows the error class; only the UI knows whether this viewer
+// holds the rights the recovery needs.
+
+import {
+  LanguageForbiddenError,
+  LanguageIsDefaultError,
+} from "@/lib/languages-api";
+
+// True when a delete was refused because the language is (or may be) the
+// org default. The page uses this to drop a stale 409 once the admin
+// changes or clears the default — the very action that unblocks it.
+export function isDefaultBlockedDeleteError(error: unknown): boolean {
+  return error instanceof LanguageIsDefaultError;
+}
+
+// The error the page-level "Save failed:" banner should render, or null.
+// Forbidden errors have their own dedicated banner; the org-default 409
+// belongs to the delete dialog alone.
+export function selectLanguageMutationBanner(
+  saveError: unknown,
+  deleteError: unknown
+): Error | null {
+  if (
+    saveError instanceof Error &&
+    !(saveError instanceof LanguageForbiddenError)
+  ) {
+    return saveError;
+  }
+  if (
+    deleteError instanceof Error &&
+    !(deleteError instanceof LanguageForbiddenError) &&
+    !isDefaultBlockedDeleteError(deleteError)
+  ) {
+    return deleteError;
+  }
+  return null;
+}
+
+// Copy for a failed language DELETE. Per-row edit+publish rights are
+// enough to delete a language, but changing the org default is admin-only
+// — so a shepherd can reach this 409 and be unable to perform the recovery
+// the admin copy prescribes.
+export function describeLanguageDeleteError(
+  error: unknown,
+  canSetDefault: boolean
+): string {
+  if (error instanceof LanguageIsDefaultError) {
+    return canSetDefault
+      ? `"${error.languageName}" can't be deleted right now — it may be this org's default language. Set a different default, or clear it, then try again.`
+      : `"${error.languageName}" can't be deleted right now — it may be this org's default language. Ask an admin to change or clear the default, then try again.`;
+  }
+  return error instanceof Error ? error.message : "Failed to delete language.";
+}

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -179,16 +179,34 @@ export async function deleteLanguage(
 // form would collide with a real language named "default".
 const DEFAULT_LANGUAGE_PATH = "/api/config/languages-default";
 
-// Upstream answers `{ name: string | null }`. Anything else (a stray
-// object, an empty string) normalizes to "no default" rather than being
-// trusted as a slug — a bogus reference would render a warning about a
-// language that doesn't exist.
-function readDefaultName(data: unknown): string | null {
-  if (data === null || typeof data !== "object") return null;
+// Upstream answers `{ name: string | null }`.
+//
+// The read is DISCRIMINATED — "the body didn't tell us" is a different
+// answer from "the body said there is no default" (#286 review rd-3).
+// Collapsing both to `null` was fine for GET, where either way there's
+// nothing to show, but wrong for PUT: the caller falls back to the
+// requested slug when the envelope is unreadable, and a valid
+// `{"name": null}` echo (the server saying "it is now unset") would get
+// overwritten by the very slug the server declined to store.
+//
+// A `name` present but neither string nor null (`42`, an object) counts as
+// UNRECOGNIZED, not as an explicit unset: a garbage value is evidence the
+// envelope isn't what we think it is, not a statement about the default.
+type DefaultNameRead =
+  | { present: false }
+  | { present: true; name: string | null };
+
+function readDefaultName(data: unknown): DefaultNameRead {
+  if (data === null || typeof data !== "object") return { present: false };
+  if (!("name" in data)) return { present: false };
   const name = (data as { name?: unknown }).name;
-  if (typeof name !== "string") return null;
+  if (name === null) return { present: true, name: null };
+  if (typeof name !== "string") return { present: false };
+  // An empty/whitespace slug is a name-shaped nothing — normalize it to
+  // "no default" rather than letting it through as a reference that would
+  // render a warning about a language nobody can find.
   const trimmed = name.trim();
-  return trimmed === "" ? null : trimmed;
+  return { present: true, name: trimmed === "" ? null : trimmed };
 }
 
 export async function getOrgDefaultLanguage(
@@ -212,7 +230,10 @@ export async function getOrgDefaultLanguage(
     throw new Error(`Failed to load default language (${res.status}): ${body}`);
   }
 
-  return { supported: true, name: readDefaultName(await res.json()) };
+  // On the READ path both "no name field" and "name: null" mean the same
+  // thing to the caller: this org has no default.
+  const echo = readDefaultName(await res.json());
+  return { supported: true, name: echo.present ? echo.name : null };
 }
 
 // `name: null` clears the default; a slug sets it. Rejects with a
@@ -248,14 +269,19 @@ export async function setOrgDefaultLanguage(
     );
   }
 
-  // Trust the server's echo only when we can actually read a slug out of
-  // it; otherwise fall back to what we asked for. worker#236 fixes the
-  // request shape but not the response envelope, so a 2xx body we don't
-  // recognize (`{}`, `{"ok":true}`, `{"defaultLanguage":"hindi"}`, a
-  // bodyless 204) must not be read as "the default is now unset" — that
-  // would make a SUCCESSFUL set render "No default language is set" with
-  // nothing to correct it until the next page load. The mutation's cache
-  // invalidation is the backstop that reconciles a wrong guess here.
+  // Server echo wins whenever the body actually carries one — INCLUDING an
+  // explicit `{"name": null}`. The server saying "it is now unset" is a
+  // fact about the org, and overwriting it with the slug we asked for
+  // would report a default that upstream just declined to store.
+  //
+  // The fallback exists only for the case where the body tells us nothing:
+  // worker#236 fixes the request shape but not the response envelope, so a
+  // 2xx we don't recognize (`{}`, `{"ok":true}`,
+  // `{"defaultLanguage":"hindi"}`, a bodyless 204) must not read as "the
+  // default is now unset" — that would make a SUCCESSFUL set render "No
+  // default language is set". The mutation's cache invalidation is the
+  // backstop that reconciles that guess.
   const data: unknown = await res.json().catch(() => null);
-  return { supported: true, name: readDefaultName(data) ?? name };
+  const echo = readDefaultName(data);
+  return { supported: true, name: echo.present ? echo.name : name };
 }

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -36,7 +36,7 @@ export class LanguageForbiddenError extends Error {
 // default is admin-only, while deleting a language only needs per-row
 // edit+publish) is not knowable in this layer, so the render layer
 // composes the actionable sentence — see `describeLanguageDeleteError` in
-// src/lib/language-default-state.ts.
+// src/lib/language-error-surface.ts.
 export class LanguageIsDefaultError extends Error {
   constructor(public readonly languageName: string) {
     super(

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -30,10 +30,17 @@ export class LanguageForbiddenError extends Error {
 // delete was refused) and offers the known cause as the likely one:
 // confidently wrong copy is worse than hedged copy the user can act on.
 // Tighten this to an exact claim once the upstream body shape is known.
+//
+// The message here is deliberately ROLE-NEUTRAL: it states the situation
+// and stops. Whether the reader can perform the recovery (changing the org
+// default is admin-only, while deleting a language only needs per-row
+// edit+publish) is not knowable in this layer, so the render layer
+// composes the actionable sentence — see `describeLanguageDeleteError` in
+// src/lib/language-default-state.ts.
 export class LanguageIsDefaultError extends Error {
   constructor(public readonly languageName: string) {
     super(
-      `"${languageName}" can't be deleted right now — it may be this org's default language. Set a different default, or clear it, then try again.`
+      `"${languageName}" can't be deleted right now — it may be this org's default language, which has to be changed or cleared first.`
     );
     this.name = "LanguageIsDefaultError";
   }

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -22,14 +22,18 @@ export class LanguageForbiddenError extends Error {
   }
 }
 
-// Thrown when DELETE is refused because the language is the org's default
-// (#286 — upstream answers 409, "unset or reassign the default first").
-// A distinct class so the delete dialog can render the actionable recovery
-// step instead of the raw `Failed to delete language (409)` text.
+// Thrown when DELETE is refused with a 409. worker#236 specifies exactly
+// one 409 on this route — "the language is the org default; unset or
+// reassign it first" — but does NOT pin an error body, so there is no
+// discriminator to key on and a future second conflict reason would land
+// here too. The wording therefore leads with the observable fact (the
+// delete was refused) and offers the known cause as the likely one:
+// confidently wrong copy is worse than hedged copy the user can act on.
+// Tighten this to an exact claim once the upstream body shape is known.
 export class LanguageIsDefaultError extends Error {
   constructor(public readonly languageName: string) {
     super(
-      `"${languageName}" is this org's default language. Set a different default — or clear it — before deleting this language.`
+      `"${languageName}" can't be deleted right now — it may be this org's default language. Set a different default, or clear it, then try again.`
     );
     this.name = "LanguageIsDefaultError";
   }
@@ -237,11 +241,14 @@ export async function setOrgDefaultLanguage(
     );
   }
 
-  // Trust the server's echo when it sends one; a bodyless 204 falls back to
-  // what we asked for, which is what the caller is about to render.
+  // Trust the server's echo only when we can actually read a slug out of
+  // it; otherwise fall back to what we asked for. worker#236 fixes the
+  // request shape but not the response envelope, so a 2xx body we don't
+  // recognize (`{}`, `{"ok":true}`, `{"defaultLanguage":"hindi"}`, a
+  // bodyless 204) must not be read as "the default is now unset" — that
+  // would make a SUCCESSFUL set render "No default language is set" with
+  // nothing to correct it until the next page load. The mutation's cache
+  // invalidation is the backstop that reconciles a wrong guess here.
   const data: unknown = await res.json().catch(() => null);
-  return {
-    supported: true,
-    name: data === null ? name : readDefaultName(data),
-  };
+  return { supported: true, name: readDefaultName(data) ?? name };
 }

--- a/src/lib/languages-api.ts
+++ b/src/lib/languages-api.ts
@@ -1,5 +1,9 @@
 import { buildConfigUrl } from "@/lib/config-url";
-import type { Language, OrgLanguages } from "@/types/language";
+import type {
+  Language,
+  OrgDefaultLanguage,
+  OrgLanguages,
+} from "@/types/language";
 
 const SAME_ORIGIN_HEADERS = {
   "X-Requested-With": "XMLHttpRequest",
@@ -16,6 +20,27 @@ export class LanguageForbiddenError extends Error {
     super(`Forbidden: ${operation} on language "${languageName}"`);
     this.name = "LanguageForbiddenError";
   }
+}
+
+// Thrown when DELETE is refused because the language is the org's default
+// (#286 — upstream answers 409, "unset or reassign the default first").
+// A distinct class so the delete dialog can render the actionable recovery
+// step instead of the raw `Failed to delete language (409)` text.
+export class LanguageIsDefaultError extends Error {
+  constructor(public readonly languageName: string) {
+    super(
+      `"${languageName}" is this org's default language. Set a different default — or clear it — before deleting this language.`
+    );
+    this.name = "LanguageIsDefaultError";
+  }
+}
+
+// Status codes that mean "this worker has no languages-default route yet"
+// rather than "something went wrong". 404 is the honest answer from a
+// worker predating worker#236; 501 is the explicit not-implemented shape.
+// Both degrade to a hidden control — never a page-load error (#286).
+function isUnsupportedStatus(status: number): boolean {
+  return status === 404 || status === 501;
 }
 
 export async function listLanguages(
@@ -121,8 +146,102 @@ export async function deleteLanguage(
   if (res.status === 403) {
     throw new LanguageForbiddenError(name, "delete");
   }
+  // #286 — upstream refuses to delete the language the org default points
+  // at. Map it to the typed error so the confirmation dialog can tell the
+  // user what to do about it (the generic branch below would surface the
+  // upstream body verbatim).
+  if (res.status === 409) {
+    throw new LanguageIsDefaultError(name);
+  }
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Failed to delete language (${res.status}): ${body}`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Org default language (#286 / worker#236)
+// ---------------------------------------------------------------------------
+
+// The route pair is deliberately `languages-default`, NOT
+// `languages/default` — `default` is a legal language slug, so the nested
+// form would collide with a real language named "default".
+const DEFAULT_LANGUAGE_PATH = "/api/config/languages-default";
+
+// Upstream answers `{ name: string | null }`. Anything else (a stray
+// object, an empty string) normalizes to "no default" rather than being
+// trusted as a slug — a bogus reference would render a warning about a
+// language that doesn't exist.
+function readDefaultName(data: unknown): string | null {
+  if (data === null || typeof data !== "object") return null;
+  const name = (data as { name?: unknown }).name;
+  if (typeof name !== "string") return null;
+  const trimmed = name.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export async function getOrgDefaultLanguage(
+  signal?: AbortSignal,
+  org?: string | null
+): Promise<OrgDefaultLanguage> {
+  const res = await fetch(buildConfigUrl(DEFAULT_LANGUAGE_PATH, org), {
+    headers: SAME_ORIGIN_HEADERS,
+    signal,
+  });
+
+  // Graceful absence: the worker endpoint ships in Ian's lane, so until it
+  // lands every portal deploy gets a 404 here. Resolving (rather than
+  // rejecting) keeps the Languages page free of a load-time error banner —
+  // the caller renders the control as unavailable instead.
+  if (isUnsupportedStatus(res.status)) {
+    return { supported: false };
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to load default language (${res.status}): ${body}`);
+  }
+
+  return { supported: true, name: readDefaultName(await res.json()) };
+}
+
+// `name: null` clears the default; a slug sets it. Rejects with a
+// user-presentable message — the control renders `error.message` inline.
+export async function setOrgDefaultLanguage(
+  name: string | null,
+  signal?: AbortSignal,
+  org?: string | null
+): Promise<OrgDefaultLanguage> {
+  const res = await fetch(buildConfigUrl(DEFAULT_LANGUAGE_PATH, org), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...SAME_ORIGIN_HEADERS },
+    body: JSON.stringify({ name }),
+    signal,
+  });
+
+  if (res.status === 403) {
+    throw new Error(
+      "You don't have permission to change this org's default language. Only admins can set or clear it."
+    );
+  }
+  if (isUnsupportedStatus(res.status)) {
+    throw new Error(
+      "This org's worker doesn't support a default language yet. Reload once it's been deployed."
+    );
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    // 400/409 from upstream carry the reason (unknown slug, for instance);
+    // pass the body through so the user sees it rather than a bare status.
+    throw new Error(
+      `Failed to update the default language (${res.status})${body ? `: ${body}` : ""}`
+    );
+  }
+
+  // Trust the server's echo when it sends one; a bodyless 204 falls back to
+  // what we asked for, which is what the caller is about to render.
+  const data: unknown = await res.json().catch(() => null);
+  return {
+    supported: true,
+    name: data === null ? name : readDefaultName(data),
+  };
 }

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -7,4 +7,21 @@ export interface Language {
 
 export interface OrgLanguages {
   languages: Language[];
+  // #286 / worker#236 — the `name` slug of the org's default language.
+  // A REFERENCE into `languages`, never a copy. Absent means either "no
+  // default set" or "this worker predates the contract"; the collection
+  // read cannot tell those apart, which is why availability is decided by
+  // the dedicated `GET /api/config/languages-default` (see
+  // `OrgDefaultLanguage`) and this field is only a convenience echo.
+  defaultLanguage?: string | null;
 }
+
+// Availability-aware read of the org default (#286). The
+// `languages-default` route pair is not deployed on every worker yet, so
+// "the endpoint answered with no default" (`supported: true, name: null`)
+// must stay distinguishable from "the endpoint isn't there" — the UI hides
+// the control entirely in the second case instead of claiming the org has
+// no default.
+export type OrgDefaultLanguage =
+  | { supported: true; name: string | null }
+  | { supported: false };

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -8,11 +8,15 @@ export interface Language {
 export interface OrgLanguages {
   languages: Language[];
   // #286 / worker#236 — the `name` slug of the org's default language.
-  // A REFERENCE into `languages`, never a copy. Absent means either "no
-  // default set" or "this worker predates the contract"; the collection
-  // read cannot tell those apart, which is why availability is decided by
-  // the dedicated `GET /api/config/languages-default` (see
-  // `OrgDefaultLanguage`) and this field is only a convenience echo.
+  // A REFERENCE into `languages`, never a copy.
+  //
+  // Declared for contract fidelity and DELIBERATELY NOT a UI source of
+  // truth: absent here is ambiguous between "no default set" and "this
+  // worker predates the contract", and the control must hide itself in
+  // the second case rather than assert the first. The dedicated
+  // `GET /api/config/languages-default` (→ `OrgDefaultLanguage`) is the
+  // only read the panel trusts. Do not wire the badge or the notice off
+  // this field.
   defaultLanguage?: string | null;
 }
 

--- a/tests/config-languages-default.test.ts
+++ b/tests/config-languages-default.test.ts
@@ -1,0 +1,294 @@
+import { env } from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { handleConfig } from "../worker/config";
+import type { SessionData } from "../worker/types";
+
+// #286 — BFF proxy for the org default language pair (contract:
+// worker#236). The route does not exist upstream yet, so every test here
+// mocks the engine; what's pinned is the PORTAL's behavior: who may write,
+// which org the request is scoped to, and that nothing leaks upstream when
+// the gate fires.
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const PATH = "/api/config/languages-default";
+
+function makeSession(overrides: Partial<SessionData> = {}): SessionData {
+  return {
+    userId: crypto.randomUUID(),
+    email: "alice@acme.com",
+    name: "Alice",
+    org: "acme",
+    isAdmin: false,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function spyFetch(status = 200, body: unknown = { name: null }) {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify(body), { status }))
+    );
+}
+
+function get(query = ""): Request {
+  return new Request(`https://portal.example.test${PATH}${query}`);
+}
+
+function put(name: string | null, query = ""): Request {
+  return new Request(`https://portal.example.test${PATH}${query}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+}
+
+describe("#286 languages-default — GET is open to any session", () => {
+  it("non-admin GET → proxies to the org's languages-default", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(get(), env, makeSession(), PATH);
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+      "https://engine.example.test/api/v1/admin/orgs/acme/languages-default"
+    );
+  });
+
+  it("reads pass the shared admin token upstream (trusted-portal model)", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(get(), env, makeSession(), PATH);
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test-engine-key"
+    );
+  });
+
+  it("passes an upstream 404 through unchanged (route not deployed yet)", async () => {
+    // The graceful-absence path in src/lib/languages-api.ts keys on this
+    // status, so the BFF must not rewrite it into a 500 or an empty 200.
+    spyFetch(404, { error: "Not found" });
+    const res = await handleConfig(get(), env, makeSession(), PATH);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("#286 languages-default — PUT is admin-only", () => {
+  it("non-admin PUT → 403 and nothing reaches upstream", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(put("hindi"), env, makeSession(), PATH);
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("a language shepherd with FULL per-row rights still cannot set the default", async () => {
+    // The org default is one pointer shared by every end user in the org.
+    // Per-row rights scope shepherds to rows; letting edit+publish on
+    // "hindi" redirect the whole org's tuning (or demote another
+    // shepherd's language) would be an org-wide write bought with a
+    // per-row grant.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      put("hindi"),
+      env,
+      makeSession({
+        language_edit_rights: "*",
+        language_publish_rights: "*",
+        language_rights: "*",
+      }),
+      PATH
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("admin PUT → proxies with the body intact", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      put("hindi"),
+      env,
+      makeSession({ isAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual({ name: "hindi" });
+  });
+
+  it("admin PUT { name: null } clears the default (null survives the proxy)", async () => {
+    // JSON.stringify round-tripping through proxyToEngine must not drop or
+    // coerce the null — it is the clear signal in the worker#236 contract.
+    const fetchSpy = spyFetch();
+    await handleConfig(put(null), env, makeSession({ isAdmin: true }), PATH);
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({ name: null });
+  });
+
+  it("super admin without isAdmin may write (super trumps isAdmin)", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      put("hindi"),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("malformed PUT body from an admin → 400, no upstream call", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(`https://portal.example.test${PATH}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: "{ not json",
+      }),
+      env,
+      makeSession({ isAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("DELETE is not part of the pair → rejected without an upstream call", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      new Request(`https://portal.example.test${PATH}`, { method: "DELETE" }),
+      env,
+      makeSession({ isAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(405);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes an upstream 409 through (default must reference a real entry)", async () => {
+    spyFetch(409, { error: "unknown language" });
+    const res = await handleConfig(
+      put("nope"),
+      env,
+      makeSession({ isAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(409);
+  });
+});
+
+describe("#286 languages-default — org scoping (#247 exact match)", () => {
+  it("?org=<own org> resolves as same-org for an org admin", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      put("hindi", "?org=acme"),
+      env,
+      makeSession({ isAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(200);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/acme/languages-default"
+    );
+  });
+
+  it("?org=<other org> from a non-super-admin → 403, nothing proxied", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      put("hindi", "?org=word-collective"),
+      env,
+      makeSession({ isAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("?org=<other org> from a super admin → proxied to THAT org", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      put("hindi", "?org=word-collective"),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(200);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      "/api/v1/admin/orgs/word-collective/languages-default"
+    );
+  });
+
+  it("a case-variant of the caller's org is a DIFFERENT org, not a same-org alias", async () => {
+    // Exact-match compare per #247 / the KV key rule: "ACME" is either a
+    // genuinely distinct org or a probe, and both must stay loud instead
+    // of silently retargeting to session.org.
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      put("hindi", "?org=ACME"),
+      env,
+      makeSession({ isAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("GET is org-scoped too — cross-org read needs isSuperAdmin", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      get("?org=word-collective"),
+      env,
+      makeSession({ isAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("an org needing URL encoding is encoded exactly once", async () => {
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      get("?org=word%20collective"),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      PATH
+    );
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+      "https://engine.example.test/api/v1/admin/orgs/word%20collective/languages-default"
+    );
+  });
+
+  it("a path-shaped org is rejected before any upstream call", async () => {
+    const fetchSpy = spyFetch();
+    const res = await handleConfig(
+      get("?org=.."),
+      env,
+      makeSession({ isAdmin: false, isSuperAdmin: true }),
+      PATH
+    );
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("#286 languages-default — route does not shadow a language named 'default'", () => {
+  it("/api/config/languages/default still addresses the LANGUAGE", async () => {
+    // The whole reason the contract uses `languages-default` instead of
+    // `languages/default`: "default" is a legal language slug.
+    const fetchSpy = spyFetch();
+    await handleConfig(
+      new Request("https://portal.example.test/api/config/languages/default"),
+      env,
+      makeSession(),
+      "/api/config/languages/default"
+    );
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+      "https://engine.example.test/api/v1/admin/orgs/acme/languages/default"
+    );
+  });
+});

--- a/tests/context-org-guard.test.ts
+++ b/tests/context-org-guard.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { decideContextChange } from "../src/lib/context-org-guard";
+import {
+  contextSwitchReason,
+  decideContextChange,
+} from "../src/lib/context-org-guard";
 
 describe("decideContextChange", () => {
   // The no-op branch must fire before any dirty/saving check — picking
@@ -62,5 +65,31 @@ describe("decideContextChange", () => {
         "confirm"
       );
     });
+  });
+});
+
+// #286 widened the guard's trigger to include in-flight org-scoped writes
+// (setting/clearing the org default, deleting a language). Those are not
+// unsaved edits, and the dialog must not say they are — a warning about
+// typing you never did is a false alarm, and false alarms teach people to
+// click through the one that matters.
+describe("contextSwitchReason", () => {
+  it("dirty editor only → 'dirty'", () => {
+    expect(contextSwitchReason(true, false)).toBe("dirty");
+  });
+
+  it("in-flight write with a clean editor → 'pending-write', not 'dirty'", () => {
+    expect(contextSwitchReason(false, true)).toBe("pending-write");
+  });
+
+  it("both at once → 'both'", () => {
+    expect(contextSwitchReason(true, true)).toBe("both");
+  });
+
+  it("never reports 'dirty' when nothing was edited", () => {
+    // The dialog only opens when decideContextChange says confirm, so the
+    // all-false input is unreachable in practice; pin that it still can't
+    // produce the edits-at-risk copy.
+    expect(contextSwitchReason(false, false)).not.toBe("dirty");
   });
 });

--- a/tests/language-default-state.test.ts
+++ b/tests/language-default-state.test.ts
@@ -4,12 +4,15 @@ import {
   computeLanguageDefaultState,
   defaultLanguageName,
   describeLanguageDefault,
+  isDefaultControlAvailable,
+  type LanguageDefaultInputs,
 } from "../src/lib/language-default-state";
 import type { Language, OrgDefaultLanguage } from "../src/types/language";
 
 // #286 — the three states Ian asked the Languages page to render, plus the
-// two the implementation has to survive: an endpoint that isn't deployed
-// yet, and a default pointing at a slug that isn't in the list.
+// four the implementation has to survive: an endpoint that isn't deployed
+// yet, a read that genuinely failed, either query still in flight, and a
+// default pointing at a slug that isn't in the list.
 
 const hindi: Language = {
   name: "hindi",
@@ -25,65 +28,117 @@ const supported = (name: string | null): OrgDefaultLanguage => ({
   name,
 });
 
-describe("computeLanguageDefaultState", () => {
+// Settled, successful, list-loaded — the baseline every test perturbs.
+function inputs(over: Partial<LanguageDefaultInputs> = {}) {
+  return {
+    orgDefault: supported("hindi"),
+    isPending: false,
+    isError: false,
+    languages: [hindi, swahili],
+    ...over,
+  } satisfies LanguageDefaultInputs;
+}
+
+describe("computeLanguageDefaultState — resolved states", () => {
   it("default + published → healthy", () => {
-    const state = computeLanguageDefaultState(supported("hindi"), [
-      hindi,
-      swahili,
-    ]);
-    expect(state).toEqual({ kind: "healthy", name: "hindi", label: "Hindi" });
+    expect(computeLanguageDefaultState(inputs())).toEqual({
+      kind: "healthy",
+      name: "hindi",
+      label: "Hindi",
+    });
   });
 
   it("default + unpublished → unpublished (deliberately legal per worker#236)", () => {
-    const state = computeLanguageDefaultState(supported("hindi"), [hindiDraft]);
+    const state = computeLanguageDefaultState(
+      inputs({ languages: [hindiDraft] })
+    );
     expect(state.kind).toBe("unpublished");
   });
 
   it("treats a language with no `published` field as a draft", () => {
     // Engine rows predating the published flag omit it; a missing flag must
     // never read as "live for end users".
-    const state = computeLanguageDefaultState(supported("swahili"), [
-      { name: "swahili" },
-    ]);
+    const state = computeLanguageDefaultState(
+      inputs({
+        orgDefault: supported("swahili"),
+        languages: [{ name: "swahili" }],
+      })
+    );
     expect(state.kind).toBe("unpublished");
   });
 
   it("no default set → none", () => {
-    expect(computeLanguageDefaultState(supported(null), [hindi])).toEqual({
-      kind: "none",
-    });
+    expect(
+      computeLanguageDefaultState(inputs({ orgDefault: supported(null) }))
+    ).toEqual({ kind: "none" });
   });
 
-  it("endpoint absent (worker predates worker#236) → unsupported", () => {
-    expect(computeLanguageDefaultState({ supported: false }, [hindi])).toEqual({
-      kind: "unsupported",
-    });
-  });
-
-  it("query not answered yet → unsupported, NOT 'none'", () => {
-    // "No default is set" is a claim about the org. Rendering it while the
-    // query is still in flight would flash a warning on every page load and
-    // then silently contradict itself.
-    expect(computeLanguageDefaultState(undefined, [hindi])).toEqual({
-      kind: "unsupported",
-    });
-  });
-
-  it("default pointing at a slug that isn't in the list → missing", () => {
-    const state = computeLanguageDefaultState(supported("gone"), [hindi]);
-    expect(state).toEqual({ kind: "missing", name: "gone" });
-  });
-
-  it("tolerates an undefined language list (list query still loading)", () => {
-    expect(computeLanguageDefaultState(supported("hindi"), undefined)).toEqual({
-      kind: "missing",
-      name: "hindi",
-    });
+  it("default pointing at a slug that isn't in the RESOLVED list → missing", () => {
+    expect(
+      computeLanguageDefaultState(inputs({ orgDefault: supported("gone") }))
+    ).toEqual({ kind: "missing", name: "gone" });
   });
 
   it("omits `label` when the entry has none (no fabricated display name)", () => {
-    const state = computeLanguageDefaultState(supported("swahili"), [swahili]);
-    expect(state).toEqual({ kind: "healthy", name: "swahili" });
+    expect(
+      computeLanguageDefaultState(
+        inputs({ orgDefault: supported("swahili"), languages: [swahili] })
+      )
+    ).toEqual({ kind: "healthy", name: "swahili" });
+  });
+});
+
+describe("computeLanguageDefaultState — unresolved reads never make claims", () => {
+  it("in-flight collection + resolved default → pending, NOT the drift warning", () => {
+    // The default payload is tiny and lands first on essentially every
+    // page load and org switch. Collapsing `undefined` into an empty list
+    // made that ordinary window render the amber "points at X, which isn't
+    // in this org's language list" — a false accusation, and a permanent
+    // one whenever the collection query failed.
+    expect(
+      computeLanguageDefaultState(inputs({ languages: undefined }))
+    ).toEqual({ kind: "pending" });
+  });
+
+  it("in-flight default query → pending, NOT 'no default set'", () => {
+    expect(
+      computeLanguageDefaultState(
+        inputs({ orgDefault: undefined, isPending: true })
+      )
+    ).toEqual({ kind: "pending" });
+  });
+
+  it("data absent with no pending flag wired → still pending, never a claim", () => {
+    expect(
+      computeLanguageDefaultState(
+        inputs({ orgDefault: undefined, isPending: false })
+      )
+    ).toEqual({ kind: "pending" });
+  });
+
+  it("a failed default read → error, NOT 'not available on this worker'", () => {
+    // 404/501 resolve as `{ supported: false }` in languages-api, so a
+    // rejection is a 5xx or a network fault. Claiming the feature doesn't
+    // exist would hide a real outage behind a permanent, undiagnosable lie.
+    expect(
+      computeLanguageDefaultState(
+        inputs({ orgDefault: undefined, isError: true })
+      )
+    ).toEqual({ kind: "error" });
+  });
+
+  it("error wins over a stale pending flag", () => {
+    expect(
+      computeLanguageDefaultState(
+        inputs({ orgDefault: undefined, isPending: true, isError: true })
+      )
+    ).toEqual({ kind: "error" });
+  });
+
+  it("endpoint absent (worker predates worker#236) → unsupported", () => {
+    expect(
+      computeLanguageDefaultState(inputs({ orgDefault: { supported: false } }))
+    ).toEqual({ kind: "unsupported" });
   });
 });
 
@@ -120,13 +175,44 @@ describe("describeLanguageDefault", () => {
     expect(notice.message).toContain("gone");
   });
 
-  it("unsupported renders nothing at all", () => {
+  it("error says the READ failed and that the default is untouched", () => {
+    const notice = describeLanguageDefault({ kind: "error" })!;
+    expect(notice.tone).toBe("error");
+    expect(notice.message).toMatch(/Couldn't load/);
+    expect(notice.message).toContain("unchanged");
+  });
+
+  it("pending and unsupported render no notice at all", () => {
+    expect(describeLanguageDefault({ kind: "pending" })).toBeNull();
     expect(describeLanguageDefault({ kind: "unsupported" })).toBeNull();
   });
 
   it("falls back to the slug when the entry has no label", () => {
     const notice = describeLanguageDefault({ kind: "healthy", name: "hindi" })!;
     expect(notice.message).toContain('"hindi"');
+  });
+});
+
+describe("isDefaultControlAvailable", () => {
+  it("offers the set/clear control only once the current default is known", () => {
+    expect(isDefaultControlAvailable({ kind: "none" })).toBe(true);
+    expect(isDefaultControlAvailable({ kind: "healthy", name: "hindi" })).toBe(
+      true
+    );
+    expect(
+      isDefaultControlAvailable({ kind: "unpublished", name: "hindi" })
+    ).toBe(true);
+    expect(isDefaultControlAvailable({ kind: "missing", name: "gone" })).toBe(
+      true
+    );
+  });
+
+  it("withholds it while pending, unsupported, or failed", () => {
+    // Offering "Set as default" against an unknown current value invites a
+    // write whose effect the admin can't predict.
+    expect(isDefaultControlAvailable({ kind: "pending" })).toBe(false);
+    expect(isDefaultControlAvailable({ kind: "unsupported" })).toBe(false);
+    expect(isDefaultControlAvailable({ kind: "error" })).toBe(false);
   });
 });
 
@@ -144,5 +230,7 @@ describe("defaultLanguageName", () => {
   it("returns null when there is no default to badge", () => {
     expect(defaultLanguageName({ kind: "none" })).toBeNull();
     expect(defaultLanguageName({ kind: "unsupported" })).toBeNull();
+    expect(defaultLanguageName({ kind: "pending" })).toBeNull();
+    expect(defaultLanguageName({ kind: "error" })).toBeNull();
   });
 });

--- a/tests/language-default-state.test.ts
+++ b/tests/language-default-state.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeLanguageDefaultState,
+  defaultLanguageName,
+  describeLanguageDefault,
+} from "../src/lib/language-default-state";
+import type { Language, OrgDefaultLanguage } from "../src/types/language";
+
+// #286 — the three states Ian asked the Languages page to render, plus the
+// two the implementation has to survive: an endpoint that isn't deployed
+// yet, and a default pointing at a slug that isn't in the list.
+
+const hindi: Language = {
+  name: "hindi",
+  label: "Hindi",
+  document: "## Tone\n",
+  published: true,
+};
+const hindiDraft: Language = { ...hindi, published: false };
+const swahili: Language = { name: "swahili", document: "", published: true };
+
+const supported = (name: string | null): OrgDefaultLanguage => ({
+  supported: true,
+  name,
+});
+
+describe("computeLanguageDefaultState", () => {
+  it("default + published → healthy", () => {
+    const state = computeLanguageDefaultState(supported("hindi"), [
+      hindi,
+      swahili,
+    ]);
+    expect(state).toEqual({ kind: "healthy", name: "hindi", label: "Hindi" });
+  });
+
+  it("default + unpublished → unpublished (deliberately legal per worker#236)", () => {
+    const state = computeLanguageDefaultState(supported("hindi"), [hindiDraft]);
+    expect(state.kind).toBe("unpublished");
+  });
+
+  it("treats a language with no `published` field as a draft", () => {
+    // Engine rows predating the published flag omit it; a missing flag must
+    // never read as "live for end users".
+    const state = computeLanguageDefaultState(supported("swahili"), [
+      { name: "swahili" },
+    ]);
+    expect(state.kind).toBe("unpublished");
+  });
+
+  it("no default set → none", () => {
+    expect(computeLanguageDefaultState(supported(null), [hindi])).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("endpoint absent (worker predates worker#236) → unsupported", () => {
+    expect(computeLanguageDefaultState({ supported: false }, [hindi])).toEqual({
+      kind: "unsupported",
+    });
+  });
+
+  it("query not answered yet → unsupported, NOT 'none'", () => {
+    // "No default is set" is a claim about the org. Rendering it while the
+    // query is still in flight would flash a warning on every page load and
+    // then silently contradict itself.
+    expect(computeLanguageDefaultState(undefined, [hindi])).toEqual({
+      kind: "unsupported",
+    });
+  });
+
+  it("default pointing at a slug that isn't in the list → missing", () => {
+    const state = computeLanguageDefaultState(supported("gone"), [hindi]);
+    expect(state).toEqual({ kind: "missing", name: "gone" });
+  });
+
+  it("tolerates an undefined language list (list query still loading)", () => {
+    expect(computeLanguageDefaultState(supported("hindi"), undefined)).toEqual({
+      kind: "missing",
+      name: "hindi",
+    });
+  });
+
+  it("omits `label` when the entry has none (no fabricated display name)", () => {
+    const state = computeLanguageDefaultState(supported("swahili"), [swahili]);
+    expect(state).toEqual({ kind: "healthy", name: "swahili" });
+  });
+});
+
+describe("describeLanguageDefault", () => {
+  it("healthy reads as a subtle confirmation, not a warning", () => {
+    const notice = describeLanguageDefault({
+      kind: "healthy",
+      name: "hindi",
+      label: "Hindi",
+    })!;
+    expect(notice.tone).toBe("healthy");
+    expect(notice.message).toContain("Hindi");
+    expect(notice.message).toContain("org default");
+  });
+
+  it("unpublished warns that end users get no tuning until it's published", () => {
+    const notice = describeLanguageDefault({
+      kind: "unpublished",
+      name: "hindi",
+    })!;
+    expect(notice.tone).toBe("warning");
+    expect(notice.message).toContain("no tuning until it's published");
+  });
+
+  it("none explains that tuning only arrives via @language", () => {
+    const notice = describeLanguageDefault({ kind: "none" })!;
+    expect(notice.tone).toBe("info");
+    expect(notice.message).toContain("@language");
+  });
+
+  it("missing warns about the dangling reference by slug", () => {
+    const notice = describeLanguageDefault({ kind: "missing", name: "gone" })!;
+    expect(notice.tone).toBe("warning");
+    expect(notice.message).toContain("gone");
+  });
+
+  it("unsupported renders nothing at all", () => {
+    expect(describeLanguageDefault({ kind: "unsupported" })).toBeNull();
+  });
+
+  it("falls back to the slug when the entry has no label", () => {
+    const notice = describeLanguageDefault({ kind: "healthy", name: "hindi" })!;
+    expect(notice.message).toContain('"hindi"');
+  });
+});
+
+describe("defaultLanguageName", () => {
+  it("returns the slug for every state that has one", () => {
+    expect(defaultLanguageName({ kind: "healthy", name: "hindi" })).toBe(
+      "hindi"
+    );
+    expect(defaultLanguageName({ kind: "unpublished", name: "hindi" })).toBe(
+      "hindi"
+    );
+    expect(defaultLanguageName({ kind: "missing", name: "gone" })).toBe("gone");
+  });
+
+  it("returns null when there is no default to badge", () => {
+    expect(defaultLanguageName({ kind: "none" })).toBeNull();
+    expect(defaultLanguageName({ kind: "unsupported" })).toBeNull();
+  });
+});

--- a/tests/language-default-state.test.ts
+++ b/tests/language-default-state.test.ts
@@ -144,52 +144,97 @@ describe("computeLanguageDefaultState — unresolved reads never make claims", (
 
 describe("describeLanguageDefault", () => {
   it("healthy reads as a subtle confirmation, not a warning", () => {
-    const notice = describeLanguageDefault({
-      kind: "healthy",
-      name: "hindi",
-      label: "Hindi",
-    })!;
+    const notice = describeLanguageDefault(
+      { kind: "healthy", name: "hindi", label: "Hindi" },
+      true
+    )!;
     expect(notice.tone).toBe("healthy");
     expect(notice.message).toContain("Hindi");
     expect(notice.message).toContain("org default");
   });
 
   it("unpublished warns that end users get no tuning until it's published", () => {
-    const notice = describeLanguageDefault({
-      kind: "unpublished",
-      name: "hindi",
-    })!;
+    const notice = describeLanguageDefault(
+      { kind: "unpublished", name: "hindi" },
+      true
+    )!;
     expect(notice.tone).toBe("warning");
     expect(notice.message).toContain("no tuning until it's published");
   });
 
   it("none explains that tuning only arrives via @language", () => {
-    const notice = describeLanguageDefault({ kind: "none" })!;
+    const notice = describeLanguageDefault({ kind: "none" }, true)!;
     expect(notice.tone).toBe("info");
     expect(notice.message).toContain("@language");
   });
 
   it("missing warns about the dangling reference by slug", () => {
-    const notice = describeLanguageDefault({ kind: "missing", name: "gone" })!;
+    const notice = describeLanguageDefault(
+      { kind: "missing", name: "gone" },
+      true
+    )!;
     expect(notice.tone).toBe("warning");
     expect(notice.message).toContain("gone");
   });
 
   it("error says the READ failed and that the default is untouched", () => {
-    const notice = describeLanguageDefault({ kind: "error" })!;
+    const notice = describeLanguageDefault({ kind: "error" }, true)!;
     expect(notice.tone).toBe("error");
     expect(notice.message).toMatch(/Couldn't load/);
     expect(notice.message).toContain("unchanged");
   });
 
   it("pending and unsupported render no notice at all", () => {
-    expect(describeLanguageDefault({ kind: "pending" })).toBeNull();
-    expect(describeLanguageDefault({ kind: "unsupported" })).toBeNull();
+    expect(describeLanguageDefault({ kind: "pending" }, true)).toBeNull();
+    expect(describeLanguageDefault({ kind: "unsupported" }, true)).toBeNull();
   });
 
   it("falls back to the slug when the entry has no label", () => {
-    const notice = describeLanguageDefault({ kind: "healthy", name: "hindi" })!;
+    const notice = describeLanguageDefault(
+      { kind: "healthy", name: "hindi" },
+      true
+    )!;
     expect(notice.message).toContain('"hindi"');
+  });
+});
+
+// A shepherd holding edit+publish on the org-default language CAN delete
+// it (per-row rights) but CANNOT set or clear the org default (admin gate
+// on the BFF PUT). Any copy that prescribes an action has to know which
+// audience it is talking to, or it sends half the users at a button they
+// will never be shown.
+
+describe("describeLanguageDefault — role-aware prescriptions", () => {
+  it("tells an admin to pick a new default when the pointer is dangling", () => {
+    const notice = describeLanguageDefault(
+      { kind: "missing", name: "gone" },
+      true
+    )!;
+    expect(notice.message).toContain("Pick a new default");
+    expect(notice.message).not.toContain("Ask an admin");
+  });
+
+  it("tells a non-admin to ask an admin instead", () => {
+    const notice = describeLanguageDefault(
+      { kind: "missing", name: "gone" },
+      false
+    )!;
+    expect(notice.message).toContain("Ask an admin to pick a new default");
+    expect(notice.message).not.toMatch(/^.*\bPick a new default\b/);
+  });
+
+  it("leaves purely descriptive copy identical for both audiences", () => {
+    // `none`, `healthy` and `unpublished` state facts about what end users
+    // get; only `missing` prescribes an admin-only action.
+    for (const state of [
+      { kind: "none" } as const,
+      { kind: "healthy", name: "hindi" } as const,
+      { kind: "unpublished", name: "hindi" } as const,
+    ]) {
+      expect(describeLanguageDefault(state, true)).toEqual(
+        describeLanguageDefault(state, false)
+      );
+    }
   });
 });
 

--- a/tests/language-error-surface.test.ts
+++ b/tests/language-error-surface.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeLanguageDeleteError,
+  isDefaultBlockedDeleteError,
+  selectLanguageMutationBanner,
+} from "../src/lib/language-error-surface";
+import {
+  LanguageForbiddenError,
+  LanguageIsDefaultError,
+} from "../src/lib/languages-api";
+
+// #286 review — two rules: one surface per failure, and copy that
+// prescribes an action must know who is reading.
+
+describe("selectLanguageMutationBanner — the org-default 409 has ONE surface", () => {
+  it("keeps the delete-409 off the page banner (the dialog owns it)", () => {
+    // Both surfaces at once is redundant while the failure is current,
+    // and the banner outlives the dialog: the admin clears the default,
+    // dismisses the dialog, and the page keeps insisting the language
+    // can't be deleted because it may be the default — which it no
+    // longer is.
+    expect(
+      selectLanguageMutationBanner(null, new LanguageIsDefaultError("hindi"))
+    ).toBeNull();
+  });
+
+  it("still banners other delete failures — silence is not the fix", () => {
+    const err = new Error("Failed to delete language (500): boom");
+    expect(selectLanguageMutationBanner(null, err)).toBe(err);
+  });
+
+  it("still banners save failures", () => {
+    const err = new Error("Failed to save language (500): boom");
+    expect(selectLanguageMutationBanner(err, null)).toBe(err);
+  });
+
+  it("leaves forbidden errors to their dedicated banner", () => {
+    expect(
+      selectLanguageMutationBanner(
+        new LanguageForbiddenError("hindi", "write"),
+        null
+      )
+    ).toBeNull();
+    expect(
+      selectLanguageMutationBanner(
+        null,
+        new LanguageForbiddenError("hindi", "delete")
+      )
+    ).toBeNull();
+  });
+
+  it("prefers the save error when both are present", () => {
+    const save = new Error("save boom");
+    const del = new Error("delete boom");
+    expect(selectLanguageMutationBanner(save, del)).toBe(save);
+  });
+
+  it("returns null when nothing failed", () => {
+    expect(selectLanguageMutationBanner(null, null)).toBeNull();
+    expect(selectLanguageMutationBanner(undefined, undefined)).toBeNull();
+  });
+});
+
+describe("isDefaultBlockedDeleteError — the recovery path", () => {
+  it("identifies the 409 the set/clear action resolves", () => {
+    // The page resets the delete mutation on a successful set/clear when
+    // this returns true, so the stale 409 can't survive the very action
+    // that unblocks it.
+    expect(
+      isDefaultBlockedDeleteError(new LanguageIsDefaultError("hindi"))
+    ).toBe(true);
+  });
+
+  it("leaves unrelated failures alone — a 500 is not fixed by re-pointing the default", () => {
+    expect(isDefaultBlockedDeleteError(new Error("boom"))).toBe(false);
+    expect(
+      isDefaultBlockedDeleteError(new LanguageForbiddenError("hindi", "delete"))
+    ).toBe(false);
+    expect(isDefaultBlockedDeleteError(null)).toBe(false);
+    expect(isDefaultBlockedDeleteError(undefined)).toBe(false);
+  });
+
+  it("full recovery sequence: 409 → change the default → nothing left to show", () => {
+    const blocked = new LanguageIsDefaultError("hindi");
+    // While blocked: no page banner, dialog shows it, and the page knows
+    // the pending set/clear will clear it.
+    expect(selectLanguageMutationBanner(null, blocked)).toBeNull();
+    expect(isDefaultBlockedDeleteError(blocked)).toBe(true);
+    // After the admin sets a different default the page calls reset(), so
+    // the mutation error is gone and neither surface has anything to say.
+    const afterReset = null;
+    expect(selectLanguageMutationBanner(null, afterReset)).toBeNull();
+    expect(isDefaultBlockedDeleteError(afterReset)).toBe(false);
+  });
+});
+
+// A shepherd holding edit+publish on the org-default language CAN delete
+// it (per-row rights) but CANNOT set or clear the org default (admin gate
+// on the BFF PUT).
+
+describe("describeLanguageDeleteError", () => {
+  it("gives an admin the recovery they can actually perform", () => {
+    const msg = describeLanguageDeleteError(
+      new LanguageIsDefaultError("hindi"),
+      true
+    );
+    expect(msg).toContain("hindi");
+    expect(msg).toContain("Set a different default, or clear it");
+    expect(msg).not.toContain("Ask an admin");
+  });
+
+  it("tells a shepherd to ask an admin — they can delete but not re-point", () => {
+    const msg = describeLanguageDeleteError(
+      new LanguageIsDefaultError("hindi"),
+      false
+    );
+    expect(msg).toContain("Ask an admin to change or clear the default");
+    expect(msg).not.toContain("Set a different default");
+  });
+
+  it("passes other errors through verbatim for both audiences", () => {
+    const err = new Error("Failed to delete language (500): boom");
+    expect(describeLanguageDeleteError(err, true)).toBe(err.message);
+    expect(describeLanguageDeleteError(err, false)).toBe(err.message);
+  });
+
+  it("falls back to a generic message for a non-Error rejection", () => {
+    expect(describeLanguageDeleteError("nope", true)).toBe(
+      "Failed to delete language."
+    );
+  });
+});

--- a/tests/language-error-surface.test.ts
+++ b/tests/language-error-surface.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeLanguageDefaultState,
+  isDefaultControlAvailable,
+} from "../src/lib/language-default-state";
+import {
   describeLanguageDeleteError,
   isDefaultBlockedDeleteError,
   selectLanguageMutationBanner,
+  shouldOfferDefaultRecovery,
 } from "../src/lib/language-error-surface";
 import {
   LanguageForbiddenError,
@@ -92,6 +97,61 @@ describe("isDefaultBlockedDeleteError — the recovery path", () => {
     const afterReset = null;
     expect(selectLanguageMutationBanner(null, afterReset)).toBeNull();
     expect(isDefaultBlockedDeleteError(afterReset)).toBe(false);
+  });
+});
+
+describe("shouldOfferDefaultRecovery — the dead-end the error state created", () => {
+  it("offers the inline recovery even when the default READ is failing", () => {
+    // The dead-end chain: GET languages-default 5xx → state "error" →
+    // isDefaultControlAvailable false → the toolbar Set/Clear controls are
+    // withheld. But the SERVER still has a default, so the delete still
+    // 409s, and the admin was left reading "set a different default, or
+    // clear it" about controls that weren't on screen. The recovery must
+    // therefore key on the ERROR, not on the read.
+    const state = computeLanguageDefaultState({
+      orgDefault: undefined,
+      isPending: false,
+      isError: true,
+      languages: [{ name: "hindi", published: true }],
+    });
+    expect(state.kind).toBe("error");
+    expect(isDefaultControlAvailable(state)).toBe(false);
+
+    expect(
+      shouldOfferDefaultRecovery(new LanguageIsDefaultError("hindi"), true)
+    ).toBe(true);
+  });
+
+  it("offers it while the queries are still pending, too", () => {
+    const state = computeLanguageDefaultState({
+      orgDefault: undefined,
+      isPending: true,
+      isError: false,
+      languages: undefined,
+    });
+    expect(isDefaultControlAvailable(state)).toBe(false);
+    expect(
+      shouldOfferDefaultRecovery(new LanguageIsDefaultError("hindi"), true)
+    ).toBe(true);
+  });
+
+  it("withholds it from a shepherd — the BFF PUT is admin-only", () => {
+    // They keep the "ask an admin" copy; offering a button that always
+    // 403s would be worse than the sentence.
+    expect(
+      shouldOfferDefaultRecovery(new LanguageIsDefaultError("hindi"), false)
+    ).toBe(false);
+  });
+
+  it("withholds it for unrelated delete failures", () => {
+    expect(shouldOfferDefaultRecovery(new Error("boom"), true)).toBe(false);
+    expect(
+      shouldOfferDefaultRecovery(
+        new LanguageForbiddenError("hindi", "delete"),
+        true
+      )
+    ).toBe(false);
+    expect(shouldOfferDefaultRecovery(null, true)).toBe(false);
   });
 });
 

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -2,10 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   LanguageForbiddenError,
+  LanguageIsDefaultError,
   deleteLanguage,
   getLanguage,
+  getOrgDefaultLanguage,
   listLanguages,
   putLanguage,
+  setOrgDefaultLanguage,
 } from "../src/lib/languages-api";
 
 afterEach(() => {
@@ -224,6 +227,168 @@ describe("deleteLanguage", () => {
     mockFetchOnce(404, "Language not found");
     await expect(deleteLanguage("missing")).rejects.toThrow(
       /Failed to delete language \(404\)/
+    );
+  });
+
+  it("throws LanguageIsDefaultError on 409 with an actionable message (#286)", async () => {
+    // Upstream refuses to delete the language the org default points at.
+    // The dialog renders `error.message` verbatim, so the recovery step
+    // ("set a different default, or clear it") has to live in the message
+    // rather than in the raw upstream body.
+    mockFetchOnce(409, "unset or reassign the default first");
+    try {
+      await deleteLanguage("hindi");
+      throw new Error("expected rejection");
+    } catch (e) {
+      expect(e).toBeInstanceOf(LanguageIsDefaultError);
+      const err = e as LanguageIsDefaultError;
+      expect(err.languageName).toBe("hindi");
+      expect(err.message).toContain("default");
+      expect(err.message).toMatch(/clear it|different default/);
+    }
+  });
+
+  it("409 is distinguishable from a permission failure", async () => {
+    mockFetchOnce(409, "");
+    await expect(deleteLanguage("hindi")).rejects.not.toBeInstanceOf(
+      LanguageForbiddenError
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Org default language (#286 / worker#236)
+// ---------------------------------------------------------------------------
+
+describe("getOrgDefaultLanguage", () => {
+  it("reads the sibling route, not /languages/default", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "hindi" })));
+    await getOrgDefaultLanguage();
+    expect(spy.mock.calls[0]![0]).toBe("/api/config/languages-default");
+  });
+
+  it("returns the slug when one is set", async () => {
+    mockFetchOnce(200, { name: "hindi" });
+    expect(await getOrgDefaultLanguage()).toEqual({
+      supported: true,
+      name: "hindi",
+    });
+  });
+
+  it("returns supported-with-null when no default is set", async () => {
+    mockFetchOnce(200, { name: null });
+    expect(await getOrgDefaultLanguage()).toEqual({
+      supported: true,
+      name: null,
+    });
+  });
+
+  it("RESOLVES as unsupported on 404 — the worker route isn't deployed yet", async () => {
+    // Rejecting here would put an error banner on the Languages page for
+    // every org until worker#236 ships. The control hides itself instead.
+    mockFetchOnce(404, "Not found");
+    expect(await getOrgDefaultLanguage()).toEqual({ supported: false });
+  });
+
+  it("RESOLVES as unsupported on 501", async () => {
+    mockFetchOnce(501, "Not implemented");
+    expect(await getOrgDefaultLanguage()).toEqual({ supported: false });
+  });
+
+  it("still rejects on a real failure (500) — absence is not the same as broken", async () => {
+    mockFetchOnce(500, "boom");
+    await expect(getOrgDefaultLanguage()).rejects.toThrow(
+      /Failed to load default language \(500\)/
+    );
+  });
+
+  it("normalizes a blank or non-string name to 'no default'", async () => {
+    mockFetchOnce(200, { name: "   " });
+    expect(await getOrgDefaultLanguage()).toEqual({
+      supported: true,
+      name: null,
+    });
+    mockFetchOnce(200, { name: 42 });
+    expect(await getOrgDefaultLanguage()).toEqual({
+      supported: true,
+      name: null,
+    });
+  });
+
+  it("threads ?org= for the cross-org view", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: null })));
+    await getOrgDefaultLanguage(undefined, "word-collective");
+    expect(spy.mock.calls[0]![0]).toBe(
+      "/api/config/languages-default?org=word-collective"
+    );
+  });
+});
+
+describe("setOrgDefaultLanguage", () => {
+  it("PUTs { name } to set", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "hindi" })));
+    const result = await setOrgDefaultLanguage("hindi");
+    const init = spy.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual({ name: "hindi" });
+    expect(result).toEqual({ supported: true, name: "hindi" });
+  });
+
+  it("PUTs { name: null } to clear", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: null })));
+    const result = await setOrgDefaultLanguage(null);
+    expect(
+      JSON.parse((spy.mock.calls[0]![1] as RequestInit).body as string)
+    ).toEqual({ name: null });
+    expect(result).toEqual({ supported: true, name: null });
+  });
+
+  it("falls back to the requested value when the server sends no body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, { status: 204 })
+    );
+    expect(await setOrgDefaultLanguage("hindi")).toEqual({
+      supported: true,
+      name: "hindi",
+    });
+  });
+
+  it("403 rejects with the admin-only explanation", async () => {
+    mockFetchOnce(403, { error: "Forbidden" });
+    await expect(setOrgDefaultLanguage("hindi")).rejects.toThrow(
+      /Only admins can set or clear it/
+    );
+  });
+
+  it("404 rejects with the not-deployed-yet explanation, not a bare status", async () => {
+    mockFetchOnce(404, "Not found");
+    await expect(setOrgDefaultLanguage("hindi")).rejects.toThrow(
+      /doesn't support a default language yet/
+    );
+  });
+
+  it("surfaces the upstream reason on a validation failure", async () => {
+    mockFetchOnce(409, "no such language: nope");
+    await expect(setOrgDefaultLanguage("nope")).rejects.toThrow(
+      /no such language: nope/
+    );
+  });
+
+  it("threads ?org= so the write lands on the org being viewed", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "hindi" })));
+    await setOrgDefaultLanguage("hindi", undefined, "word-collective");
+    expect(spy.mock.calls[0]![0]).toBe(
+      "/api/config/languages-default?org=word-collective"
     );
   });
 });

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -230,11 +230,10 @@ describe("deleteLanguage", () => {
     );
   });
 
-  it("throws LanguageIsDefaultError on 409 with an actionable message (#286)", async () => {
-    // Upstream refuses to delete the language the org default points at.
-    // The dialog renders `error.message` verbatim, so the recovery step
-    // ("set a different default, or clear it") has to live in the message
-    // rather than in the raw upstream body.
+  it("throws LanguageIsDefaultError on 409, carrying the slug (#286)", async () => {
+    // The class is the discriminator the render layer keys on to compose
+    // role-aware copy (describeLanguageDeleteError) — so what this layer
+    // owes is the type and the slug, not the wording.
     mockFetchOnce(409, "unset or reassign the default first");
     try {
       await deleteLanguage("hindi");
@@ -244,8 +243,18 @@ describe("deleteLanguage", () => {
       const err = e as LanguageIsDefaultError;
       expect(err.languageName).toBe("hindi");
       expect(err.message).toContain("default");
-      expect(err.message).toMatch(/clear it|different default/);
     }
+  });
+
+  it("keeps the API-layer message ROLE-NEUTRAL (no admin-only instruction)", async () => {
+    // Deleting needs per-row edit+publish; changing the org default is
+    // admin-only. This layer can't know which the reader holds, so it must
+    // not prescribe — the render layer composes that.
+    mockFetchOnce(409, "");
+    const err = (await deleteLanguage("hindi").catch(
+      (e: unknown) => e
+    )) as Error;
+    expect(err.message).not.toMatch(/Set a different default|Ask an admin/);
   });
 
   it("hedges the 409 copy — worker#236 pins no error body to discriminate on", async () => {

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -248,6 +248,16 @@ describe("deleteLanguage", () => {
     }
   });
 
+  it("hedges the 409 copy — worker#236 pins no error body to discriminate on", async () => {
+    // Every delete 409 lands on this class, so the message must stay true
+    // if upstream ever adds a second conflict reason: it states the
+    // observable fact (refused) and offers the known cause as likely.
+    mockFetchOnce(409, "");
+    const err = await deleteLanguage("hindi").catch((e: unknown) => e);
+    expect((err as Error).message).toMatch(/can't be deleted right now/);
+    expect((err as Error).message).toMatch(/may be/);
+  });
+
   it("409 is distinguishable from a permission failure", async () => {
     mockFetchOnce(409, "");
     await expect(deleteLanguage("hindi")).rejects.not.toBeInstanceOf(
@@ -358,6 +368,45 @@ describe("setOrgDefaultLanguage", () => {
     expect(await setOrgDefaultLanguage("hindi")).toEqual({
       supported: true,
       name: "hindi",
+    });
+  });
+
+  it.each([
+    ["an empty object", {}],
+    ["an ack envelope", { ok: true }],
+    ["a differently-named key", { defaultLanguage: "hindi" }],
+    ["a wrapped envelope", { org: "acme", message: "saved" }],
+  ])(
+    "a successful set with %s still reports the slug we set, not 'no default'",
+    async (_label, body) => {
+      // worker#236 fixes the REQUEST shape only. Reading an unrecognized
+      // 2xx body as `name: null` would make a successful set immediately
+      // render "No default language is set" — a lie with no self-
+      // correction until the next page load. The mutation's invalidation
+      // is what reconciles this optimistic guess.
+      mockFetchOnce(200, body);
+      expect(await setOrgDefaultLanguage("hindi")).toEqual({
+        supported: true,
+        name: "hindi",
+      });
+    }
+  );
+
+  it("a recognized echo still wins over the requested value", async () => {
+    // If the server says the default is something else, believe the
+    // server — the fallback is for unreadable bodies, not a veto.
+    mockFetchOnce(200, { name: "swahili" });
+    expect(await setOrgDefaultLanguage("hindi")).toEqual({
+      supported: true,
+      name: "swahili",
+    });
+  });
+
+  it("clearing reports null even when the body is unrecognizable", async () => {
+    mockFetchOnce(200, { ok: true });
+    expect(await setOrgDefaultLanguage(null)).toEqual({
+      supported: true,
+      name: null,
     });
   });
 

--- a/tests/languages-api.test.ts
+++ b/tests/languages-api.test.ts
@@ -385,14 +385,17 @@ describe("setOrgDefaultLanguage", () => {
     ["an ack envelope", { ok: true }],
     ["a differently-named key", { defaultLanguage: "hindi" }],
     ["a wrapped envelope", { org: "acme", message: "saved" }],
+    ["a name of the wrong type", { name: 42 }],
   ])(
-    "a successful set with %s still reports the slug we set, not 'no default'",
+    "a successful set with %s (no readable name) still reports the slug we set",
     async (_label, body) => {
       // worker#236 fixes the REQUEST shape only. Reading an unrecognized
       // 2xx body as `name: null` would make a successful set immediately
       // render "No default language is set" — a lie with no self-
       // correction until the next page load. The mutation's invalidation
-      // is what reconciles this optimistic guess.
+      // is what reconciles this optimistic guess. A `name` of the wrong
+      // TYPE belongs here too: garbage is evidence the envelope isn't what
+      // we think it is, not a statement that the default is unset.
       mockFetchOnce(200, body);
       expect(await setOrgDefaultLanguage("hindi")).toEqual({
         supported: true,
@@ -408,6 +411,27 @@ describe("setOrgDefaultLanguage", () => {
     expect(await setOrgDefaultLanguage("hindi")).toEqual({
       supported: true,
       name: "swahili",
+    });
+  });
+
+  it("an explicit { name: null } echo wins over the slug we requested", async () => {
+    // The server accepted the request but reports the default as UNSET —
+    // upstream declined to store the slug (a race with another admin's
+    // clear, say). Falling back to the requested name here would have the
+    // cache assert a default the server just said doesn't exist. Absent is
+    // not the same answer as null (#286 review rd-3).
+    mockFetchOnce(200, { name: null });
+    expect(await setOrgDefaultLanguage("hindi")).toEqual({
+      supported: true,
+      name: null,
+    });
+  });
+
+  it("a blank-string echo is a name-shaped nothing, not a slug", async () => {
+    mockFetchOnce(200, { name: "   " });
+    expect(await setOrgDefaultLanguage("hindi")).toEqual({
+      supported: true,
+      name: null,
     });
   });
 

--- a/tests/use-languages-cache.test.ts
+++ b/tests/use-languages-cache.test.ts
@@ -1,0 +1,143 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyLanguageDeletionToCache,
+  applyOrgDefaultToCache,
+  languageQueryKeys,
+} from "../src/hooks/use-languages";
+import type { OrgDefaultLanguage, OrgLanguages } from "../src/types/language";
+
+// #286 — the cache effects of the two mutations that can move the org
+// default. Both were originally invalidating only the languages
+// collection, which left two provable stale paths (below).
+
+function makeClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function seed(qc: QueryClient, org: string | null): void {
+  qc.setQueryData<OrgLanguages>(languageQueryKeys.languages(org), {
+    languages: [{ name: "hindi", document: "", published: true }],
+  });
+  qc.setQueryData<OrgDefaultLanguage>(languageQueryKeys.orgDefault(org), {
+    supported: true,
+    name: "hindi",
+  });
+}
+
+function invalidatedKeys(spy: { mock: { calls: unknown[][] } }): unknown[][] {
+  return spy.mock.calls.map(
+    (call) => (call[0] as { queryKey: unknown[] }).queryKey
+  );
+}
+
+describe("query keys", () => {
+  it("the org-default key cannot collide with a language named 'default'", () => {
+    // `default` is a legal language slug — the same collision worker#236
+    // avoided by naming the route `languages-default`. A key of
+    // ["languages", "default", org] would make the per-language cache
+    // entry and the org-default entry the same cache slot.
+    expect(languageQueryKeys.orgDefault(null)).not.toEqual(
+      languageQueryKeys.language("default", null)
+    );
+    expect(languageQueryKeys.orgDefault(null)[0]).not.toBe(
+      languageQueryKeys.languages(null)[0]
+    );
+  });
+
+  it("keys are org-scoped so a cross-org view can't read the home org's default", () => {
+    expect(languageQueryKeys.orgDefault("word-collective")).not.toEqual(
+      languageQueryKeys.orgDefault(null)
+    );
+  });
+});
+
+describe("applyOrgDefaultToCache", () => {
+  it("paints the new value immediately (no round-trip of dead UI)", () => {
+    const qc = makeClient();
+    seed(qc, null);
+    applyOrgDefaultToCache(qc, null, { supported: true, name: "swahili" });
+    expect(qc.getQueryData(languageQueryKeys.orgDefault(null))).toEqual({
+      supported: true,
+      name: "swahili",
+    });
+  });
+
+  it("invalidates the org default AFTER painting, so an echo guess self-corrects", () => {
+    // setOrgDefaultLanguage falls back to the requested slug when the 2xx
+    // body isn't recognizable (worker#236 doesn't pin the envelope). That
+    // optimistic value must be reconciled against the server rather than
+    // trusted until the next page load.
+    const qc = makeClient();
+    seed(qc, null);
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    applyOrgDefaultToCache(qc, null, { supported: true, name: "swahili" });
+    expect(invalidatedKeys(spy)).toContainEqual(
+      languageQueryKeys.orgDefault(null)
+    );
+  });
+
+  it("also invalidates the collection the published-state notice reads", () => {
+    const qc = makeClient();
+    seed(qc, null);
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    applyOrgDefaultToCache(qc, null, { supported: true, name: "swahili" });
+    expect(invalidatedKeys(spy)).toContainEqual(
+      languageQueryKeys.languages(null)
+    );
+  });
+
+  it("scopes both invalidations to the org being viewed", () => {
+    const qc = makeClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    applyOrgDefaultToCache(qc, "word-collective", {
+      supported: true,
+      name: "hindi",
+    });
+    for (const key of invalidatedKeys(spy)) {
+      expect(key).toContain("word-collective");
+    }
+  });
+
+  it("clearing writes null through rather than dropping the entry", () => {
+    const qc = makeClient();
+    seed(qc, null);
+    applyOrgDefaultToCache(qc, null, { supported: true, name: null });
+    expect(qc.getQueryData(languageQueryKeys.orgDefault(null))).toEqual({
+      supported: true,
+      name: null,
+    });
+  });
+});
+
+describe("applyLanguageDeletionToCache", () => {
+  it("invalidates the cached org default, not just the collection", () => {
+    // Stale path: admin B clears the default; admin A's cache still names
+    // "hindi". A's delete of "hindi" then succeeds upstream (no 409,
+    // because it is no longer the default) — and with only the collection
+    // refreshed, A's page renders the drift warning about a language A
+    // just deleted, as a pure cache artifact.
+    const qc = makeClient();
+    seed(qc, null);
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    applyLanguageDeletionToCache(qc, null);
+    expect(invalidatedKeys(spy)).toContainEqual(
+      languageQueryKeys.orgDefault(null)
+    );
+    expect(invalidatedKeys(spy)).toContainEqual(
+      languageQueryKeys.languages(null)
+    );
+  });
+
+  it("scopes the invalidation to the org being viewed", () => {
+    const qc = makeClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    applyLanguageDeletionToCache(qc, "word-collective");
+    for (const key of invalidatedKeys(spy)) {
+      expect(key).toContain("word-collective");
+    }
+  });
+});

--- a/tests/use-languages-cache.test.ts
+++ b/tests/use-languages-cache.test.ts
@@ -1,12 +1,18 @@
 import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   applyLanguageDeletionToCache,
   applyOrgDefaultToCache,
+  languageDeleteMutationOptions,
   languageQueryKeys,
+  orgDefaultMutationOptions,
 } from "../src/hooks/use-languages";
 import type { OrgDefaultLanguage, OrgLanguages } from "../src/types/language";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // #286 — the cache effects of the two mutations that can move the org
 // default. Both were originally invalidating only the languages
@@ -110,6 +116,86 @@ describe("applyOrgDefaultToCache", () => {
       supported: true,
       name: null,
     });
+  });
+});
+
+// The org-context switch race: a super admin hits Set on org A and picks
+// org B from the context selector before the PUT resolves. TanStack hands
+// a settled mutation the LATEST options closure, so a hook that read an
+// ambient org key would apply A's outcome to B. These tests drive the
+// exact options objects the hooks use and assert both the request target
+// and the cache write follow the mutate-time variables instead.
+
+describe("orgDefaultMutationOptions — org travels in the variables", () => {
+  it("sends the PUT to the org named at mutate time", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "hindi" })));
+    const opts = orgDefaultMutationOptions(makeClient());
+    await opts.mutationFn({ name: "hindi", org: "alpha" });
+    expect(String(spy.mock.calls[0]![0])).toBe(
+      "/api/config/languages-default?org=alpha"
+    );
+  });
+
+  it("writes the result to the mutate-time org, even after the view moved on", async () => {
+    const qc = makeClient();
+    seed(qc, "alpha");
+    seed(qc, "beta");
+    const opts = orgDefaultMutationOptions(qc);
+    // The user is now looking at beta; this settled request was made
+    // against alpha.
+    opts.onSuccess(
+      { supported: true, name: "swahili" },
+      {
+        name: "swahili",
+        org: "alpha",
+      }
+    );
+    expect(qc.getQueryData(languageQueryKeys.orgDefault("alpha"))).toEqual({
+      supported: true,
+      name: "swahili",
+    });
+    expect(qc.getQueryData(languageQueryKeys.orgDefault("beta"))).toEqual({
+      supported: true,
+      name: "hindi",
+    });
+  });
+
+  it("same-org (null key) writes are unaffected by the pinning", async () => {
+    const qc = makeClient();
+    seed(qc, null);
+    const opts = orgDefaultMutationOptions(qc);
+    opts.onSuccess({ supported: true, name: null }, { name: null, org: null });
+    expect(qc.getQueryData(languageQueryKeys.orgDefault(null))).toEqual({
+      supported: true,
+      name: null,
+    });
+  });
+});
+
+describe("languageDeleteMutationOptions — org travels in the variables", () => {
+  it("sends the DELETE to the org named at mutate time", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    const opts = languageDeleteMutationOptions(makeClient());
+    await opts.mutationFn({ name: "hindi", org: "alpha" });
+    expect(String(spy.mock.calls[0]![0])).toBe(
+      "/api/config/languages/hindi?org=alpha"
+    );
+  });
+
+  it("invalidates the mutate-time org, not whichever org is on screen", () => {
+    const qc = makeClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    languageDeleteMutationOptions(qc).onSuccess(undefined, {
+      name: "hindi",
+      org: "alpha",
+    });
+    for (const key of invalidatedKeys(spy)) {
+      expect(key).toContain("alpha");
+    }
   });
 });
 

--- a/tests/use-languages-cache.test.ts
+++ b/tests/use-languages-cache.test.ts
@@ -6,6 +6,7 @@ import {
   applyOrgDefaultToCache,
   languageDeleteMutationOptions,
   languageQueryKeys,
+  languageSaveMutationOptions,
   orgDefaultMutationOptions,
 } from "../src/hooks/use-languages";
 import type { OrgDefaultLanguage, OrgLanguages } from "../src/types/language";
@@ -171,6 +172,59 @@ describe("orgDefaultMutationOptions — org travels in the variables", () => {
       supported: true,
       name: null,
     });
+  });
+});
+
+describe("languageSaveMutationOptions — org travels in the variables", () => {
+  it("sends the PUT to the org named at mutate time", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ language: { name: "hindi" } }))
+      );
+    const opts = languageSaveMutationOptions(makeClient());
+    await opts.mutationFn({
+      name: "hindi",
+      body: { document: "x" },
+      org: "alpha",
+    });
+    expect(String(spy.mock.calls[0]![0])).toBe(
+      "/api/config/languages/hindi?org=alpha"
+    );
+  });
+
+  it("invalidates the mutate-time org after the ambient key moved on", () => {
+    // Reachable, not theoretical: the org-context dialog offers "Discard
+    // and switch" WHILE a save is in flight. With a closure-read key, org
+    // A's completed save would refresh org B and leave A's cache holding
+    // the pre-save document — a save that looks lost, and a stale base for
+    // the next edit to overwrite it from.
+    const qc = makeClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    languageSaveMutationOptions(qc).onSuccess(undefined, {
+      name: "hindi",
+      body: { document: "x" },
+      org: "alpha",
+    });
+    for (const key of invalidatedKeys(spy)) {
+      expect(key).toContain("alpha");
+    }
+  });
+
+  it("refreshes both the collection and the saved row's own entry", () => {
+    const qc = makeClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    languageSaveMutationOptions(qc).onSuccess(undefined, {
+      name: "hindi",
+      body: { document: "x" },
+      org: null,
+    });
+    expect(invalidatedKeys(spy)).toContainEqual(
+      languageQueryKeys.languages(null)
+    );
+    expect(invalidatedKeys(spy)).toContainEqual(
+      languageQueryKeys.language("hindi", null)
+    );
   });
 });
 

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -163,10 +163,14 @@ export async function validateSession(
 
 // Shared between validateSession and handleLogin so the session shape is
 // identical whether the session is freshly minted or rehydrated from KV.
-// Exported for the #247 bootstrap auto-grant (worker/rights-migration.ts),
-// which must materialize explicit verb fields under EXACTLY this rule — a
-// third hand-rolled copy of the partner-aware fallback is how the original
-// #256 review bug happened.
+//
+// #272: the export note used to point at the #247 bootstrap auto-grant in
+// worker/rights-migration.ts. That consumer is gone — #249 made admin
+// powers trump per-row language rights, so creating an org's first
+// language draft is an ordinary admin write with no explicit verb fields
+// to materialize at create time. The export stays so that any future
+// caller reuses THIS partner-aware rule rather than hand-rolling a third
+// copy of it, which is how the original #256 review bug happened.
 export function lazyMigrateLanguageRights(user: StoredUser): {
   language_edit_rights: LanguageRights | undefined;
   language_publish_rights: LanguageRights | undefined;

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -1090,6 +1090,49 @@ export async function handleConfig(
     );
   }
 
+  // /api/config/languages-default → GET (any session) / PUT (admin-only)
+  //
+  // Org default language, rung 3 of the language cascade (#286, contract
+  // on worker#236). The upstream pair is `languages-default`, NOT
+  // `languages/default`: `default` is a legal language slug, so the nested
+  // form would be ambiguous with a real language named "default". The
+  // literal match here is likewise unambiguous — the `/languages/(.+)`
+  // route below needs a slash and never sees this path — but the arm sits
+  // beside the languages routes so the pair reads as one surface.
+  //
+  // Authorization: PUT is ADMIN-ONLY (`isAdminMutation` — the same gate
+  // org-wide prompt-overrides use), deliberately stricter than the
+  // per-language DELETE rule (edit + publish on the row). No verb right
+  // governs it, because no verb right is org-wide: the default is one
+  // pointer shared by every end user in the org, so a shepherd holding
+  // edit+publish on "hindi" would otherwise be able to redirect the whole
+  // org's tuning to their own language — or away from another shepherd's —
+  // without holding a single right on the language they demoted. Rights
+  // scope non-admin shepherds to rows; org policy stays with admins
+  // (#249's trump already gives admins every row). Super admins pass via
+  // hasAdminPowers even if self-demoted, and cross-org targeting is
+  // already super-admin-only with an EXACT org compare in `resolveOrg`
+  // (#247).
+  //
+  // GET stays open to any session, matching the languages list/read
+  // convention: shepherds need to see which language is the org default to
+  // understand whether their draft is the one end users receive.
+  //
+  // Body validation (`name` must reference an existing entry) is upstream's
+  // job; this proxy stays thin and passes 400/409 through untouched, as it
+  // does for every other config route.
+  if (pathname === "/api/config/languages-default") {
+    if (isAdminMutation(request.method, session)) {
+      return errorResponse("Forbidden", 403);
+    }
+    return proxyToEngine(
+      request,
+      env,
+      `/api/v1/admin/orgs/${encodedOrg}/languages-default`,
+      ["GET", "PUT"]
+    );
+  }
+
   // /api/config/languages/{name} → GET / PUT / DELETE
   // (per-language verb-perms, admin-trump, super-admin cross-org bypass)
   const languageMatch = pathname.match(/^\/api\/config\/languages\/(.+)$/);


### PR DESCRIPTION
Portal side of the org-default-language feature, built against the v1 storage contract Ian settled on unfoldingWord/bt-servant-worker#236 (2026-08-11). This is rung 3 of the language cascade and the fix path for #255: users who never type `@language` finally receive the org's tuning. Explicitly **not** the #172 chain-storage work.

**The worker endpoint does not exist yet** — this ships contract-first. The UI feature-detects: an upstream 404/501 on the read renders nothing but a quiet admin-only note, so deploying this before the worker half is safe. End-to-end staging verification happens once worker#236's implementation lands.

## What's here

**BFF** (`worker/config.ts`): proxy pair for `GET`/`PUT /api/config/languages-default` → worker `.../orgs/:org/languages-default`. GET is open to any session (shepherds need to see which draft end users receive); **PUT is admin-only** (`isAdminMutation`, same gate as prompt-overrides — the only comparable org-wide mutable surface). Deliberately *stricter* than per-row language verb rights: the default is one org-wide pointer, and a shepherd holding edit+publish on `hindi` should not be able to redirect the whole org's tuning and demote another shepherd's language they hold no rights on. Org scoping is the standard `resolveOrg` path (exact-match compare, cross-org super-admin-only, single encode). All non-GET/PUT methods 405 before any upstream call.

**UI** (Languages page): a Default set/unset control on the language rows, driven by a pure state machine (`src/lib/language-default-state.ts`) with seven states:

- `pending` — either read still in flight → renders nothing (no flash, no layout shift)
- `error` — the *read* failed → destructive notice saying so ("the default is unchanged"), never conflated with…
- `unsupported` — upstream 404/501 → quiet admin-only "not available on this org's worker yet"
- healthy / `unpublished` (warn: end users get no tuning until published) / none (info: end users only get tuning via `@language`) / `missing` (drift: default points at a deleted slug) — `missing` computed **only** from a resolved list

Clearing the default requires confirmation (it silently removes tuning for every quiet user in the org); setting is one click. Deleting the language currently set as default surfaces the worker's 409 inline in the delete dialog (plain-Button pattern, dialog stays open) with hedged copy — worker#236 pins no error body to discriminate on yet, noted in code.

**Cache coherence**: mutations paint-then-invalidate both the `["languages-default", org]` key and the collection; the PUT echo parse falls back to the requested slug on an unrecognized 2xx body (the exact envelope is unverified until the worker ships). Query key is flat `["languages-default", org]` — the nested form would collide with a language literally named `default`, the same trap the route naming dodges (`/api/config/languages/default` still addresses that language; tested).

**Ride-along — closes the #272 checklist** (separate commit): stale #247-carve-out comments in `worker/auth.ts` and `language-selector.tsx` updated for the #249 trump, and the provably-unreachable name-collision branch deleted (list and `takenNames` shared the unfiltered catalog; premise re-verified against the current tree before deletion).

## Deliberately out

- **Export round-trip**: Export Config (#187) is modes-only today; an org-level pointer inside a per-mode snapshot raises real questions (would importing a mode re-point the org default?) for zero current value. Deferred; needs its own issue if a language export ever lands.
- Rung-3 resolution itself — entirely worker-side.

## Known pre-existing issues surfaced during review (not addressed here)

- Create-over-existing slug silently overwrites that language's document and unpublishes it (no confirmation) — predates this PR.
- Delete errors render both inline and in the page banner, and the banner outlives the dialog.

## Verification

Adversarially verified by an independent reviewer before push: the BFF surface survived method-coverage, gate-parity, org-scoping, route-shadowing, and CSRF attack construction; the three UI-state findings it did surface (loading-window drift false-alarm, loading/error/unsupported conflation, missing invalidations) are fixed in the third commit with the pinned-wrong tests flipped.

778 tests passing (+75 over main): BFF authz allowed/denied/wrong-org/method matrix, all seven UI states, echo-envelope tolerance (`it.each` over four unrecognized bodies), cache-effect functions against a real QueryClient, and the admin-A/admin-B stale-cache path. Lint zero warnings, typecheck, build, prettier all clean.

Closes #286
Closes #272
