### PR TITLE
chore: bump version 1.11.0 -> 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-admin-portal",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-admin-portal",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Release-time version bump that was missed before today's prod portal deploy. Prod is currently running the four functional PRs merged since v1.11.0 while still displaying **v1.11.0** in the login footer and user-menu chip (`__APP_VERSION__` is baked from `package.json` at build time).

Covered by this bump (all already merged and deployed):
- #286 org default language — Languages-page control (PR #288)
- #277 per-mode resource prioritization (PR #282)
- #281 outside-priority disclosure line (PR #290)
- #230 server-attribution join fix (PR #289)

## After merge
1. Tag `v1.12.0` on main
2. Redeploy prod portal so the displayed version matches the shipped code