### PR TITLE
fix(#230): one server-attribution join across all three resource surfaces

### DIFF
--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -65,11 +65,16 @@ function ServerChip({
           server.status === "error" && "bg-destructive"
         )}
       />
+      {/* Full name as the text node, bounded visually by CSS: a
+          character-truncated string would become the accessible name too, so
+          assistive tech would hear the cut version. aria-label carries the
+          machine id, which is otherwise tooltip-only. */}
       <span
         className="text-foreground/80 max-w-[16rem] min-w-0 truncate font-medium"
         title={label.title}
+        aria-label={label.title}
       >
-        {label.display}
+        {label.full}
       </span>
       {server.status === "unsupported" && <span>no resource listing</span>}
       {server.status === "error" && (
@@ -93,10 +98,10 @@ function ServerChip({
 // Source attribution, resolved from `servers[]` (#230 "indicate the source MCP
 // server for each resource"). Renders the human-readable serverName rather than
 // the machine id — the same attribution the topology map and the priority panel
-// already show — with the id retained in the tooltip. serverName is untrusted
-// third-party text, so it arrives collapsed and character-bounded from
-// lib/resource-servers; the extra `max-w` is a CSS backstop for a name that is
-// short in characters but wide in glyphs.
+// already show — with the id retained in the tooltip and the accessible name.
+// serverName is untrusted third-party text: it arrives collapsed to one line
+// from lib/resource-servers, and the width bound is CSS so the full name stays
+// in the DOM for assistive tech.
 function ServerBadge({
   serverId,
   serverNames,
@@ -110,11 +115,12 @@ function ServerBadge({
       variant="outline"
       className="max-w-[14rem] px-1.5 py-0 text-[10px]"
       title={label.title}
+      aria-label={label.title}
     >
       {/* `truncate` has to sit on a child, not on the Badge: the Badge is an
           inline-flex container, where overflow clips the flex item hard
           instead of ellipsising it. */}
-      <span className="min-w-0 truncate">{label.display}</span>
+      <span className="min-w-0 truncate">{label.full}</span>
     </Badge>
   );
 }

--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -34,13 +34,19 @@ import type { ResourceItem, ResourceServerReport } from "@/types/resources";
 // and a transient failure is not a capability gap.
 function ServerChip({
   server,
+  serverNames,
   onRetry,
   isRetrying,
 }: {
   server: ResourceServerReport;
+  serverNames: ServerNameMap;
   onRetry: () => void;
   isRetrying: boolean;
 }) {
+  // Resolved rather than read raw: a server reporting a blank name would
+  // otherwise render an unidentifiable chip — worst exactly in the `error`
+  // case, where the chip's whole job is to say WHICH server failed.
+  const label = resolveServerLabel(server.serverId, serverNames);
   return (
     <span
       className={cn(
@@ -59,8 +65,11 @@ function ServerChip({
           server.status === "error" && "bg-destructive"
         )}
       />
-      <span className="text-foreground/80 font-medium">
-        {server.serverName}
+      <span
+        className="text-foreground/80 max-w-[16rem] min-w-0 truncate font-medium"
+        title={label.title}
+      >
+        {label.display}
       </span>
       {server.status === "unsupported" && <span>no resource listing</span>}
       {server.status === "error" && (
@@ -99,10 +108,13 @@ function ServerBadge({
   return (
     <Badge
       variant="outline"
-      className="max-w-[14rem] truncate px-1.5 py-0 text-[10px]"
+      className="max-w-[14rem] px-1.5 py-0 text-[10px]"
       title={label.title}
     >
-      {label.display}
+      {/* `truncate` has to sit on a child, not on the Badge: the Badge is an
+          inline-flex container, where overflow clips the flex item hard
+          instead of ellipsising it. */}
+      <span className="min-w-0 truncate">{label.display}</span>
     </Badge>
   );
 }
@@ -296,6 +308,7 @@ export function ResourcesPage() {
                   <ServerChip
                     key={server.serverId}
                     server={server}
+                    serverNames={serverNames}
                     onRetry={() => void resources.refetch()}
                     isRetrying={resources.isFetching}
                   />

--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -67,14 +67,17 @@ function ServerChip({
       />
       {/* Full name as the text node, bounded visually by CSS: a
           character-truncated string would become the accessible name too, so
-          assistive tech would hear the cut version. aria-label carries the
-          machine id, which is otherwise tooltip-only. */}
+          assistive tech would hear the cut version. The id rides in an sr-only
+          span rather than an aria-label — per HTML-AAM a generic element's
+          aria-label is not reliably exposed, but its text content always is. */}
       <span
         className="text-foreground/80 max-w-[16rem] min-w-0 truncate font-medium"
         title={label.title}
-        aria-label={label.title}
       >
         {label.full}
+        {label.machineId && (
+          <span className="sr-only"> ({label.machineId})</span>
+        )}
       </span>
       {server.status === "unsupported" && <span>no resource listing</span>}
       {server.status === "error" && (
@@ -115,12 +118,12 @@ function ServerBadge({
       variant="outline"
       className="max-w-[14rem] px-1.5 py-0 text-[10px]"
       title={label.title}
-      aria-label={label.title}
     >
       {/* `truncate` has to sit on a child, not on the Badge: the Badge is an
           inline-flex container, where overflow clips the flex item hard
           instead of ellipsising it. */}
       <span className="min-w-0 truncate">{label.full}</span>
+      {label.machineId && <span className="sr-only"> ({label.machineId})</span>}
     </Badge>
   );
 }

--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -10,6 +10,11 @@ import {
 } from "lucide-react";
 
 import { safeResourceHref } from "@/lib/resource-href";
+import {
+  buildServerNameMap,
+  resolveServerLabel,
+  type ServerNameMap,
+} from "@/lib/resource-servers";
 import { subjectLabel } from "@/lib/resource-subjects";
 import { useUiStore } from "@/lib/ui-store";
 import { cn } from "@/lib/utils";
@@ -76,7 +81,39 @@ function ServerChip({
   );
 }
 
-function ResourceRow({ item }: { item: ResourceItem }) {
+// Source attribution, resolved from `servers[]` (#230 "indicate the source MCP
+// server for each resource"). Renders the human-readable serverName rather than
+// the machine id — the same attribution the topology map and the priority panel
+// already show — with the id retained in the tooltip. serverName is untrusted
+// third-party text, so it arrives collapsed and character-bounded from
+// lib/resource-servers; the extra `max-w` is a CSS backstop for a name that is
+// short in characters but wide in glyphs.
+function ServerBadge({
+  serverId,
+  serverNames,
+}: {
+  serverId: string;
+  serverNames: ServerNameMap;
+}) {
+  const label = resolveServerLabel(serverId, serverNames);
+  return (
+    <Badge
+      variant="outline"
+      className="max-w-[14rem] truncate px-1.5 py-0 text-[10px]"
+      title={label.title}
+    >
+      {label.display}
+    </Badge>
+  );
+}
+
+function ResourceRow({
+  item,
+  serverNames,
+}: {
+  item: ResourceItem;
+  serverNames: ServerNameMap;
+}) {
   // Scheme-guarded: item.url is third-party MCP server output relayed by
   // the worker — see lib/resource-href.ts.
   const href = safeResourceHref(item.url);
@@ -95,9 +132,7 @@ function ResourceRow({ item }: { item: ResourceItem }) {
       {item.label && (
         <code className="text-muted-foreground text-[11px]">{item.name}</code>
       )}
-      <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
-        {item.serverId}
-      </Badge>
+      <ServerBadge serverId={item.serverId} serverNames={serverNames} />
       {meta.length > 0 && (
         <span className="text-muted-foreground text-xs">
           {meta.join(" · ")}
@@ -146,7 +181,12 @@ export function ResourcesPage() {
   // map (#261). No separate fetch: the map renders whatever the list has.
   const [view, setView] = useState<"list" | "map">("list");
 
-  const servers = data?.servers ?? [];
+  // Memoized so the attribution map below has a stable identity across renders
+  // (same reason `subjects` is memoized off `data`).
+  const servers = useMemo(() => data?.servers ?? [], [data]);
+  // One join for the whole page: every per-resource and per-subject badge below
+  // resolves its attribution through this map rather than re-scanning servers[].
+  const serverNames = useMemo(() => buildServerNameMap(servers), [servers]);
   const noneListable =
     servers.length > 0 && servers.every((s) => s.status !== "ok");
 
@@ -337,13 +377,11 @@ export function ResourcesPage() {
                           </span>
                           <span className="hidden shrink-0 gap-1 sm:flex">
                             {serverIds.map((id) => (
-                              <Badge
+                              <ServerBadge
                                 key={id}
-                                variant="outline"
-                                className="px-1.5 py-0 text-[10px]"
-                              >
-                                {id}
-                              </Badge>
+                                serverId={id}
+                                serverNames={serverNames}
+                              />
                             ))}
                           </span>
                         </button>
@@ -353,6 +391,7 @@ export function ResourcesPage() {
                               <ResourceRow
                                 key={`${item.serverId}:${item.name}`}
                                 item={item}
+                                serverNames={serverNames}
                               />
                             ))}
                           </ul>

--- a/src/components/resource-priority-panel.tsx
+++ b/src/components/resource-priority-panel.tsx
@@ -21,7 +21,12 @@ import {
   type MergedEntry,
   type PriorityEntry,
 } from "@/lib/resource-priority";
-import { buildServerNameMap, resolveServerLabel } from "@/lib/resource-servers";
+import {
+  buildServerNameMap,
+  resolveServerLabel,
+  resolveServerName,
+  type ServerNameMap,
+} from "@/lib/resource-servers";
 import { useUiStore } from "@/lib/ui-store";
 import { cn } from "@/lib/utils";
 import { useResources } from "@/hooks/use-resources";
@@ -450,15 +455,17 @@ function PanelBody({
                     )}
                   />
                   {/* One truncation strategy for the panel: full name in the
-                      DOM, CSS does the visual cut, aria-label carries the id.
-                      Character-truncating here would shorten the accessible
+                      DOM, CSS does the visual cut, an sr-only span carries the
+                      id. Character-truncating here would shorten the accessible
                       name of the notice that identifies a failed server. */}
                   <span
                     className="max-w-[14rem] min-w-0 truncate font-medium"
                     title={label.title}
-                    aria-label={label.title}
                   >
                     {label.full}
+                    {label.machineId && (
+                      <span className="sr-only"> ({label.machineId})</span>
+                    )}
                   </span>
                   <span>
                     {server.status === "error"
@@ -525,7 +532,7 @@ function PanelBody({
                       <span className="text-muted-foreground w-5 shrink-0 text-right text-xs tabular-nums">
                         {index + 1}
                       </span>
-                      <RowIdentity row={row} />
+                      <RowIdentity row={row} serverNames={serverNames} />
                       <div className="flex shrink-0 items-center gap-0.5">
                         <div className="flex flex-col">
                           {/* The rank lives in a sibling span the button never
@@ -605,7 +612,7 @@ function PanelBody({
                     className="hover:bg-card flex items-center gap-3 rounded-lg border border-transparent px-2.5 py-2 transition-colors"
                   >
                     <span aria-hidden className="w-5 shrink-0" />
-                    <RowIdentity row={row} muted />
+                    <RowIdentity row={row} serverNames={serverNames} muted />
                     <Button
                       ref={(el) => {
                         buttons.current.set(`${row.id}:rank`, el);
@@ -714,11 +721,20 @@ function PanelBody({
 /** Label, badge and attribution — identical in both lists. */
 function RowIdentity({
   row,
+  serverNames,
   muted = false,
 }: {
   row: MergedEntry;
+  serverNames: ServerNameMap;
   muted?: boolean;
 }) {
+  // `row.serverName` is the RAW status-block value, kept raw because it feeds
+  // the emitted document. For display it goes through the same join the rest of
+  // the app uses, so a tabbed or blank name reads here exactly as it does on
+  // the Resources page and the map — without disturbing a single emitted byte.
+  const serverText = row.missing
+    ? ""
+    : resolveServerName(row.serverId, serverNames);
   return (
     <div className="min-w-0 flex-1">
       <div className="flex items-baseline gap-2">
@@ -747,7 +763,7 @@ function RowIdentity({
       <p className="text-muted-foreground truncate text-[11px]">
         {row.missing
           ? "Kept from the saved order — no server listed it for this language"
-          : [row.serverName, row.subjectLabelText].filter(Boolean).join(" · ")}
+          : [serverText, row.subjectLabelText].filter(Boolean).join(" · ")}
       </p>
     </div>
   );

--- a/src/components/resource-priority-panel.tsx
+++ b/src/components/resource-priority-panel.tsx
@@ -21,6 +21,7 @@ import {
   type MergedEntry,
   type PriorityEntry,
 } from "@/lib/resource-priority";
+import { buildServerNameMap, resolveServerLabel } from "@/lib/resource-servers";
 import { useUiStore } from "@/lib/ui-store";
 import { cn } from "@/lib/utils";
 import { useResources } from "@/hooks/use-resources";
@@ -324,6 +325,13 @@ function PanelBody({
   }, []);
 
   const degraded = (data?.servers ?? []).filter((s) => s.status !== "ok");
+  // Same attribution join the Resources page and the topology map use, so a
+  // server that reports a blank name is still identifiable in the notice that
+  // explains why its resources are absent from the ranking.
+  const serverNames = useMemo(
+    () => buildServerNameMap(data?.servers ?? []),
+    [data]
+  );
 
   return (
     <>
@@ -420,33 +428,41 @@ function PanelBody({
 
         {degraded.length > 0 && (
           <ul className="space-y-1">
-            {degraded.map((server) => (
-              <li
-                key={server.serverId}
-                className={cn(
-                  "flex flex-wrap items-center gap-x-1.5 text-[11px]",
-                  server.status === "error"
-                    ? "text-destructive"
-                    : "text-muted-foreground"
-                )}
-              >
-                <span
-                  aria-hidden
+            {degraded.map((server) => {
+              const label = resolveServerLabel(server.serverId, serverNames);
+              return (
+                <li
+                  key={server.serverId}
                   className={cn(
-                    "size-1.5 rounded-full",
+                    "flex flex-wrap items-center gap-x-1.5 text-[11px]",
                     server.status === "error"
-                      ? "bg-destructive"
-                      : "bg-muted-foreground/40"
+                      ? "text-destructive"
+                      : "text-muted-foreground"
                   )}
-                />
-                <span className="font-medium">{server.serverName}</span>
-                <span>
-                  {server.status === "error"
-                    ? "failed to respond, so its resources are missing from this list"
-                    : "doesn't list resources, so it can't be ranked"}
-                </span>
-              </li>
-            ))}
+                >
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "size-1.5 rounded-full",
+                      server.status === "error"
+                        ? "bg-destructive"
+                        : "bg-muted-foreground/40"
+                    )}
+                  />
+                  <span
+                    className="max-w-[14rem] min-w-0 truncate font-medium"
+                    title={label.title}
+                  >
+                    {label.display}
+                  </span>
+                  <span>
+                    {server.status === "error"
+                      ? "failed to respond, so its resources are missing from this list"
+                      : "doesn't list resources, so it can't be ranked"}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         )}
 

--- a/src/components/resource-priority-panel.tsx
+++ b/src/components/resource-priority-panel.tsx
@@ -449,11 +449,16 @@ function PanelBody({
                         : "bg-muted-foreground/40"
                     )}
                   />
+                  {/* One truncation strategy for the panel: full name in the
+                      DOM, CSS does the visual cut, aria-label carries the id.
+                      Character-truncating here would shorten the accessible
+                      name of the notice that identifies a failed server. */}
                   <span
                     className="max-w-[14rem] min-w-0 truncate font-medium"
                     title={label.title}
+                    aria-label={label.title}
                   >
-                    {label.display}
+                    {label.full}
                   </span>
                   <span>
                     {server.status === "error"

--- a/src/lib/resource-map-layout.ts
+++ b/src/lib/resource-map-layout.ts
@@ -7,7 +7,7 @@
 
 import { buildServerNameMap, resolveServerName } from "@/lib/resource-servers";
 import { subjectLabel } from "@/lib/resource-subjects";
-import { codePointLength, truncateLabel } from "@/lib/truncate";
+import { displayColumns, truncateLabel } from "@/lib/truncate";
 import type {
   AggregatedResourcesResponse,
   ResourceServerStatus,
@@ -117,10 +117,15 @@ function quoteLanguage(tag: string): string {
   return `${EMPTY_CAPTION_PREFIX}“${tag}”`;
 }
 
-/** What the tag itself may spend once the prose and quotes are paid for. */
+/**
+ * What the tag itself may spend once the prose and quotes are paid for. The
+ * surrounding prose is fixed narrow text, so this is the same number either
+ * way — but it is a column budget being subtracted from a column budget, and
+ * measuring it as one keeps that true if the prose ever changes.
+ */
 const LANGUAGE_TAG_MAX_CHARS = Math.max(
   1,
-  SERVER_CAPTION_MAX_CHARS - quoteLanguage("").length
+  SERVER_CAPTION_MAX_CHARS - displayColumns(quoteLanguage(""))
 );
 
 function bounded(full: string): ServerCaption {
@@ -166,13 +171,15 @@ export function serverCaption(
   return bounded(counted);
 }
 
-// Counted in code points, matching truncateLabel: budgeting an astral label by
-// UTF-16 units would double-count every emoji and overestimate its ink, cutting
-// the node wider than the glyphs need.
+// Measured in display columns, the same budget truncateLabel cuts to — so the
+// width computed here and the length the label was cut to agree. Counting code
+// points instead would size an emoji label at half its ink and overflow the
+// node; counting UTF-16 units would misjudge it the other way for anything
+// else astral.
 function leafWidth(label: string, count: number): number {
   const raw =
     LEAF_PAD_X * 2 +
-    codePointLength(label) * LEAF_CHAR_W +
+    displayColumns(label) * LEAF_CHAR_W +
     LEAF_COUNT_GAP +
     String(count).length * COUNT_CHAR_W;
   return Math.min(Math.ceil(raw), MAX_LEAF_WIDTH);

--- a/src/lib/resource-map-layout.ts
+++ b/src/lib/resource-map-layout.ts
@@ -7,7 +7,7 @@
 
 import { buildServerNameMap, resolveServerName } from "@/lib/resource-servers";
 import { subjectLabel } from "@/lib/resource-subjects";
-import { truncateLabel } from "@/lib/truncate";
+import { codePointLength, truncateLabel } from "@/lib/truncate";
 import type {
   AggregatedResourcesResponse,
   ResourceServerStatus,
@@ -166,10 +166,13 @@ export function serverCaption(
   return bounded(counted);
 }
 
+// Counted in code points, matching truncateLabel: budgeting an astral label by
+// UTF-16 units would double-count every emoji and overestimate its ink, cutting
+// the node wider than the glyphs need.
 function leafWidth(label: string, count: number): number {
   const raw =
     LEAF_PAD_X * 2 +
-    label.length * LEAF_CHAR_W +
+    codePointLength(label) * LEAF_CHAR_W +
     LEAF_COUNT_GAP +
     String(count).length * COUNT_CHAR_W;
   return Math.min(Math.ceil(raw), MAX_LEAF_WIDTH);

--- a/src/lib/resource-map-layout.ts
+++ b/src/lib/resource-map-layout.ts
@@ -5,7 +5,9 @@
 // output. No diagram library — the topology is small and fixed-shape
 // (org → servers → subject leaves), so hand-rolled elbows beat a dependency.
 
+import { buildServerNameMap, resolveServerName } from "@/lib/resource-servers";
 import { subjectLabel } from "@/lib/resource-subjects";
+import { truncateLabel } from "@/lib/truncate";
 import type {
   AggregatedResourcesResponse,
   ResourceServerStatus,
@@ -101,12 +103,6 @@ export interface ResourceMapLayout {
   servers: ResourceMapServer[];
 }
 
-/** Ellipsis-truncate to at most `max` characters (including the ellipsis). */
-export function truncateLabel(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
-}
-
 /** The two forms of a server-node caption. */
 export interface ServerCaption {
   /** Untruncated — the sr-only tree and the node <title> carry this. */
@@ -191,6 +187,11 @@ export function buildResourceMapLayout(
   data: AggregatedResourcesResponse
 ): ResourceMapLayout {
   const subjectEntries = Object.entries(data.resources);
+  // Same attribution join the list page and the priority panel use, so a
+  // blank or whitespace-only serverName degrades to the server id here too
+  // rather than labelling a node with an empty string, and untrusted control
+  // characters are collapsed before they reach the sr-only tree or a <title>.
+  const serverNames = buildServerNameMap(data.servers);
 
   let y = MAP.padY;
   const servers: ResourceMapServer[] = data.servers.map((server) => {
@@ -224,10 +225,12 @@ export function buildResourceMapLayout(
 
     y += height + MAP.blockGap;
 
+    const resolvedName = resolveServerName(server.serverId, serverNames);
+
     return {
       serverId: server.serverId,
-      serverName: server.serverName,
-      displayName: truncateLabel(server.serverName, SERVER_NAME_MAX_CHARS),
+      serverName: resolvedName,
+      displayName: truncateLabel(resolvedName, SERVER_NAME_MAX_CHARS),
       status: server.status,
       error: server.error,
       top,

--- a/src/lib/resource-map-layout.ts
+++ b/src/lib/resource-map-layout.ts
@@ -5,7 +5,11 @@
 // output. No diagram library — the topology is small and fixed-shape
 // (org → servers → subject leaves), so hand-rolled elbows beat a dependency.
 
-import { buildServerNameMap, resolveServerName } from "@/lib/resource-servers";
+import {
+  buildServerNameMap,
+  collapseDisplayText,
+  resolveServerName,
+} from "@/lib/resource-servers";
 import { subjectLabel } from "@/lib/resource-subjects";
 import { displayColumns, truncateLabel } from "@/lib/truncate";
 import type {
@@ -242,7 +246,12 @@ export function buildResourceMapLayout(
       serverName: resolvedName,
       displayName: truncateLabel(resolvedName, SERVER_NAME_MAX_CHARS),
       status: server.status,
-      error: server.error,
+      // Same untrusted class as serverName, and it lands in the sr-only tree
+      // and a node <title> verbatim — so it gets the same single-line collapse.
+      error:
+        server.error === undefined
+          ? undefined
+          : collapseDisplayText(server.error),
       top,
       height,
       centerY: top + height / 2,

--- a/src/lib/resource-priority.ts
+++ b/src/lib/resource-priority.ts
@@ -12,7 +12,6 @@
 // Everything here is pure and DOM-free: it runs (and is tested) under the
 // workers-pool tsconfig, and the panel component is a thin projection of it.
 
-import { buildServerNameMap, resolveServerName } from "@/lib/resource-servers";
 import { subjectLabel } from "@/lib/resource-subjects";
 import type { PromptSlot } from "@/types/prompt-override";
 import { PROMPT_SLOTS, SLOT_LABELS } from "@/types/prompt-override";
@@ -136,22 +135,26 @@ export function sanitizePromptText(text: string): string {
 export function buildPriorityEntries(
   response: AggregatedResourcesResponse
 ): PriorityEntry[] {
-  // Shared with the Resources page and the topology map so all three surfaces
-  // name a server identically. The name is taken FULL and untruncated: it
-  // reaches the mode document via `describeEntry`, and the display budget is a
-  // property of a badge, not of the prompt.
+  // A RAW join, deliberately not the display resolution in lib/resource-servers
+  // — including its `?? ` (not `||`) fallback, which leaves a blank serverName
+  // as the empty string rather than substituting the id.
   //
-  // This DOES change emitted bytes for some pre-existing documents. Collapsing
-  // rewrites any name carrying a tab, a run of spaces, an NBSP, a zero-width
-  // character or a soft hyphen, and a blank name now resolves to the server id
-  // instead of an empty string. For an affected document the regenerated block
-  // no longer matches the stored one, so the panel opens with Apply enabled
-  // once even though the user changed nothing — a cosmetic false positive, not
-  // a data risk: applying rewrites the block to the collapsed form, and every
-  // regeneration after that is byte-identical again. The round-trip test in
-  // tests/resource-priority.test.ts pins that steady state, so the invariant is
-  // machine-checked rather than asserted here in prose.
-  const serverNames = buildServerNameMap(response.servers);
+  // This value reaches the mode document through `describeEntry`, and Apply
+  // PUTs the WHOLE document (see handleApplyResourcePriorities in
+  // app/pages/modes.tsx). So any change to these bytes would make the
+  // regenerated block differ from the stored one for existing documents,
+  // enabling Apply with no ranking intent behind it: a user opening the panel
+  // to look would be offered a save that silently rewrites names — and carries
+  // any unrelated unsaved draft edits along with it — while the blocked-state
+  // copy still talks only about the ORDER. Emission is therefore frozen, and
+  // display hardening is kept strictly on the display side. The round-trip test
+  // in tests/resource-priority.test.ts holds this without an intervening apply.
+  //
+  // Emission-side safety is `sanitizePromptText` in `describeEntry`, which is
+  // what neutralizes newlines and the worker's rewrite markers.
+  const serverNames = new Map(
+    response.servers.map((server) => [server.serverId, server.serverName])
+  );
   const entries: PriorityEntry[] = [];
   const seen = new Set<string>();
 
@@ -163,7 +166,7 @@ export function buildPriorityEntries(
       entries.push({
         id,
         label: item.label ?? item.name,
-        serverName: resolveServerName(item.serverId, serverNames),
+        serverName: serverNames.get(item.serverId) ?? item.serverId,
         subjectLabelText: subjectLabel(slug),
       });
     }

--- a/src/lib/resource-priority.ts
+++ b/src/lib/resource-priority.ts
@@ -56,6 +56,13 @@ export interface PriorityEntry {
   id: string;
   /** `label ?? name` — what a human recognizes the resource by. */
   label: string;
+  /**
+   * Attribution id, carried so the panel can run its own DISPLAY-side join
+   * (lib/resource-servers) without re-deriving it from the `serverId:name`
+   * composite — which would misparse any resource name containing a colon.
+   */
+  serverId: string;
+  /** RAW name from the status block — emission input. See the note below. */
   serverName: string;
   /** Display form of the (open-set) subject slug. */
   subjectLabelText: string;
@@ -166,6 +173,7 @@ export function buildPriorityEntries(
       entries.push({
         id,
         label: item.label ?? item.name,
+        serverId: item.serverId,
         serverName: serverNames.get(item.serverId) ?? item.serverId,
         subjectLabelText: subjectLabel(slug),
       });
@@ -236,6 +244,10 @@ export function mergeOrderWithLive(
             // carried in the document; only an id the document never
             // described renders raw.
             label: recoveredDescriptions?.get(id) ?? id,
+            // No live report to attribute to. The row renders its own
+            // "kept from the saved order" line instead of an attribution, so
+            // there is nothing to resolve and nothing to guess at.
+            serverId: "",
             serverName: "",
             subjectLabelText: "",
             missing: true,

--- a/src/lib/resource-priority.ts
+++ b/src/lib/resource-priority.ts
@@ -136,11 +136,21 @@ export function sanitizePromptText(text: string): string {
 export function buildPriorityEntries(
   response: AggregatedResourcesResponse
 ): PriorityEntry[] {
-  // Shared with the Resources page so both surfaces name a server identically.
-  // Note this is the FULL name, deliberately untruncated: the value reaches the
-  // mode document via `describeEntry`, and shortening it would change emitted
-  // prompt text — breaking the byte-identical regeneration that keeps Apply
-  // honestly disabled when nothing changed.
+  // Shared with the Resources page and the topology map so all three surfaces
+  // name a server identically. The name is taken FULL and untruncated: it
+  // reaches the mode document via `describeEntry`, and the display budget is a
+  // property of a badge, not of the prompt.
+  //
+  // This DOES change emitted bytes for some pre-existing documents. Collapsing
+  // rewrites any name carrying a tab, a run of spaces, an NBSP, a zero-width
+  // character or a soft hyphen, and a blank name now resolves to the server id
+  // instead of an empty string. For an affected document the regenerated block
+  // no longer matches the stored one, so the panel opens with Apply enabled
+  // once even though the user changed nothing — a cosmetic false positive, not
+  // a data risk: applying rewrites the block to the collapsed form, and every
+  // regeneration after that is byte-identical again. The round-trip test in
+  // tests/resource-priority.test.ts pins that steady state, so the invariant is
+  // machine-checked rather than asserted here in prose.
   const serverNames = buildServerNameMap(response.servers);
   const entries: PriorityEntry[] = [];
   const seen = new Set<string>();

--- a/src/lib/resource-priority.ts
+++ b/src/lib/resource-priority.ts
@@ -12,6 +12,7 @@
 // Everything here is pure and DOM-free: it runs (and is tested) under the
 // workers-pool tsconfig, and the panel component is a thin projection of it.
 
+import { buildServerNameMap, resolveServerName } from "@/lib/resource-servers";
 import { subjectLabel } from "@/lib/resource-subjects";
 import type { PromptSlot } from "@/types/prompt-override";
 import { PROMPT_SLOTS, SLOT_LABELS } from "@/types/prompt-override";
@@ -135,9 +136,12 @@ export function sanitizePromptText(text: string): string {
 export function buildPriorityEntries(
   response: AggregatedResourcesResponse
 ): PriorityEntry[] {
-  const serverNames = new Map(
-    response.servers.map((server) => [server.serverId, server.serverName])
-  );
+  // Shared with the Resources page so both surfaces name a server identically.
+  // Note this is the FULL name, deliberately untruncated: the value reaches the
+  // mode document via `describeEntry`, and shortening it would change emitted
+  // prompt text — breaking the byte-identical regeneration that keeps Apply
+  // honestly disabled when nothing changed.
+  const serverNames = buildServerNameMap(response.servers);
   const entries: PriorityEntry[] = [];
   const seen = new Set<string>();
 
@@ -149,7 +153,7 @@ export function buildPriorityEntries(
       entries.push({
         id,
         label: item.label ?? item.name,
-        serverName: serverNames.get(item.serverId) ?? item.serverId,
+        serverName: resolveServerName(item.serverId, serverNames),
         subjectLabelText: subjectLabel(slug),
       });
     }

--- a/src/lib/resource-servers.ts
+++ b/src/lib/resource-servers.ts
@@ -1,0 +1,108 @@
+// Server attribution for resources (#230 "indicate the source MCP server for
+// each resource"). The aggregated response carries attribution as a machine id
+// on every `ResourceItem` (`serverId`) and the human-readable name only once,
+// in the `servers[]` status block (`serverName`) — so rendering a resource's
+// source as a NAME is always a join, never a field read. This module owns that
+// join, so the three surfaces built on the same response (list page, topology
+// map, priority panel) resolve attribution one way rather than three.
+//
+// `serverName` is third-party MCP-server output relayed by the worker, i.e.
+// untrusted display text. React escapes it, so the hazard here is layout and
+// legibility rather than injection: an unbounded name blows out a badge row,
+// and embedded newlines/control characters break a single-line chip. Both are
+// neutralized on the way in (collapse) and on the way out (truncate).
+
+import { truncateLabel } from "@/lib/resource-map-layout";
+import type { ResourceServerReport } from "@/types/resources";
+
+/**
+ * Character budget for an inline server badge. Chosen to match the topology
+ * map's in-node budget (`SERVER_NAME_MAX_CHARS`, 24) plus a little slack — the
+ * badge is laid out by CSS rather than fitted into fixed SVG geometry, so it
+ * can afford a few more characters without wrapping its row.
+ */
+export const RESOURCE_SERVER_LABEL_MAX_CHARS = 28;
+
+/** serverId → human-readable serverName, blank and unusable names omitted. */
+export type ServerNameMap = ReadonlyMap<string, string>;
+
+// Untrusted text arrives as a single display line: newlines, tabs and other
+// control characters collapse to spaces so a name can never span rows or smuggle
+// invisible structure into a chip. `\p{Cc}` catches C0/C1 controls and
+// `\p{Cf}` the invisible formatting characters (zero-width joiners, bidi
+// overrides) that render as nothing while still consuming the budget.
+function collapseWhitespace(text: string): string {
+  return text.replace(/[\s\p{Cc}\p{Cf}]+/gu, " ").trim();
+}
+
+/**
+ * Index the `servers[]` status block by id.
+ *
+ * A server whose name is blank (or collapses to nothing) is omitted rather than
+ * indexed as `""` — an empty name is not an improvement on the id, and callers
+ * fall back to the id for anything this map doesn't answer.
+ */
+export function buildServerNameMap(
+  servers: readonly ResourceServerReport[]
+): ServerNameMap {
+  const names = new Map<string, string>();
+  for (const server of servers) {
+    const name = collapseWhitespace(server.serverName ?? "");
+    if (name.length > 0) names.set(server.serverId, name);
+  }
+  return names;
+}
+
+/**
+ * The best full-length human label for `serverId`.
+ *
+ * Falls back to the id itself when the server isn't in the status block — which
+ * is off-contract but observable in practice (a server can list resources and
+ * then drop out of a later aggregation), and showing the raw id beats showing
+ * nothing about where a resource came from.
+ */
+export function resolveServerName(
+  serverId: string,
+  names: ServerNameMap
+): string {
+  return names.get(serverId) ?? collapseWhitespace(serverId);
+}
+
+/** A server attribution ready to render in a fixed-width chip. */
+export interface ServerLabel {
+  /** Full resolved name — never truncated. */
+  full: string;
+  /** `full` bounded to the character budget; what the chip renders. */
+  display: string;
+  /** True when `display` had to cut `full` short. */
+  truncated: boolean;
+  /**
+   * Tooltip text. Always the full name, and additionally the machine id when
+   * the two differ — the id was what this badge showed before names landed, and
+   * it stays discoverable rather than being replaced outright.
+   */
+  title: string;
+}
+
+/**
+ * Resolve `serverId` to a bounded, tooltip-annotated display label.
+ *
+ * Truncation is by character count (the same mechanism the topology map uses)
+ * rather than CSS: it bounds the string itself, so it holds in a tooltip, an
+ * accessible name, and any container the badge is dropped into.
+ */
+export function resolveServerLabel(
+  serverId: string,
+  names: ServerNameMap,
+  max: number = RESOURCE_SERVER_LABEL_MAX_CHARS
+): ServerLabel {
+  const full = resolveServerName(serverId, names);
+  const display = truncateLabel(full, max);
+  const id = collapseWhitespace(serverId);
+  return {
+    full,
+    display,
+    truncated: display !== full,
+    title: full === id ? full : `${full} (${id})`,
+  };
+}

--- a/src/lib/resource-servers.ts
+++ b/src/lib/resource-servers.ts
@@ -8,20 +8,21 @@
 //
 // `serverName` is third-party MCP-server output relayed by the worker, i.e.
 // untrusted display text. React escapes it, so the hazard here is layout and
-// legibility rather than injection: an unbounded name blows out a badge row,
-// and embedded newlines/control characters break a single-line chip. Both are
-// neutralized on the way in (collapse) and on the way out (truncate).
+// legibility rather than injection: embedded newlines and control characters
+// break a single-line chip, so they are collapsed on the way in.
+//
+// This resolution is DISPLAY-ONLY. It deliberately has no consumer on the
+// path that emits text into a mode document (lib/resource-priority), which
+// keeps its own raw join so that generated prompt bytes stay stable — see the
+// note above `buildPriorityEntries`. Hardening a rendered badge must never be
+// able to author a document revision.
+//
+// Length is NOT bounded here. DOM surfaces render the full name and let CSS
+// (`truncate`) do the visual cut, so the accessible name stays complete; only
+// the SVG map, where CSS cannot reach, cuts the string itself via
+// lib/truncate.
 
-import { truncateLabel } from "@/lib/truncate";
 import type { ResourceServerReport } from "@/types/resources";
-
-/**
- * Character budget for an inline server badge. Chosen to match the topology
- * map's in-node budget (`SERVER_NAME_MAX_CHARS`, 24) plus a little slack — the
- * badge is laid out by CSS rather than fitted into fixed SVG geometry, so it
- * can afford a few more characters without wrapping its row.
- */
-export const RESOURCE_SERVER_LABEL_MAX_CHARS = 28;
 
 /** serverId → human-readable serverName, blank and unusable names omitted. */
 export type ServerNameMap = ReadonlyMap<string, string>;
@@ -68,38 +69,34 @@ export function resolveServerName(
   return names.get(serverId) ?? collapseWhitespace(serverId);
 }
 
-/** A server attribution ready to render in a fixed-width chip. */
+/** A server attribution ready to render in a DOM chip. */
 export interface ServerLabel {
-  /** Full resolved name — never truncated. */
-  full: string;
-  /** `full` bounded to the character budget; what the chip renders. */
-  display: string;
   /**
-   * Tooltip text. Always the full name, and additionally the machine id when
-   * the two differ — the id was what this badge showed before names landed, and
-   * it stays discoverable rather than being replaced outright.
+   * The full resolved name — the text node. Rendering it whole is what keeps a
+   * screen reader's announcement complete when CSS visually truncates it.
+   */
+  full: string;
+  /**
+   * Tooltip and accessible name. Always the full name, and additionally the
+   * machine id when the two differ — the id was what these badges showed
+   * before names landed, and it stays discoverable rather than being replaced
+   * outright.
    */
   title: string;
 }
 
 /**
- * Resolve `serverId` to a bounded, tooltip-annotated display label.
+ * Resolve `serverId` to a renderable display label.
  *
- * Truncation is by character count (the same mechanism the topology map uses)
- * rather than CSS: it bounds the string itself, so it holds in a tooltip, an
- * accessible name, and any container the badge is dropped into.
+ * Nothing is cut: callers pair `full` with a CSS `truncate` for the visual
+ * bound and pass `title` to both `title` and `aria-label`, so sighted users get
+ * a bounded chip and assistive tech gets the whole name plus the id.
  */
 export function resolveServerLabel(
   serverId: string,
-  names: ServerNameMap,
-  max: number = RESOURCE_SERVER_LABEL_MAX_CHARS
+  names: ServerNameMap
 ): ServerLabel {
   const full = resolveServerName(serverId, names);
-  const display = truncateLabel(full, max);
   const id = collapseWhitespace(serverId);
-  return {
-    full,
-    display,
-    title: full === id ? full : `${full} (${id})`,
-  };
+  return { full, title: full === id ? full : `${full} (${id})` };
 }

--- a/src/lib/resource-servers.ts
+++ b/src/lib/resource-servers.ts
@@ -12,7 +12,7 @@
 // and embedded newlines/control characters break a single-line chip. Both are
 // neutralized on the way in (collapse) and on the way out (truncate).
 
-import { truncateLabel } from "@/lib/resource-map-layout";
+import { truncateLabel } from "@/lib/truncate";
 import type { ResourceServerReport } from "@/types/resources";
 
 /**
@@ -74,8 +74,6 @@ export interface ServerLabel {
   full: string;
   /** `full` bounded to the character budget; what the chip renders. */
   display: string;
-  /** True when `display` had to cut `full` short. */
-  truncated: boolean;
   /**
    * Tooltip text. Always the full name, and additionally the machine id when
    * the two differ — the id was what this badge showed before names landed, and
@@ -102,7 +100,6 @@ export function resolveServerLabel(
   return {
     full,
     display,
-    truncated: display !== full,
     title: full === id ? full : `${full} (${id})`,
   };
 }

--- a/src/lib/resource-servers.ts
+++ b/src/lib/resource-servers.ts
@@ -27,12 +27,19 @@ import type { ResourceServerReport } from "@/types/resources";
 /** serverId → human-readable serverName, blank and unusable names omitted. */
 export type ServerNameMap = ReadonlyMap<string, string>;
 
-// Untrusted text arrives as a single display line: newlines, tabs and other
-// control characters collapse to spaces so a name can never span rows or smuggle
-// invisible structure into a chip. `\p{Cc}` catches C0/C1 controls and
-// `\p{Cf}` the invisible formatting characters (zero-width joiners, bidi
-// overrides) that render as nothing while still consuming the budget.
-function collapseWhitespace(text: string): string {
+/**
+ * Flatten untrusted server text to a single display line.
+ *
+ * Newlines, tabs and other control characters collapse to spaces so a value can
+ * never span rows or smuggle invisible structure into a chip. `\p{Cc}` catches
+ * C0/C1 controls and `\p{Cf}` the invisible formatting characters (zero-width
+ * joiners, bidi overrides) that render as nothing while still consuming width.
+ *
+ * Exported because `serverName` is not the only untrusted string the response
+ * carries — `error` is read straight into the map's screen-reader tree and node
+ * tooltips, and wants exactly the same treatment.
+ */
+export function collapseDisplayText(text: string): string {
   return text.replace(/[\s\p{Cc}\p{Cf}]+/gu, " ").trim();
 }
 
@@ -48,7 +55,7 @@ export function buildServerNameMap(
 ): ServerNameMap {
   const names = new Map<string, string>();
   for (const server of servers) {
-    const name = collapseWhitespace(server.serverName ?? "");
+    const name = collapseDisplayText(server.serverName ?? "");
     if (name.length > 0) names.set(server.serverId, name);
   }
   return names;
@@ -66,22 +73,27 @@ export function resolveServerName(
   serverId: string,
   names: ServerNameMap
 ): string {
-  return names.get(serverId) ?? collapseWhitespace(serverId);
+  return names.get(serverId) ?? collapseDisplayText(serverId);
 }
 
 /** A server attribution ready to render in a DOM chip. */
 export interface ServerLabel {
   /**
-   * The full resolved name — the text node. Rendering it whole is what keeps a
-   * screen reader's announcement complete when CSS visually truncates it.
+   * The full resolved name — the visible text node. Rendering it whole is what
+   * keeps a screen reader's announcement complete when CSS visually truncates
+   * it.
    */
   full: string;
   /**
-   * Tooltip and accessible name. Always the full name, and additionally the
-   * machine id when the two differ — the id was what these badges showed
-   * before names landed, and it stays discoverable rather than being replaced
-   * outright.
+   * The machine id, when it differs from `full`; otherwise `null`. Callers put
+   * it in an sr-only span INSIDE the labelled element rather than in an
+   * `aria-label`: per HTML-AAM, `aria-label` on a generic element (a bare
+   * `span`, or a `Badge` that renders one) is not reliably mapped to an
+   * accessible name, whereas text content always is. The id was what these
+   * badges showed before names landed, so it stays discoverable.
    */
+  machineId: string | null;
+  /** Mouse tooltip: the full name, plus the id when the two differ. */
   title: string;
 }
 
@@ -89,14 +101,19 @@ export interface ServerLabel {
  * Resolve `serverId` to a renderable display label.
  *
  * Nothing is cut: callers pair `full` with a CSS `truncate` for the visual
- * bound and pass `title` to both `title` and `aria-label`, so sighted users get
- * a bounded chip and assistive tech gets the whole name plus the id.
+ * bound, so sighted users get a bounded chip while the DOM — and therefore the
+ * accessible name — keeps the whole string.
  */
 export function resolveServerLabel(
   serverId: string,
   names: ServerNameMap
 ): ServerLabel {
   const full = resolveServerName(serverId, names);
-  const id = collapseWhitespace(serverId);
-  return { full, title: full === id ? full : `${full} (${id})` };
+  const id = collapseDisplayText(serverId);
+  const differs = full !== id;
+  return {
+    full,
+    machineId: differs ? id : null,
+    title: differs ? `${full} (${id})` : full,
+  };
 }

--- a/src/lib/truncate.ts
+++ b/src/lib/truncate.ts
@@ -3,51 +3,79 @@
 // text with CSS instead, so they keep the full string as their text node (and
 // therefore as their accessible name) — see lib/resource-servers.
 //
-// Measuring and cutting must agree on what a "character" is, so both live here
-// and both count code points.
+// Cutting and measuring are deliberately NOT the same count:
+//   - cutting is by CODE POINT, so a surrogate pair is never split in half;
+//   - measuring is by COLUMN, because an emoji occupies roughly two Latin
+//     columns of ink and budgeting it as one glyph overflows a fixed-width
+//     node just as surely as budgeting a Latin letter as two undersizes one.
 
-/**
- * Length in code points rather than UTF-16 units.
- *
- * Every astral character (emoji, historic scripts) is two UTF-16 units but one
- * glyph, so `String.length` overstates its width — which matters both for
- * cutting a string and for estimating the ink it will occupy.
- */
-export function codePointLength(text: string): number {
-  let count = 0;
-  // String iteration yields code points, not UTF-16 units — and counting this
-  // way avoids materializing an array for what is usually a short label.
-  for (let i = 0; i < text.length; i += 1) {
-    const code = text.charCodeAt(i);
-    // Skip the low half of a well-formed surrogate pair.
-    if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
-      const next = text.charCodeAt(i + 1);
-      if (next >= 0xdc00 && next <= 0xdfff) i += 1;
-    }
-    count += 1;
-  }
-  return count;
+// Ranges that render at roughly double the advance width of a Latin glyph in
+// the fonts these labels are painted in. This is East-Asian-width-lite: the
+// wide/fullwidth blocks plus everything astral (emoji, historic scripts).
+function isWide(code: number): boolean {
+  return (
+    // Everything outside the BMP: emoji, historic and rare scripts.
+    code > 0xffff ||
+    (code >= 0x1100 && code <= 0x115f) || // Hangul Jamo
+    (code >= 0x2e80 && code <= 0x303e) || // CJK radicals … punctuation
+    (code >= 0x3041 && code <= 0x33ff) || // Kana, Bopomofo, CJK compat
+    (code >= 0x3400 && code <= 0x4dbf) || // CJK Ext A
+    (code >= 0x4e00 && code <= 0x9fff) || // CJK Unified
+    (code >= 0xa000 && code <= 0xa4cf) || // Yi
+    (code >= 0xac00 && code <= 0xd7a3) || // Hangul syllables
+    (code >= 0xf900 && code <= 0xfaff) || // CJK compat ideographs
+    (code >= 0xfe30 && code <= 0xfe6f) || // CJK compat forms
+    (code >= 0xff00 && code <= 0xff60) || // Fullwidth forms
+    (code >= 0xffe0 && code <= 0xffe6)
+  );
 }
 
 /**
- * Ellipsis-truncate to at most `max` characters (including the ellipsis).
+ * Approximate rendered width of `text` in Latin-character columns.
  *
- * The budget is counted in CODE POINTS, not UTF-16 units: slicing a raw string
- * at an arbitrary index can cut an astral character (emoji, historic scripts)
- * in half and emit a lone surrogate, which renders as a replacement glyph and
- * corrupts anything that later re-encodes the label. Counting code points also
- * makes the budget track rendered width more closely than UTF-16 units do.
+ * A deliberate ESTIMATE for sizing SVG nodes, not typography: real advance
+ * widths depend on the font and on kerning, and proportional Latin text varies
+ * per glyph anyway. What it buys is that the two failure modes at the extremes
+ * — counting an emoji as one column (text overflows its node) or as two
+ * UTF-16 units' worth of anything else — stop being systematic.
+ */
+export function displayColumns(text: string): number {
+  let columns = 0;
+  for (const char of text) {
+    columns += isWide(char.codePointAt(0) ?? 0) ? 2 : 1;
+  }
+  return columns;
+}
+
+/**
+ * Ellipsis-truncate `text` to at most `max` display columns, ellipsis included.
  *
- * Combining marks and ZWJ sequences can still be split — a full grapheme
- * segmentation would be the fix, and is deliberately not taken on here: the
- * failure mode is a dropped accent or a de-joined emoji, not the malformed
- * string a surrogate split produces.
+ * The budget is in columns (see `displayColumns`) while the cut lands on a code
+ * point boundary: slicing raw UTF-16 could bisect an astral character and emit
+ * a lone surrogate, which renders as a replacement glyph and corrupts anything
+ * that later re-encodes the label.
+ *
+ * For plain Latin text — every real subject label and nearly every server name
+ * — columns and characters coincide, so this behaves exactly as a simple
+ * character truncation would.
+ *
+ * Combining marks and ZWJ sequences can still be split; full grapheme
+ * segmentation would be the fix and is deliberately not taken on here, because
+ * the failure mode is a dropped accent or a de-joined emoji rather than the
+ * malformed string a surrogate split produces.
  */
 export function truncateLabel(text: string, max: number): string {
-  if (codePointLength(text) <= max) return text;
-  const points = Array.from(text);
-  return `${points
-    .slice(0, Math.max(0, max - 1))
-    .join("")
-    .trimEnd()}…`;
+  if (displayColumns(text) <= max) return text;
+
+  // The ellipsis itself costs one column.
+  const budget = Math.max(0, max - 1);
+  let columns = 0;
+  let out = "";
+  for (const char of text) {
+    const width = isWide(char.codePointAt(0) ?? 0) ? 2 : 1;
+    if (columns + width > budget) break;
+    columns += width;
+    out += char;
+  }
+  return `${out.trimEnd()}…`;
 }

--- a/src/lib/truncate.ts
+++ b/src/lib/truncate.ts
@@ -1,0 +1,30 @@
+// Display truncation, shared by every surface that renders untrusted
+// third-party text in a bounded container (map nodes, server badges).
+//
+// It lives in its own module rather than alongside its first caller because
+// both the map geometry and the server-attribution join need it, and those two
+// now depend on each other — a shared primitive here is what keeps that
+// dependency acyclic.
+
+/**
+ * Ellipsis-truncate to at most `max` characters (including the ellipsis).
+ *
+ * The budget is counted in CODE POINTS, not UTF-16 units: slicing a raw string
+ * at an arbitrary index can cut an astral character (emoji, historic scripts)
+ * in half and emit a lone surrogate, which renders as a replacement glyph and
+ * corrupts anything that later re-encodes the label. Counting code points also
+ * makes the budget track rendered width more closely than UTF-16 units do.
+ *
+ * Combining marks and ZWJ sequences can still be split — a full grapheme
+ * segmentation would be the fix, and is deliberately not taken on here: the
+ * failure mode is a dropped accent or a de-joined emoji, not the malformed
+ * string a surrogate split produces.
+ */
+export function truncateLabel(text: string, max: number): string {
+  const points = Array.from(text);
+  if (points.length <= max) return text;
+  return `${points
+    .slice(0, Math.max(0, max - 1))
+    .join("")
+    .trimEnd()}…`;
+}

--- a/src/lib/truncate.ts
+++ b/src/lib/truncate.ts
@@ -1,10 +1,33 @@
-// Display truncation, shared by every surface that renders untrusted
-// third-party text in a bounded container (map nodes, server badges).
+// Display truncation for SVG text, where the glyphs are painted at computed
+// coordinates and CSS `text-overflow` cannot help. DOM surfaces bound their
+// text with CSS instead, so they keep the full string as their text node (and
+// therefore as their accessible name) — see lib/resource-servers.
 //
-// It lives in its own module rather than alongside its first caller because
-// both the map geometry and the server-attribution join need it, and those two
-// now depend on each other — a shared primitive here is what keeps that
-// dependency acyclic.
+// Measuring and cutting must agree on what a "character" is, so both live here
+// and both count code points.
+
+/**
+ * Length in code points rather than UTF-16 units.
+ *
+ * Every astral character (emoji, historic scripts) is two UTF-16 units but one
+ * glyph, so `String.length` overstates its width — which matters both for
+ * cutting a string and for estimating the ink it will occupy.
+ */
+export function codePointLength(text: string): number {
+  let count = 0;
+  // String iteration yields code points, not UTF-16 units — and counting this
+  // way avoids materializing an array for what is usually a short label.
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    // Skip the low half of a well-formed surrogate pair.
+    if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
+      const next = text.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) i += 1;
+    }
+    count += 1;
+  }
+  return count;
+}
 
 /**
  * Ellipsis-truncate to at most `max` characters (including the ellipsis).
@@ -21,8 +44,8 @@
  * string a surrogate split produces.
  */
 export function truncateLabel(text: string, max: number): string {
+  if (codePointLength(text) <= max) return text;
   const points = Array.from(text);
-  if (points.length <= max) return text;
   return `${points
     .slice(0, Math.max(0, max - 1))
     .join("")

--- a/tests/resource-map-layout.test.ts
+++ b/tests/resource-map-layout.test.ts
@@ -6,8 +6,8 @@ import {
   SERVER_CAPTION_MAX_CHARS,
   buildResourceMapLayout,
   serverCaption,
-  truncateLabel,
 } from "../src/lib/resource-map-layout";
+import { truncateLabel } from "../src/lib/truncate";
 import type {
   AggregatedResourcesResponse,
   ResourceItem,
@@ -51,6 +51,27 @@ describe("truncateLabel", () => {
     // Slicing "abcd efgh" at 6 chars lands on the space — "abcd …" would
     // read as a typo.
     expect(truncateLabel("abcd efgh", 6)).toBe("abcd…");
+  });
+
+  it("never splits an astral character into a lone surrogate", () => {
+    // Budget is counted in code points, not UTF-16 units: slicing the raw
+    // string would cut a 2-unit emoji in half and emit an unpaired surrogate.
+    const emoji = "🌍".repeat(20);
+    const out = truncateLabel(emoji, 28);
+
+    expect(out).toBe(emoji);
+    for (const unit of out) {
+      const code = unit.codePointAt(0) ?? 0;
+      expect(code >= 0xd800 && code <= 0xdfff).toBe(false);
+    }
+  });
+
+  it("counts an astral label in code points when it does exceed the budget", () => {
+    const out = truncateLabel("🌍".repeat(20), 10);
+
+    expect(Array.from(out)).toHaveLength(10);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.startsWith("🌍🌍")).toBe(true);
   });
 });
 
@@ -287,5 +308,47 @@ describe("org node label", () => {
     expect(layout.orgName).toBe(org);
     expect(layout.orgDisplayName).toHaveLength(ORG_NAME_MAX_CHARS);
     expect(layout.orgDisplayName.endsWith("…")).toBe(true);
+  });
+});
+
+describe("buildResourceMapLayout server attribution", () => {
+  // The map used to read `server.serverName` raw. It now goes through the same
+  // buildServerNameMap/resolveServerName join as the Resources page and the
+  // priority panel, so all three surfaces name a server identically.
+  function named(serverId: string, serverName: string): ResourceServerReport {
+    return { serverId, serverName, status: "ok" };
+  }
+
+  it("falls back to the server id when the report names the server blank", () => {
+    const layout = buildResourceMapLayout(response([named("aquifer", "   ")]));
+
+    expect(layout.servers[0]!.serverName).toBe("aquifer");
+    expect(layout.servers[0]!.displayName).toBe("aquifer");
+  });
+
+  it("collapses control characters before they reach the sr-only tree", () => {
+    // serverName is untrusted third-party text and lands in an SVG <title> and
+    // the screen-reader list; it has to be one display line.
+    const layout = buildResourceMapLayout(
+      response([named("th", "Translation\nHelps\tMCP")])
+    );
+
+    expect(layout.servers[0]!.serverName).toBe("Translation Helps MCP");
+  });
+
+  it("keeps a well-formed name untouched", () => {
+    const layout = buildResourceMapLayout(response([named("th", "Aquifer")]));
+
+    expect(layout.servers[0]!.serverName).toBe("Aquifer");
+    expect(layout.servers[0]!.displayName).toBe("Aquifer");
+  });
+
+  it("truncates a long name for the node while keeping the full one", () => {
+    const long = "The Exceedingly Verbose Translation Helps MCP Server";
+    const layout = buildResourceMapLayout(response([named("th", long)]));
+
+    expect(layout.servers[0]!.serverName).toBe(long);
+    expect(layout.servers[0]!.displayName.endsWith("…")).toBe(true);
+    expect(layout.servers[0]!.displayName.length).toBeLessThan(long.length);
   });
 });

--- a/tests/resource-map-layout.test.ts
+++ b/tests/resource-map-layout.test.ts
@@ -7,7 +7,7 @@ import {
   buildResourceMapLayout,
   serverCaption,
 } from "../src/lib/resource-map-layout";
-import { truncateLabel } from "../src/lib/truncate";
+import { codePointLength, truncateLabel } from "../src/lib/truncate";
 import type {
   AggregatedResourcesResponse,
   ResourceItem,
@@ -308,6 +308,20 @@ describe("org node label", () => {
     expect(layout.orgName).toBe(org);
     expect(layout.orgDisplayName).toHaveLength(ORG_NAME_MAX_CHARS);
     expect(layout.orgDisplayName.endsWith("…")).toBe(true);
+  });
+});
+
+describe("codePointLength", () => {
+  it("counts astral characters once, unlike String.length", () => {
+    expect(codePointLength("🌍🌍🌍")).toBe(3);
+    expect("🌍🌍🌍".length).toBe(6);
+  });
+
+  it("matches String.length for plain BMP text", () => {
+    expect(codePointLength("Bible Translations")).toBe(
+      "Bible Translations".length
+    );
+    expect(codePointLength("")).toBe(0);
   });
 });
 

--- a/tests/resource-map-layout.test.ts
+++ b/tests/resource-map-layout.test.ts
@@ -4,10 +4,11 @@ import {
   MAP,
   ORG_NAME_MAX_CHARS,
   SERVER_CAPTION_MAX_CHARS,
+  SERVER_NAME_MAX_CHARS,
   buildResourceMapLayout,
   serverCaption,
 } from "../src/lib/resource-map-layout";
-import { codePointLength, truncateLabel } from "../src/lib/truncate";
+import { displayColumns, truncateLabel } from "../src/lib/truncate";
 import type {
   AggregatedResourcesResponse,
   ResourceItem,
@@ -53,25 +54,59 @@ describe("truncateLabel", () => {
     expect(truncateLabel("abcd efgh", 6)).toBe("abcd…");
   });
 
-  it("never splits an astral character into a lone surrogate", () => {
-    // Budget is counted in code points, not UTF-16 units: slicing the raw
-    // string would cut a 2-unit emoji in half and emit an unpaired surrogate.
+  it("truncates a wide label that fits on a code-point count but not on ink", () => {
+    // 20 emoji is 20 code points but ~40 Latin columns of ink, so a 28-column
+    // node cannot hold it. Budgeting by code point would pass it through
+    // unchanged and let the text overflow its fixed-width node.
     const emoji = "🌍".repeat(20);
     const out = truncateLabel(emoji, 28);
 
-    expect(out).toBe(emoji);
-    for (const unit of out) {
-      const code = unit.codePointAt(0) ?? 0;
+    expect(out).not.toBe(emoji);
+    expect(out.endsWith("…")).toBe(true);
+    expect(displayColumns(out)).toBeLessThanOrEqual(28);
+    // Still surrogate-safe: the cut lands on a code point boundary.
+    for (const char of out) {
+      const code = char.codePointAt(0) ?? 0;
       expect(code >= 0xd800 && code <= 0xdfff).toBe(false);
     }
   });
 
-  it("counts an astral label in code points when it does exceed the budget", () => {
+  it("spends two columns per wide glyph when cutting", () => {
     const out = truncateLabel("🌍".repeat(20), 10);
 
-    expect(Array.from(out)).toHaveLength(10);
-    expect(out.endsWith("…")).toBe(true);
-    expect(out.startsWith("🌍🌍")).toBe(true);
+    // 9 columns of budget after the ellipsis = 4 emoji (8 columns); a 5th
+    // would overrun.
+    expect(Array.from(out)).toHaveLength(5);
+    expect(out).toBe("🌍🌍🌍🌍…");
+    expect(displayColumns(out)).toBeLessThanOrEqual(10);
+  });
+
+  it("is byte-for-byte unchanged for plain Latin labels", () => {
+    // Columns and characters coincide for narrow text, so the column budget
+    // must not perturb the overwhelmingly common case.
+    expect(truncateLabel("a very long resource subject label", 12)).toBe(
+      "a very long…"
+    );
+    expect(truncateLabel("abcd efgh", 6)).toBe("abcd…");
+    expect(truncateLabel("exactly-10", 10)).toBe("exactly-10");
+  });
+});
+
+describe("displayColumns", () => {
+  it("counts an astral glyph as two Latin columns", () => {
+    expect(displayColumns("🌍🌍🌍")).toBe(6);
+  });
+
+  it("counts CJK and fullwidth text as two columns per glyph", () => {
+    expect(displayColumns("漢字")).toBe(4);
+    expect(displayColumns("ＡＢ")).toBe(4);
+  });
+
+  it("matches String.length for plain BMP text", () => {
+    expect(displayColumns("Bible Translations")).toBe(
+      "Bible Translations".length
+    );
+    expect(displayColumns("")).toBe(0);
   });
 });
 
@@ -311,17 +346,26 @@ describe("org node label", () => {
   });
 });
 
-describe("codePointLength", () => {
-  it("counts astral characters once, unlike String.length", () => {
-    expect(codePointLength("🌍🌍🌍")).toBe(3);
-    expect("🌍🌍🌍".length).toBe(6);
+describe("leaf width for wide labels", () => {
+  function leafWidthFor(slug: string): number {
+    const layout = buildResourceMapLayout(
+      response([server("a")], { [slug]: [item("a", slug, "x")] })
+    );
+    return layout.servers[0]!.leaves[0]!.width;
+  }
+
+  it("sizes a wide label by its ink, not by its code-point count", () => {
+    // 5 emoji ≈ 10 Latin columns, so the node must be as wide as a 10-character
+    // Latin label — which is exactly what the pre-round-1 UTF-16 estimate gave.
+    // Code-point counting would have sized this like a 5-character label.
+    expect(leafWidthFor("🌍🌍🌍🌍🌍")).toBe(leafWidthFor("abcdefghij"));
+    expect(leafWidthFor("🌍🌍🌍🌍🌍")).toBeGreaterThan(leafWidthFor("abcde"));
   });
 
-  it("matches String.length for plain BMP text", () => {
-    expect(codePointLength("Bible Translations")).toBe(
-      "Bible Translations".length
-    );
-    expect(codePointLength("")).toBe(0);
+  it("leaves narrow labels at their established width", () => {
+    // Pin the common case in absolute terms: a 5-character Latin label is
+    // measured exactly as it was before the column budget landed.
+    expect(leafWidthFor("abcde")).toBe(71);
   });
 });
 
@@ -355,6 +399,21 @@ describe("buildResourceMapLayout server attribution", () => {
 
     expect(layout.servers[0]!.serverName).toBe("Aquifer");
     expect(layout.servers[0]!.displayName).toBe("Aquifer");
+  });
+
+  it("truncates a wide server name a code-point budget would have passed", () => {
+    // The reported symptom: 20 emoji is 20 code points, under the 24 budget,
+    // but ~40 columns of ink — it would have overflowed the fixed-width node.
+    const wide = "🌍".repeat(20);
+    const layout = buildResourceMapLayout(response([named("emoji", wide)]));
+    const node = layout.servers[0]!;
+
+    expect(node.serverName).toBe(wide);
+    expect(node.displayName).not.toBe(wide);
+    expect(node.displayName.endsWith("…")).toBe(true);
+    expect(displayColumns(node.displayName)).toBeLessThanOrEqual(
+      SERVER_NAME_MAX_CHARS
+    );
   });
 
   it("truncates a long name for the node while keeping the full one", () => {

--- a/tests/resource-map-layout.test.ts
+++ b/tests/resource-map-layout.test.ts
@@ -401,6 +401,28 @@ describe("buildResourceMapLayout server attribution", () => {
     expect(layout.servers[0]!.displayName).toBe("Aquifer");
   });
 
+  it("collapses an untrusted error string, which lands in the sr-only tree raw", () => {
+    // `error` is the same untrusted class as serverName and is read straight
+    // into the screen-reader list and the node <title>.
+    const layout = buildResourceMapLayout(
+      response([
+        {
+          serverId: "aquifer",
+          serverName: "Aquifer",
+          status: "error",
+          error: "upstream 502\n\n  at handler\ttimeout",
+        },
+      ])
+    );
+
+    expect(layout.servers[0]!.error).toBe("upstream 502 at handler timeout");
+  });
+
+  it("leaves a missing error undefined rather than turning it into an empty string", () => {
+    const layout = buildResourceMapLayout(response([named("a", "A")]));
+    expect(layout.servers[0]!.error).toBeUndefined();
+  });
+
   it("truncates a wide server name a code-point budget would have passed", () => {
     // The reported symptom: 20 emoji is 20 code points, under the 24 budget,
     // but ~40 columns of ink — it would have overflowed the fixed-width node.

--- a/tests/resource-priority.test.ts
+++ b/tests/resource-priority.test.ts
@@ -15,6 +15,10 @@ import {
   splicePriorityBlock,
 } from "../src/lib/resource-priority";
 import type { PriorityEntry } from "../src/lib/resource-priority";
+import {
+  buildServerNameMap,
+  resolveServerName,
+} from "../src/lib/resource-servers";
 import type {
   AggregatedResourcesResponse,
   ResourceItem,
@@ -27,7 +31,14 @@ function entry(
   serverName: string,
   subjectLabelText = "Bible Translations"
 ): PriorityEntry {
-  return { id, label, serverName, subjectLabelText };
+  // Ids are `serverId:name`, so the id's prefix is the natural serverId here.
+  return {
+    id,
+    label,
+    serverId: id.split(":")[0] ?? "",
+    serverName,
+    subjectLabelText,
+  };
 }
 
 function byId(entries: PriorityEntry[]): Map<string, PriorityEntry> {
@@ -544,6 +555,19 @@ describe("buildPriorityEntries", () => {
     expect(entries[0]!.serverName).toBe("orphan");
   });
 
+  it("carries serverId so the panel can run its own display join", () => {
+    // Without this the panel would have to split the `serverId:name` id, which
+    // misparses any resource name containing a colon.
+    const entries = buildPriorityEntries(
+      response([server("aquifer", "Aquifer")], {
+        bible: [item("aquifer", "Notes:2024", "bible")],
+      })
+    );
+
+    expect(entries[0]!.serverId).toBe("aquifer");
+    expect(entries[0]!.id).toBe("aquifer:Notes:2024");
+  });
+
   it("passes a blank server name through verbatim rather than substituting the id", () => {
     // Emission is FROZEN: this join is raw on purpose, and its `??` fallback
     // only catches a MISSING server, not a blank name. The display resolution
@@ -647,6 +671,43 @@ describe("buildPriorityEntries", () => {
     expect(entries.map((e) => e.subjectLabelText)).toEqual([
       "Bible Translations",
     ]);
+  });
+});
+
+// The panel's rows are the highest-traffic consumer of server attribution, and
+// they must show what every other surface shows WITHOUT perturbing the bytes
+// the same entries emit. This pins both halves of that split at once.
+describe("panel row display join vs emission", () => {
+  const data = response(
+    [server("th", "Translation\tHelps"), server("aquifer", "   ")],
+    {
+      bible: [item("th", "en_ult", "bible"), item("aquifer", "NIV", "bible")],
+    }
+  );
+
+  it("renders collapsed and id-fallback attribution in the row path", () => {
+    // Exactly what RowIdentity composes.
+    const entries = buildPriorityEntries(data);
+    const names = buildServerNameMap(data.servers);
+
+    expect(resolveServerName(entries[0]!.serverId, names)).toBe(
+      "Translation Helps"
+    );
+    expect(resolveServerName(entries[1]!.serverId, names)).toBe("aquifer");
+  });
+
+  it("keeps the raw form on the entries and in the emitted block", () => {
+    const entries = buildPriorityEntries(data);
+
+    expect(entries[0]!.serverName).toBe("Translation\tHelps");
+    expect(entries[1]!.serverName).toBe("   ");
+
+    const block = generatePriorityBlock(
+      entries.map((e) => e.id),
+      byId(entries)
+    );
+    expect(block).toContain("Translation\tHelps");
+    expect(block).toContain("2. NIV — (Bible Translations)");
   });
 });
 

--- a/tests/resource-priority.test.ts
+++ b/tests/resource-priority.test.ts
@@ -544,34 +544,50 @@ describe("buildPriorityEntries", () => {
     expect(entries[0]!.serverName).toBe("orphan");
   });
 
-  it("falls back to the server id when the report names the server blank", () => {
-    // Shared with the Resources page via buildServerNameMap: an empty
-    // serverName is not an improvement on the id, so attribution degrades to
-    // the id rather than to nothing.
+  it("passes a blank server name through verbatim rather than substituting the id", () => {
+    // Emission is FROZEN: this join is raw on purpose, and its `??` fallback
+    // only catches a MISSING server, not a blank name. The display resolution
+    // in lib/resource-servers would substitute the id here — deliberately not
+    // shared, because changing these bytes would enable Apply (a whole-document
+    // PUT) on existing documents with no ranking intent behind it.
     const entries = buildPriorityEntries(
       response([server("aquifer", "  ")], {
         bible: [item("aquifer", "x", "bible")],
       })
     );
-    expect(entries[0]!.serverName).toBe("aquifer");
+    expect(entries[0]!.serverName).toBe("  ");
   });
 
-  it("collapses an untrusted multi-line server name before it reaches the prompt", () => {
+  it("relies on sanitizePromptText, not the entry join, to keep a name on one line", () => {
+    // The raw name reaches the entry untouched; the emission hardening happens
+    // where the block is generated, so a newline can never break the ranked
+    // list even though nothing collapsed it upstream.
     const entries = buildPriorityEntries(
       response([server("aquifer", "Aquifer\nMCP")], {
         bible: [item("aquifer", "x", "bible")],
       })
     );
-    expect(entries[0]!.serverName).toBe("Aquifer MCP");
+    expect(entries[0]!.serverName).toBe("Aquifer\nMCP");
+
+    const block = generatePriorityBlock(
+      entries.map((e) => e.id),
+      byId(entries)
+    );
+    expect(block).toContain("Aquifer MCP");
+    expect(block).not.toContain("Aquifer\nMCP");
+    // One ranked line, not two — the newline did not smuggle in a list entry.
+    expect(block.split("\n").filter((l) => /^\d+\.\s/.test(l))).toHaveLength(1);
   });
 
-  it("reaches a byte-identical steady state after one apply", () => {
-    // Collapsing untrusted server names DOES change emitted bytes relative to
-    // the pre-collapse block, so a document written before it opens with Apply
-    // enabled once. What must hold from then on is idempotence: generate →
-    // splice → parse → regenerate has to return the same bytes, or the panel
-    // would offer a spurious "apply" forever and the block would churn on
-    // every open. This pins that steady state.
+  it("regenerates a stored block byte-identically with no apply in between", () => {
+    // The anti-regression guard for the emission freeze. Apply PUTs the whole
+    // mode document, so the regenerated block MUST equal the stored one on a
+    // plain open — otherwise the panel offers a save nobody asked for, which
+    // would also persist any unrelated unsaved draft edits.
+    //
+    // The fixture is chosen to be exactly what display hardening would have
+    // rewritten: a tab-bearing name and a blank name. Route either through the
+    // display resolution and this test fails.
     const live = buildPriorityEntries(
       response(
         [
@@ -591,25 +607,34 @@ describe("buildPriorityEntries", () => {
     const lookup = byId(live);
     const ids = live.map((e) => e.id);
 
-    const first = generatePriorityBlock(ids, lookup);
+    // The block as a v1.11.0 portal wrote it, sitting in a saved document.
+    const stored = generatePriorityBlock(ids, lookup);
     const document = splicePriorityBlock(
       "## Tool Guidance\n\nUse the tools well.\n",
-      first
+      stored
     );
 
-    // Round-trip: read the order back out and regenerate from live data.
+    // Opening the panel: read the order back and regenerate from live data.
     const reparsed = parsePriorityOrder(document);
     expect(reparsed).toEqual(ids);
 
-    const second = generatePriorityBlock(
+    const regenerated = generatePriorityBlock(
       reparsed as string[],
       lookup,
       parsePriorityDescriptions(document)
     );
-    expect(second).toBe(first);
+    expect(regenerated).toBe(stored);
 
-    // And splicing the regenerated block is a no-op on the document.
-    expect(splicePriorityBlock(document, second)).toBe(document);
+    // Which is what makes `unchanged` true in the panel, keeping Apply
+    // disabled: splicing the regenerated block back is a no-op.
+    expect(splicePriorityBlock(document, regenerated)).toBe(document);
+
+    // The raw names survived into the emitted text: the tab is still a tab
+    // (sanitizePromptText collapses newlines, not tabs) and the blank name
+    // still emits empty attribution rather than the server id. Route either
+    // through the display resolution and both of these flip.
+    expect(stored).toContain("Translation\tHelps");
+    expect(stored).toContain("2. NIV — (Bible Translations)");
   });
 
   it("keeps the first occurrence when an id surfaces under two subjects", () => {

--- a/tests/resource-priority.test.ts
+++ b/tests/resource-priority.test.ts
@@ -544,6 +544,27 @@ describe("buildPriorityEntries", () => {
     expect(entries[0]!.serverName).toBe("orphan");
   });
 
+  it("falls back to the server id when the report names the server blank", () => {
+    // Shared with the Resources page via buildServerNameMap: an empty
+    // serverName is not an improvement on the id, so attribution degrades to
+    // the id rather than to nothing.
+    const entries = buildPriorityEntries(
+      response([server("aquifer", "  ")], {
+        bible: [item("aquifer", "x", "bible")],
+      })
+    );
+    expect(entries[0]!.serverName).toBe("aquifer");
+  });
+
+  it("collapses an untrusted multi-line server name before it reaches the prompt", () => {
+    const entries = buildPriorityEntries(
+      response([server("aquifer", "Aquifer\nMCP")], {
+        bible: [item("aquifer", "x", "bible")],
+      })
+    );
+    expect(entries[0]!.serverName).toBe("Aquifer MCP");
+  });
+
   it("keeps the first occurrence when an id surfaces under two subjects", () => {
     const entries = buildPriorityEntries(
       response([server("a", "A")], {

--- a/tests/resource-priority.test.ts
+++ b/tests/resource-priority.test.ts
@@ -565,6 +565,53 @@ describe("buildPriorityEntries", () => {
     expect(entries[0]!.serverName).toBe("Aquifer MCP");
   });
 
+  it("reaches a byte-identical steady state after one apply", () => {
+    // Collapsing untrusted server names DOES change emitted bytes relative to
+    // the pre-collapse block, so a document written before it opens with Apply
+    // enabled once. What must hold from then on is idempotence: generate →
+    // splice → parse → regenerate has to return the same bytes, or the panel
+    // would offer a spurious "apply" forever and the block would churn on
+    // every open. This pins that steady state.
+    const live = buildPriorityEntries(
+      response(
+        [
+          server("th", "Translation\tHelps"),
+          server("aquifer", "  "),
+          server("fia", "FIA"),
+        ],
+        {
+          bible: [
+            item("th", "en_ult", "bible"),
+            item("aquifer", "NIV", "bible"),
+          ],
+          "study-notes": [item("fia", "Notes", "study-notes")],
+        }
+      )
+    );
+    const lookup = byId(live);
+    const ids = live.map((e) => e.id);
+
+    const first = generatePriorityBlock(ids, lookup);
+    const document = splicePriorityBlock(
+      "## Tool Guidance\n\nUse the tools well.\n",
+      first
+    );
+
+    // Round-trip: read the order back out and regenerate from live data.
+    const reparsed = parsePriorityOrder(document);
+    expect(reparsed).toEqual(ids);
+
+    const second = generatePriorityBlock(
+      reparsed as string[],
+      lookup,
+      parsePriorityDescriptions(document)
+    );
+    expect(second).toBe(first);
+
+    // And splicing the regenerated block is a no-op on the document.
+    expect(splicePriorityBlock(document, second)).toBe(document);
+  });
+
   it("keeps the first occurrence when an id surfaces under two subjects", () => {
     const entries = buildPriorityEntries(
       response([server("a", "A")], {

--- a/tests/resource-servers.test.ts
+++ b/tests/resource-servers.test.ts
@@ -90,16 +90,23 @@ describe("resolveServerLabel", () => {
     server("th", "Translation Helps"),
   ]);
 
-  it("renders the name and keeps the machine id in the tooltip", () => {
+  it("renders the name and exposes the machine id separately", () => {
     const label = resolveServerLabel("th", names);
 
     expect(label.full).toBe("Translation Helps");
+    // Surfaced as its own field so callers can put it in an sr-only span:
+    // aria-label on a generic element is not reliably exposed (HTML-AAM).
+    expect(label.machineId).toBe("th");
     expect(label.title).toBe("Translation Helps (th)");
   });
 
-  it("does not repeat the id in the tooltip when it equals the name", () => {
+  it("reports no machine id when it would merely repeat the name", () => {
     const idOnly = buildServerNameMap([]);
-    expect(resolveServerLabel("aquifer", idOnly).title).toBe("aquifer");
+    const label = resolveServerLabel("aquifer", idOnly);
+
+    expect(label.full).toBe("aquifer");
+    expect(label.machineId).toBeNull();
+    expect(label.title).toBe("aquifer");
   });
 
   it("never truncates — DOM callers bound the width with CSS", () => {

--- a/tests/resource-servers.test.ts
+++ b/tests/resource-servers.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  RESOURCE_SERVER_LABEL_MAX_CHARS,
   buildServerNameMap,
   resolveServerLabel,
   resolveServerName,
@@ -94,7 +93,6 @@ describe("resolveServerLabel", () => {
   it("renders the name and keeps the machine id in the tooltip", () => {
     const label = resolveServerLabel("th", names);
 
-    expect(label.display).toBe("Translation Helps");
     expect(label.full).toBe("Translation Helps");
     expect(label.title).toBe("Translation Helps (th)");
   });
@@ -104,40 +102,22 @@ describe("resolveServerLabel", () => {
     expect(resolveServerLabel("aquifer", idOnly).title).toBe("aquifer");
   });
 
-  it("bounds an unbounded untrusted name to the character budget", () => {
+  it("never truncates — DOM callers bound the width with CSS", () => {
+    // Cutting the string would cut the accessible name with it, since the text
+    // node IS the accessible name. Only the SVG map, where CSS cannot reach,
+    // truncates (see lib/truncate).
     const long = "A".repeat(400);
     const label = resolveServerLabel(
       "bloated",
       buildServerNameMap([server("bloated", long)])
     );
 
-    expect(label.display.length).toBeLessThanOrEqual(
-      RESOURCE_SERVER_LABEL_MAX_CHARS
-    );
-    expect(label.display.endsWith("…")).toBe(true);
-    // The full name still reaches the tooltip — truncation is display-only.
     expect(label.full).toBe(long);
+    expect(label.full).not.toContain("…");
     expect(label.title).toContain(long);
   });
 
-  it("honors an explicit budget", () => {
-    const label = resolveServerLabel("th", names, 8);
-
-    expect(label.display).toBe("Transla…");
-    expect(label.display.length).toBe(8);
-  });
-
-  it("leaves a name exactly at the budget untruncated", () => {
-    const exact = "B".repeat(RESOURCE_SERVER_LABEL_MAX_CHARS);
-    const label = resolveServerLabel(
-      "exact",
-      buildServerNameMap([server("exact", exact)])
-    );
-
-    expect(label.display).toBe(exact);
-  });
-
-  it("bounds a name that is only long because of collapsed whitespace", () => {
+  it("still collapses a name that is long only because of whitespace", () => {
     const label = resolveServerLabel(
       "spacey",
       buildServerNameMap([server("spacey", `Aquifer${" ".repeat(200)}MCP`)])

--- a/tests/resource-servers.test.ts
+++ b/tests/resource-servers.test.ts
@@ -96,7 +96,6 @@ describe("resolveServerLabel", () => {
 
     expect(label.display).toBe("Translation Helps");
     expect(label.full).toBe("Translation Helps");
-    expect(label.truncated).toBe(false);
     expect(label.title).toBe("Translation Helps (th)");
   });
 
@@ -112,7 +111,6 @@ describe("resolveServerLabel", () => {
       buildServerNameMap([server("bloated", long)])
     );
 
-    expect(label.truncated).toBe(true);
     expect(label.display.length).toBeLessThanOrEqual(
       RESOURCE_SERVER_LABEL_MAX_CHARS
     );
@@ -127,7 +125,6 @@ describe("resolveServerLabel", () => {
 
     expect(label.display).toBe("Transla…");
     expect(label.display.length).toBe(8);
-    expect(label.truncated).toBe(true);
   });
 
   it("leaves a name exactly at the budget untruncated", () => {
@@ -138,7 +135,6 @@ describe("resolveServerLabel", () => {
     );
 
     expect(label.display).toBe(exact);
-    expect(label.truncated).toBe(false);
   });
 
   it("bounds a name that is only long because of collapsed whitespace", () => {
@@ -148,6 +144,5 @@ describe("resolveServerLabel", () => {
     );
 
     expect(label.full).toBe("Aquifer MCP");
-    expect(label.truncated).toBe(false);
   });
 });

--- a/tests/resource-servers.test.ts
+++ b/tests/resource-servers.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RESOURCE_SERVER_LABEL_MAX_CHARS,
+  buildServerNameMap,
+  resolveServerLabel,
+  resolveServerName,
+} from "../src/lib/resource-servers";
+import type { ResourceServerReport } from "../src/types/resources";
+
+function server(
+  serverId: string,
+  serverName: string,
+  status: ResourceServerReport["status"] = "ok"
+): ResourceServerReport {
+  return { serverId, serverName, status };
+}
+
+describe("buildServerNameMap", () => {
+  it("indexes the servers[] status block by id", () => {
+    const names = buildServerNameMap([
+      server("translation-helps", "Translation Helps"),
+      server("aquifer", "Aquifer"),
+    ]);
+
+    expect(names.get("translation-helps")).toBe("Translation Helps");
+    expect(names.get("aquifer")).toBe("Aquifer");
+    expect(names.size).toBe(2);
+  });
+
+  it("indexes degraded servers too — attribution outlives a listing failure", () => {
+    // A resource cached from an earlier aggregation still needs a name even
+    // when its server is currently erroring or can't list.
+    const names = buildServerNameMap([
+      server("fia", "FIA", "unsupported"),
+      server("aquifer", "Aquifer", "error"),
+    ]);
+
+    expect(names.get("fia")).toBe("FIA");
+    expect(names.get("aquifer")).toBe("Aquifer");
+  });
+
+  it("omits blank and whitespace-only names rather than indexing an empty label", () => {
+    const names = buildServerNameMap([
+      server("blank", ""),
+      server("spaces", "   \t  "),
+    ]);
+
+    expect(names.has("blank")).toBe(false);
+    expect(names.has("spaces")).toBe(false);
+  });
+
+  it("collapses newlines, tabs and invisible characters in untrusted names", () => {
+    // serverName is third-party MCP output: it must render as one display line
+    // and must not smuggle invisible structure into a chip.
+    const names = buildServerNameMap([
+      server("multiline", "Translation\nHelps\r\n  MCP"),
+      server("zerowidth", "Aqui​fer‮"),
+    ]);
+
+    expect(names.get("multiline")).toBe("Translation Helps MCP");
+    expect(names.get("zerowidth")).toBe("Aqui fer");
+  });
+
+  it("returns an empty map for an empty status block", () => {
+    expect(buildServerNameMap([]).size).toBe(0);
+  });
+});
+
+describe("resolveServerName", () => {
+  const names = buildServerNameMap([server("aquifer", "Aquifer")]);
+
+  it("prefers the human-readable name", () => {
+    expect(resolveServerName("aquifer", names)).toBe("Aquifer");
+  });
+
+  it("falls back to the machine id for a server missing from servers[]", () => {
+    // Off-contract but observable: a server can list resources and then drop
+    // out of a later aggregation. The raw id beats showing no attribution.
+    expect(resolveServerName("ubs-handbooks", names)).toBe("ubs-handbooks");
+  });
+
+  it("collapses an untrusted id used as the fallback", () => {
+    expect(resolveServerName("we\nird", names)).toBe("we ird");
+  });
+});
+
+describe("resolveServerLabel", () => {
+  const names = buildServerNameMap([
+    server("aquifer", "Aquifer"),
+    server("th", "Translation Helps"),
+  ]);
+
+  it("renders the name and keeps the machine id in the tooltip", () => {
+    const label = resolveServerLabel("th", names);
+
+    expect(label.display).toBe("Translation Helps");
+    expect(label.full).toBe("Translation Helps");
+    expect(label.truncated).toBe(false);
+    expect(label.title).toBe("Translation Helps (th)");
+  });
+
+  it("does not repeat the id in the tooltip when it equals the name", () => {
+    const idOnly = buildServerNameMap([]);
+    expect(resolveServerLabel("aquifer", idOnly).title).toBe("aquifer");
+  });
+
+  it("bounds an unbounded untrusted name to the character budget", () => {
+    const long = "A".repeat(400);
+    const label = resolveServerLabel(
+      "bloated",
+      buildServerNameMap([server("bloated", long)])
+    );
+
+    expect(label.truncated).toBe(true);
+    expect(label.display.length).toBeLessThanOrEqual(
+      RESOURCE_SERVER_LABEL_MAX_CHARS
+    );
+    expect(label.display.endsWith("…")).toBe(true);
+    // The full name still reaches the tooltip — truncation is display-only.
+    expect(label.full).toBe(long);
+    expect(label.title).toContain(long);
+  });
+
+  it("honors an explicit budget", () => {
+    const label = resolveServerLabel("th", names, 8);
+
+    expect(label.display).toBe("Transla…");
+    expect(label.display.length).toBe(8);
+    expect(label.truncated).toBe(true);
+  });
+
+  it("leaves a name exactly at the budget untruncated", () => {
+    const exact = "B".repeat(RESOURCE_SERVER_LABEL_MAX_CHARS);
+    const label = resolveServerLabel(
+      "exact",
+      buildServerNameMap([server("exact", exact)])
+    );
+
+    expect(label.display).toBe(exact);
+    expect(label.truncated).toBe(false);
+  });
+
+  it("bounds a name that is only long because of collapsed whitespace", () => {
+    const label = resolveServerLabel(
+      "spacey",
+      buildServerNameMap([server("spacey", `Aquifer${" ".repeat(200)}MCP`)])
+    );
+
+    expect(label.full).toBe("Aquifer MCP");
+    expect(label.truncated).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #230 (closed) and the #265/#268/#282 resources surface. No new panel features — this PR fixes an attribution inconsistency the tracker's stale "remaining scope" line was hiding.

## What the scout found

The tracker listed "per-resource server indicator + taxonomy grouping" as #230's remaining scope. **Both shipped in PR #265** (`resources.tsx` renders a per-row `serverId` badge and subject-grouped headings). What actually remained was a defect: the list page was the only one of three surfaces showing the machine id where the topology map and priority panel show the human name — the same server read as `translation-helps` in one view and `Translation Helps` in the other two. Naming a resource's source is a *join* (`serverName` lives once per server in `servers[]`, never on the resource item), and two of three surfaces each had their own copy of it.

## What's here

- **One shared join** — `src/lib/resource-servers.ts` (`buildServerNameMap` / `resolveServerName` / `resolveServerLabel`). All three surfaces route through it: list-page badges (per-row + per-subject header), the topology map layout (sr-only tree + SVG titles included), and the priority panel, plus the previously-raw `ServerChip` status row and the panel's degraded-server notice.
- **Untrusted-text hardening** on the display path (per the #277 marker-smuggling history): names collapse to a single display line on the way in — including `\p{Cc}`/`\p{Cf}`, so zero-width and bidi-override characters can't hide — and are character-bounded on the way out. Machine id stays discoverable via tooltip (`Name (id)`, parenthetical omitted when equal). No `dangerouslySetInnerHTML` anywhere on the path.
- **Blank-name fallback**: a server reporting an empty/whitespace `serverName` now shows its id everywhere (previously `?? ` let `""` win and some surfaces rendered nothing).
- `truncateLabel` moved to `src/lib/truncate.ts` (breaking an import cycle the convergence exposed) and now slices by **code point**, so astral characters can't be split into lone surrogates in any label — server names, org names, and map leaves alike.

## Honest behavior note for reviewers

The collapsing reaches **emitted mode-document text** for pathological names (tab, multi-space, NBSP, zero-width, soft-hyphen, blank): a priority block saved under v1.11.0 whose server names contain such characters will open with Apply enabled once, and the rewrite is idempotent thereafter. This is documented at the source and enforced by a new round-trip byte-identity test (generate → splice → parse → regenerate → byte-identical), rather than claimed in prose. The concurrent #281 PR introduces the same one-time upgrade for a different reason; if both land, the two drifts compound into a single rewrite — no additive user cost.

## Left open (deliberate, noted for the record)

- Machine id is tooltip-only on the list page now; ids remain visible in the mode document's `<!-- order: [...] -->` comment.
- Two servers sharing a display name render identical badges (disambiguation is hover-only).
- The per-subject badge strip carries longer text than the ids it replaced and can squeeze subject labels on narrow desktops.

## Verification

Adversarially verified by an independent reviewer before push; its three P2s (map not actually converged, two raw render sites, undocumented emitted-bytes drift) are fixed in the second commit. 726 tests passing (+23 over main): join semantics, degraded/absent servers, blank and control-character names, surrogate-safe truncation, tooltip composition, and the round-trip invariant. Lint zero warnings, typecheck, build clean.

Refs #230.
