### PR TITLE
fix(#293, #294): confirm language-create overwrite + harden untrusted resource text

### DIFF
--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -119,13 +119,6 @@ export function LanguagesPage() {
   const orgDefaultQuery = useOrgDefaultLanguage(contextOrg);
   const setOrgDefault = useSetOrgDefaultLanguage();
 
-  // Detail loaded for the CURRENT selection — not a stale row still in the
-  // cache mid-switch. Publish/Unpublish acts on the loaded document + label, so
-  // it must wait for this: clicked during an A→B load it would send A's draft
-  // and label into B (grok rd-3). Matches the editor pane, which is read-only
-  // until the detail arrives.
-  const detailReady = languageQuery.data?.name === selectedLanguage;
-
   // Local document draft (auto-save target).
   //
   // We track `lastSyncedDoc` separately from React Query's cache so that:
@@ -200,6 +193,14 @@ export function LanguagesPage() {
   const isDirty = draft !== lastSyncedDoc;
   const isSaving = saveLanguage.isPending;
   const hasSelection = selectedLanguage !== null && languageQuery.data;
+  // Local editor state is synced to the CURRENT selection. Gate Publish/Unpublish
+  // on this, not on `languageQuery.data?.name === selectedLanguage`: a cache HIT
+  // makes the query name match on the first render after a switch, before the
+  // sync effect above has loaded this language's document/label — so a Publish
+  // in that render would send the PREVIOUS language's draft and label into this
+  // one (codex rd-4 P1). `syncedNameRef` only advances alongside those state
+  // writes, so it re-renders correctly and can't be true with stale locals.
+  const detailReady = syncedNameRef.current === selectedLanguage;
 
   // Single save path — both auto-save and the manual Save button funnel
   // through here so the lastSyncedDoc bookkeeping stays consistent.

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -356,8 +356,18 @@ export function LanguagesPage() {
       // (Frank P2 on PR #106).
       const scaffold = scaffoldQuery.data;
       if (!scaffold) return;
-      saveLanguage.mutate(
-        {
+      // #293 grok F1: whether this is a fresh create or a re-scaffold of an
+      // existing language, the write lands a blank, unpublished document. If
+      // we're overwriting a DIFFERENT language while the current editor is
+      // dirty or mid-save, yanking the selection would leave the autosave
+      // effect about to PUT this row's draft into the new one — so hold the
+      // selection where it is in that case.
+      const stealsFocusFromDirty =
+        name !== selectedLanguage && (isDirty || isSaving);
+      // Returned so the selector's overwrite confirmation can await the write
+      // and render failures inline (grok F2 / #102).
+      return saveLanguage
+        .mutateAsync({
           name,
           org: contextOrg,
           body: {
@@ -365,18 +375,36 @@ export function LanguagesPage() {
             document: scaffold.document,
             published: false,
           },
-        },
-        {
-          onSuccess: () => {
-            // #249 — no creator auto-grant to mirror any more: creation
-            // is an ordinary admin write under the worker's admin trump,
-            // and admins read every row through the "*" short-circuit.
+        })
+        .then(() => {
+          if (name === selectedLanguage) {
+            // Replacing the language being VIEWED: the selection doesn't
+            // change, so the sync effect won't re-pull. Reset the editor to
+            // the blank scaffold the server now holds — otherwise the next
+            // keystroke autosaves the OLD document back and republishes it,
+            // undoing the replace (grok F1, Failure A). Leave syncedNameRef
+            // alone so a refetch of stale cache can't reload the old doc.
+            setDraft(scaffold.document);
+            setLastSyncedDoc(scaffold.document);
+            setLastSyncedPublished(false);
+            setLastFailedDoc(null);
+          } else if (!stealsFocusFromDirty) {
+            // #249 — no creator auto-grant to mirror any more: creation is an
+            // ordinary admin write under the worker's admin trump, and admins
+            // read every row through the "*" short-circuit.
             setSelectedLanguage(name);
-          },
-        }
-      );
+          }
+        });
     },
-    [contextOrg, saveLanguage, scaffoldQuery.data, setSelectedLanguage]
+    [
+      contextOrg,
+      isDirty,
+      isSaving,
+      saveLanguage,
+      scaffoldQuery.data,
+      selectedLanguage,
+      setSelectedLanguage,
+    ]
   );
 
   const handleSetPublished = useCallback(
@@ -534,6 +562,7 @@ export function LanguagesPage() {
               onSelectLanguage={handleSelectLanguage}
               onCreateLanguage={handleCreateLanguage}
               editRights={editRights}
+              publishRights={publishRights}
               onDeleteLanguage={handleDeleteLanguage}
               onSetPublished={handleSetPublished}
               isCreating={saveLanguage.isPending}

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -533,6 +533,7 @@ export function LanguagesPage() {
               selectedLanguage={selectedLanguage}
               onSelectLanguage={handleSelectLanguage}
               onCreateLanguage={handleCreateLanguage}
+              editRights={editRights}
               onDeleteLanguage={handleDeleteLanguage}
               onSetPublished={handleSetPublished}
               isCreating={saveLanguage.isPending}

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -219,9 +219,14 @@ export function LanguagesPage() {
   const performSave = useCallback(
     (doc: string) => {
       if (!selectedLanguage) return;
+      // The row this save targets, pinned at call time. A save that settles
+      // after a discard-and-switch must not retarget the NEW selection's
+      // shared bookkeeping — check the live selection in the callbacks before
+      // touching lastSyncedDoc/lastFailedDoc (grok rd-5).
+      const target = selectedLanguage;
       saveLanguage.mutate(
         {
-          name: selectedLanguage,
+          name: target,
           // Org pinned at call time — see handleSetDefault.
           org: contextOrg,
           body: {
@@ -235,10 +240,14 @@ export function LanguagesPage() {
         },
         {
           onSuccess: () => {
+            if (useUiStore.getState().selectedLanguage !== target) return;
             setLastSyncedDoc(doc);
             setLastFailedDoc(null);
           },
-          onError: () => setLastFailedDoc(doc),
+          onError: () => {
+            if (useUiStore.getState().selectedLanguage !== target) return;
+            setLastFailedDoc(doc);
+          },
         }
       );
     },
@@ -266,6 +275,12 @@ export function LanguagesPage() {
   useEffect(() => {
     if (!selectedLanguage) return;
     if (saveLanguage.isPending) return;
+    // Local editor state must belong to the current selection. On a
+    // discard-and-switch the selection flips to B in a render where `draft`,
+    // `lastSyncedLabel` and `lastSyncedPublished` are still A's, before the sync
+    // effect loads B — saving in that window PUTs A's document onto B (grok
+    // rd-5). Same gate the publish control uses.
+    if (syncedName !== selectedLanguage) return;
     // A debounced snapshot that hasn't caught up to `draft` is a value from
     // the past — writing it would undo an out-of-band change (an overwrite
     // reset, or a language switch) that already advanced `draft`/lastSyncedDoc.
@@ -290,14 +305,26 @@ export function LanguagesPage() {
     lastFailedDoc,
     performSave,
     selectedLanguage,
+    syncedName,
     canEditSelected,
   ]);
 
   const flushSave = useCallback(() => {
     if (!isDirty || isSaving) return;
     if (!canEditSelected) return;
+    // Same selection-ownership gate as autosave: never flush A's locals onto B
+    // during the render window after a discard-and-switch (grok rd-5).
+    if (syncedName !== selectedLanguage) return;
     performSave(draft);
-  }, [canEditSelected, draft, isDirty, isSaving, performSave]);
+  }, [
+    canEditSelected,
+    draft,
+    isDirty,
+    isSaving,
+    performSave,
+    syncedName,
+    selectedLanguage,
+  ]);
 
   // Block route changes while there are pending edits or an in-flight save.
   // The blocker fires only when navigating to a different pathname (selecting

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -380,7 +380,15 @@ export function LanguagesPage() {
       // refuse to save instead of silently committing an empty doc
       // (Frank P2 on PR #106).
       const scaffold = scaffoldQuery.data;
-      if (!scaffold) return;
+      // Reject (not a silent resolve) so the destructive overwrite dialog stays
+      // open and shows the error instead of closing as if it replaced (grok
+      // rd-4). The create button is disabled until the scaffold loads, so this
+      // is defense in depth (Frank P2 on PR #106).
+      if (!scaffold) {
+        return Promise.reject(
+          new Error("The language template isn't loaded yet — try again.")
+        );
+      }
       // Returned so the selector's overwrite confirmation can await the write
       // and render failures inline (grok F2 / #102).
       return saveLanguage
@@ -394,16 +402,22 @@ export function LanguagesPage() {
           },
         })
         .then(() => {
-          // Never re-scaffold onto a DIFFERENT language while one is being
-          // edited: auto-selecting it would couple the two through the
-          // autosave debounce register and could show a stale cache read over
-          // the scaffold just written (grok rd-2 F2). Leave the selection put;
-          // the new language is in the dropdown either way.
-          if (name !== selectedLanguage && selectedLanguage !== null) return;
-          // Otherwise we are landing on `name` — either replacing the language
-          // being VIEWED, or selecting the freshly written one from an empty
-          // editor. Install the scaffold state locally and PIN syncedNameRef so
-          // the sync effect won't overwrite it: without this the next keystroke
+          // Read the LIVE selection, not the click-time closure value: the user
+          // can switch languages during the in-flight PUT (the switch dialog
+          // offers "discard and switch" while saving), and acting on a stale
+          // `selectedLanguage` would skip the local install for the row now on
+          // screen, or yank the selection off a row they moved to (grok rd-4).
+          const liveSelection = useUiStore.getState().selectedLanguage;
+          // Never re-scaffold onto a DIFFERENT language while one is open:
+          // auto-selecting it would couple the two through the autosave debounce
+          // register and could show a stale cache read over the scaffold just
+          // written (grok rd-2 F2). Leave the selection put; the new language is
+          // in the dropdown either way.
+          if (name !== liveSelection && liveSelection !== null) return;
+          // Otherwise we are landing on `name` — replacing the language being
+          // VIEWED, or selecting the freshly written one from an empty editor.
+          // Install the scaffold state locally and PIN syncedNameRef so the sync
+          // effect won't overwrite it: without this the next keystroke
           // republishes the old document (grok rd-2 F1), or a stale cache read
           // for a previously-visited language reloads its old doc over the
           // scaffold (codex rd-3 P1). The label is mirrored for the same reason
@@ -414,16 +428,10 @@ export function LanguagesPage() {
           setLastSyncedLabel(label || undefined);
           setLastFailedDoc(null);
           syncedNameRef.current = name;
-          if (name !== selectedLanguage) setSelectedLanguage(name);
+          if (name !== liveSelection) setSelectedLanguage(name);
         });
     },
-    [
-      contextOrg,
-      saveLanguage,
-      scaffoldQuery.data,
-      selectedLanguage,
-      setSelectedLanguage,
-    ]
+    [contextOrg, saveLanguage, scaffoldQuery.data, setSelectedLanguage]
   );
 
   const handleSetPublished = useCallback(

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -438,6 +438,11 @@ export function LanguagesPage() {
           },
         })
         .then(() => {
+          // Bail if the ORG context switched during the in-flight PUT: the
+          // discard-and-switch dialog nulls selectedLanguage, and treating that
+          // as "empty editor, land here" would install org A's scaffold and
+          // autosave it onto org B's row (grok rd-6). Only land on the same org.
+          if (useUiStore.getState().contextOrg !== contextOrg) return;
           // Read the LIVE selection, not the click-time closure value: the user
           // can switch languages during the in-flight PUT (the switch dialog
           // offers "discard and switch" while saving), and acting on a stale
@@ -488,7 +493,11 @@ export function LanguagesPage() {
         org: contextOrg,
         body: { label: lastSyncedLabel, document: doc, published },
       });
-      if (isSelected) {
+      // Only bookkeep locals if we're STILL on the row this toggle targeted —
+      // a discard-and-switch during the await would otherwise stamp this row's
+      // published flag and document onto the newly selected language, which the
+      // next autosave then PUTs (grok rd-6). Same live check as performSave.
+      if (useUiStore.getState().selectedLanguage === name) {
         setLastSyncedDoc(doc);
         setLastSyncedPublished(published);
       }

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -152,7 +152,14 @@ export function LanguagesPage() {
   const editorRef = useRef<MarkdownEditorHandle | null>(null);
   const debouncedDraft = useDebounced(draft, AUTO_SAVE_DEBOUNCE_MS);
 
-  const serverLabel = languageQuery.data?.label;
+  // Same local-mirror rationale as lastSyncedDoc/Published: the label lives in
+  // the React Query cache, which lags a create/overwrite that changed it. An
+  // autosave must send the label we KNOW we last synced — not a stale
+  // languageQuery.data.label — or a save right after an overwrite that set a
+  // new label reverts it (codex rd-2 P2).
+  const [lastSyncedLabel, setLastSyncedLabel] = useState<string | undefined>(
+    undefined
+  );
 
   // Re-sync from the server *only* when the selection changes — never
   // post-save. The ref tracks the language whose contents we last loaded
@@ -165,6 +172,7 @@ export function LanguagesPage() {
       setDraft("");
       setLastSyncedDoc("");
       setLastSyncedPublished(false);
+      setLastSyncedLabel(undefined);
       setLastFailedDoc(null);
       return;
     }
@@ -177,6 +185,7 @@ export function LanguagesPage() {
     setDraft(languageQuery.data.document);
     setLastSyncedDoc(languageQuery.data.document);
     setLastSyncedPublished(languageQuery.data.published ?? false);
+    setLastSyncedLabel(languageQuery.data.label);
     setLastFailedDoc(null);
     syncedNameRef.current = selectedLanguage;
   }, [selectedLanguage, languageQuery.data]);
@@ -199,7 +208,7 @@ export function LanguagesPage() {
           // Org pinned at call time — see handleSetDefault.
           org: contextOrg,
           body: {
-            label: serverLabel,
+            label: lastSyncedLabel,
             document: doc,
             // Read published from local state, not the React Query cache —
             // the cache lags a just-completed Publish/Unpublish PUT, so
@@ -221,7 +230,7 @@ export function LanguagesPage() {
       lastSyncedPublished,
       saveLanguage,
       selectedLanguage,
-      serverLabel,
+      lastSyncedLabel,
     ]
   );
 
@@ -240,6 +249,13 @@ export function LanguagesPage() {
   useEffect(() => {
     if (!selectedLanguage) return;
     if (saveLanguage.isPending) return;
+    // A debounced snapshot that hasn't caught up to `draft` is a value from
+    // the past — writing it would undo an out-of-band change (an overwrite
+    // reset, or a language switch) that already advanced `draft`/lastSyncedDoc.
+    // Same refusal the modes editor extracted as `shouldAutoSaveDraft`
+    // (lib/autosave-gate) after the priority-panel Apply race; grok rd-2 flagged
+    // the identical lag here (overwrite → republish, cross-language draft bleed).
+    if (debouncedDraft !== draft) return;
     if (debouncedDraft === lastSyncedDoc) return;
     if (debouncedDraft === lastFailedDoc) return;
     // Frank rd-2 P2: skip autosave when the user has no edit rights on
@@ -250,6 +266,7 @@ export function LanguagesPage() {
     if (!canEditSelected) return;
     performSave(debouncedDraft);
   }, [
+    draft,
     debouncedDraft,
     saveLanguage.isPending,
     lastSyncedDoc,
@@ -356,14 +373,6 @@ export function LanguagesPage() {
       // (Frank P2 on PR #106).
       const scaffold = scaffoldQuery.data;
       if (!scaffold) return;
-      // #293 grok F1: whether this is a fresh create or a re-scaffold of an
-      // existing language, the write lands a blank, unpublished document. If
-      // we're overwriting a DIFFERENT language while the current editor is
-      // dirty or mid-save, yanking the selection would leave the autosave
-      // effect about to PUT this row's draft into the new one — so hold the
-      // selection where it is in that case.
-      const stealsFocusFromDirty =
-        name !== selectedLanguage && (isDirty || isSaving);
       // Returned so the selector's overwrite confirmation can await the write
       // and render failures inline (grok F2 / #102).
       return saveLanguage
@@ -387,19 +396,25 @@ export function LanguagesPage() {
             setDraft(scaffold.document);
             setLastSyncedDoc(scaffold.document);
             setLastSyncedPublished(false);
+            // Mirror the label we just sent so autosave doesn't revert it to
+            // the stale cached label before the refetch lands (codex rd-2 P2).
+            setLastSyncedLabel(label || undefined);
             setLastFailedDoc(null);
-          } else if (!stealsFocusFromDirty) {
-            // #249 — no creator auto-grant to mirror any more: creation is an
-            // ordinary admin write under the worker's admin trump, and admins
-            // read every row through the "*" short-circuit.
+          } else if (selectedLanguage === null) {
+            // Only jump to the new/replaced language when no editor is open.
+            // Auto-selecting a DIFFERENT language while one is being edited
+            // couples the two through the autosave debounce register: the
+            // lagging draft would PUT into the new row, and a stale cache read
+            // for a previously-opened target would show its old document over
+            // the scaffold we just wrote (grok rd-2 F2). Leaving the selection
+            // put avoids both; the new language is in the dropdown either way.
+            // (#249 — creation is an ordinary admin write; no creator grant.)
             setSelectedLanguage(name);
           }
         });
     },
     [
       contextOrg,
-      isDirty,
-      isSaving,
       saveLanguage,
       scaffoldQuery.data,
       selectedLanguage,
@@ -422,7 +437,7 @@ export function LanguagesPage() {
       await saveLanguage.mutateAsync({
         name,
         org: contextOrg,
-        body: { label: serverLabel, document: doc, published },
+        body: { label: lastSyncedLabel, document: doc, published },
       });
       if (isSelected) {
         setLastSyncedDoc(doc);
@@ -435,7 +450,7 @@ export function LanguagesPage() {
       languageQuery.data,
       saveLanguage,
       selectedLanguage,
-      serverLabel,
+      lastSyncedLabel,
     ]
   );
 

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -166,9 +166,17 @@ export function LanguagesPage() {
   // into local state, so we don't repeatedly overwrite the draft each time
   // the cache emits.
   const syncedNameRef = useRef<string | null>(null);
+  // A STATE mirror of syncedNameRef, used for render-time gating. The ref gives
+  // the sync effect a synchronous guard; the state gives the publish gate a
+  // reactive one. A ref alone can't drive render output: switching to a cached
+  // language whose document/published/label/failure all equal the current
+  // locals makes every setter below a no-op, so nothing re-renders and a
+  // ref-derived flag would stay stale forever (codex rd-5).
+  const [syncedName, setSyncedName] = useState<string | null>(null);
   useEffect(() => {
     if (!selectedLanguage) {
       syncedNameRef.current = null;
+      setSyncedName(null);
       setDraft("");
       setLastSyncedDoc("");
       setLastSyncedPublished(false);
@@ -188,6 +196,7 @@ export function LanguagesPage() {
     setLastSyncedLabel(languageQuery.data.label);
     setLastFailedDoc(null);
     syncedNameRef.current = selectedLanguage;
+    setSyncedName(selectedLanguage);
   }, [selectedLanguage, languageQuery.data]);
 
   const isDirty = draft !== lastSyncedDoc;
@@ -198,9 +207,9 @@ export function LanguagesPage() {
   // makes the query name match on the first render after a switch, before the
   // sync effect above has loaded this language's document/label — so a Publish
   // in that render would send the PREVIOUS language's draft and label into this
-  // one (codex rd-4 P1). `syncedNameRef` only advances alongside those state
-  // writes, so it re-renders correctly and can't be true with stale locals.
-  const detailReady = syncedNameRef.current === selectedLanguage;
+  // one (codex rd-4 P1). Read from `syncedName` STATE, not the ref, so an
+  // all-no-op sync still re-renders the gate (codex rd-5).
+  const detailReady = syncedName === selectedLanguage;
 
   // Single save path — both auto-save and the manual Save button funnel
   // through here so the lastSyncedDoc bookkeeping stays consistent.
@@ -428,6 +437,7 @@ export function LanguagesPage() {
           setLastSyncedLabel(label || undefined);
           setLastFailedDoc(null);
           syncedNameRef.current = name;
+          setSyncedName(name);
           if (name !== liveSelection) setSelectedLanguage(name);
         });
     },

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -119,6 +119,13 @@ export function LanguagesPage() {
   const orgDefaultQuery = useOrgDefaultLanguage(contextOrg);
   const setOrgDefault = useSetOrgDefaultLanguage();
 
+  // Detail loaded for the CURRENT selection — not a stale row still in the
+  // cache mid-switch. Publish/Unpublish acts on the loaded document + label, so
+  // it must wait for this: clicked during an A→B load it would send A's draft
+  // and label into B (grok rd-3). Matches the editor pane, which is read-only
+  // until the detail arrives.
+  const detailReady = languageQuery.data?.name === selectedLanguage;
+
   // Local document draft (auto-save target).
   //
   // We track `lastSyncedDoc` separately from React Query's cache so that:
@@ -386,31 +393,27 @@ export function LanguagesPage() {
           },
         })
         .then(() => {
-          if (name === selectedLanguage) {
-            // Replacing the language being VIEWED: the selection doesn't
-            // change, so the sync effect won't re-pull. Reset the editor to
-            // the blank scaffold the server now holds — otherwise the next
-            // keystroke autosaves the OLD document back and republishes it,
-            // undoing the replace (grok F1, Failure A). Leave syncedNameRef
-            // alone so a refetch of stale cache can't reload the old doc.
-            setDraft(scaffold.document);
-            setLastSyncedDoc(scaffold.document);
-            setLastSyncedPublished(false);
-            // Mirror the label we just sent so autosave doesn't revert it to
-            // the stale cached label before the refetch lands (codex rd-2 P2).
-            setLastSyncedLabel(label || undefined);
-            setLastFailedDoc(null);
-          } else if (selectedLanguage === null) {
-            // Only jump to the new/replaced language when no editor is open.
-            // Auto-selecting a DIFFERENT language while one is being edited
-            // couples the two through the autosave debounce register: the
-            // lagging draft would PUT into the new row, and a stale cache read
-            // for a previously-opened target would show its old document over
-            // the scaffold we just wrote (grok rd-2 F2). Leaving the selection
-            // put avoids both; the new language is in the dropdown either way.
-            // (#249 — creation is an ordinary admin write; no creator grant.)
-            setSelectedLanguage(name);
-          }
+          // Never re-scaffold onto a DIFFERENT language while one is being
+          // edited: auto-selecting it would couple the two through the
+          // autosave debounce register and could show a stale cache read over
+          // the scaffold just written (grok rd-2 F2). Leave the selection put;
+          // the new language is in the dropdown either way.
+          if (name !== selectedLanguage && selectedLanguage !== null) return;
+          // Otherwise we are landing on `name` — either replacing the language
+          // being VIEWED, or selecting the freshly written one from an empty
+          // editor. Install the scaffold state locally and PIN syncedNameRef so
+          // the sync effect won't overwrite it: without this the next keystroke
+          // republishes the old document (grok rd-2 F1), or a stale cache read
+          // for a previously-visited language reloads its old doc over the
+          // scaffold (codex rd-3 P1). The label is mirrored for the same reason
+          // (codex rd-2 P2). (#249 — creation is an ordinary admin write.)
+          setDraft(scaffold.document);
+          setLastSyncedDoc(scaffold.document);
+          setLastSyncedPublished(false);
+          setLastSyncedLabel(label || undefined);
+          setLastFailedDoc(null);
+          syncedNameRef.current = name;
+          if (name !== selectedLanguage) setSelectedLanguage(name);
         });
     },
     [
@@ -586,7 +589,7 @@ export function LanguagesPage() {
               showDrafts={showDrafts}
               onToggleShowDrafts={setShowDrafts}
               canCreate={canCreate}
-              canPublishSelected={canPublishSelected}
+              canPublishSelected={canPublishSelected && detailReady}
               canDeleteSelected={canDeleteSelected}
               isScaffoldReady={scaffoldQuery.isSuccess}
               scaffoldError={scaffoldQuery.isError}

--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -167,13 +167,19 @@ function ResourceRow({
         {display.title}
       </span>
       {display.secondaryName && (
-        <code className="text-muted-foreground text-[11px]">
+        <code
+          className="text-muted-foreground max-w-[16rem] min-w-0 truncate text-[11px]"
+          title={display.secondaryName}
+        >
           {display.secondaryName}
         </code>
       )}
       <ServerBadge serverId={item.serverId} serverNames={serverNames} />
       {meta.length > 0 && (
-        <span className="text-muted-foreground text-xs">
+        <span
+          className="text-muted-foreground max-w-full min-w-0 truncate text-xs"
+          title={meta.join(" · ")}
+        >
           {meta.join(" · ")}
         </span>
       )}

--- a/src/app/pages/resources.tsx
+++ b/src/app/pages/resources.tsx
@@ -12,6 +12,8 @@ import {
 import { safeResourceHref } from "@/lib/resource-href";
 import {
   buildServerNameMap,
+  collapseDisplayText,
+  resolveResourceItemDisplay,
   resolveServerLabel,
   type ServerNameMap,
 } from "@/lib/resource-servers";
@@ -82,7 +84,13 @@ function ServerChip({
       {server.status === "unsupported" && <span>no resource listing</span>}
       {server.status === "error" && (
         <>
-          <span title={server.error}>failed to respond</span>
+          {/* server.error is untrusted MCP-relayed text; collapse control and
+              format characters out of the tooltip (#294), matching the map. */}
+          <span
+            title={server.error ? collapseDisplayText(server.error) : undefined}
+          >
+            failed to respond
+          </span>
           <button
             type="button"
             className="hover:text-foreground inline-flex items-center gap-1 underline underline-offset-2"
@@ -138,20 +146,30 @@ function ResourceRow({
   // Scheme-guarded: item.url is third-party MCP server output relayed by
   // the worker — see lib/resource-href.ts.
   const href = safeResourceHref(item.url);
+  // label / name / organization / version are untrusted MCP-relayed text:
+  // collapse control and format characters so a value can't span rows or
+  // smuggle invisible width (#294). The load-bearing title also gets a CSS
+  // width bound with the full text kept in the DOM (title tooltip).
+  const display = resolveResourceItemDisplay(item);
   const meta = [
-    item.organization,
-    item.version && `v${item.version}`,
+    display.organization,
+    display.version && `v${display.version}`,
     item.articleCount !== undefined &&
       `${String(item.articleCount)} article${item.articleCount === 1 ? "" : "s"}`,
   ].filter(Boolean);
 
   return (
     <li className="flex flex-wrap items-baseline gap-x-2 gap-y-1 py-2">
-      <span className="text-foreground text-sm font-medium">
-        {item.label || item.name}
+      <span
+        className="text-foreground max-w-full min-w-0 truncate text-sm font-medium"
+        title={display.title}
+      >
+        {display.title}
       </span>
-      {item.label && (
-        <code className="text-muted-foreground text-[11px]">{item.name}</code>
+      {display.secondaryName && (
+        <code className="text-muted-foreground text-[11px]">
+          {display.secondaryName}
+        </code>
       )}
       <ServerBadge serverId={item.serverId} serverNames={serverNames} />
       {meta.length > 0 && (

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -18,12 +18,14 @@ import {
   isDefaultControlAvailable,
   type LanguageDefaultState,
 } from "@/lib/language-default-state";
+import { classifyLanguageCreate } from "@/lib/language-create";
 import {
   describeLanguageDeleteError,
   shouldOfferDefaultRecovery,
 } from "@/lib/language-error-surface";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
 import { cn } from "@/lib/utils";
+import type { LanguageRights } from "@/types/auth";
 import type { Language, OrgLanguages } from "@/types/language";
 import {
   AlertDialog,
@@ -52,6 +54,13 @@ interface LanguageSelectorProps {
   selectedLanguage: string | null;
   onSelectLanguage: (language: string | null) => void;
   onCreateLanguage: (name: string, label: string) => void;
+  /** The caller's effective language EDIT rights, already trump-aware (`"*"`
+      for admins and cross-org super-admins). #293: a create over an existing
+      slug overwrites its document with a blank scaffold and unpublishes it, so
+      the selector confirms first when the caller may overwrite the row, and
+      refuses up front when they can't (the worker would 403 the write).
+      `undefined` is the legacy full-access shape (see hasRights). */
+  editRights: LanguageRights | undefined;
   /** Must return a promise that rejects on error — the destructive
       confirmation dialogs render inline error UI on the rejection path
       and stay open so the user can read it (#102). */
@@ -107,6 +116,7 @@ export function LanguageSelector({
   selectedLanguage,
   onSelectLanguage,
   onCreateLanguage,
+  editRights,
   onDeleteLanguage,
   onSetPublished,
   isCreating,
@@ -127,6 +137,14 @@ export function LanguageSelector({
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
   const [newLabel, setNewLabel] = useState("");
+  // #293: create-time collision handling. `createError` blocks a create over a
+  // name the caller can't edit; `overwriteTarget` drives the destructive
+  // confirmation for a create over one they can (replace document + unpublish).
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [overwriteTarget, setOverwriteTarget] = useState<{
+    slug: string;
+    label: string;
+  } | null>(null);
 
   // Destructive-confirmation dialogs are controlled so we can keep them
   // open on async failure and render the error inline (#102). Closing on
@@ -271,17 +289,44 @@ export function LanguageSelector({
       .replace(/[^a-z0-9\-_]/g, "")
       .replace(/^-+|-+$/g, "");
     if (!slug) return;
-    // #272: no hidden-name collision check any more. It guarded the case
-    // where a name was taken by a row the user couldn't see, which #249
-    // removed — the dropdown now lists the org's whole catalog, so a taken
-    // name is always a name in `languages`, and re-creating one is the
-    // deliberate PUT-over-existing re-scaffold flow (#256 rd-3) rather
-    // than an error. The worker's gate remains the enforcement either way.
+    setCreateError(null);
+    // #293: a create over an existing slug PUTs a blank scaffold that
+    // overwrites the language's tuning document and unpublishes it. #272
+    // removed the last guard, so it happened silently. #249 lists the org's
+    // whole catalog, so `languages` is authoritative for what names are taken;
+    // `editRights` decides whether this caller may overwrite the row (confirm
+    // first) or the worker would 403 the write (block up front).
+    const existingNames = languages.map((l) => l.name);
+    const action = classifyLanguageCreate(slug, existingNames, editRights);
+    if (action.kind === "blocked") {
+      setCreateError(
+        `A language named “${slug}” already exists in this org, but you don’t have edit rights on it. Pick a different name, or ask a shepherd or admin for access.`
+      );
+      return;
+    }
+    if (action.kind === "confirm") {
+      setOverwriteTarget({ slug, label: newLabel.trim() });
+      return;
+    }
     onCreateLanguage(slug, newLabel.trim());
     setNewName("");
     setNewLabel("");
     setShowCreate(false);
-  }, [newName, newLabel, onCreateLanguage]);
+  }, [newName, newLabel, onCreateLanguage, languages, editRights]);
+
+  // Re-scaffolding an existing language is destructive (blank document +
+  // unpublish), so it only runs from the confirmation dialog. Fire-and-forget
+  // to match the plain create path — the worker's write error surfaces the
+  // same way either creation does.
+  const handleConfirmOverwrite = useCallback(() => {
+    if (overwriteTarget === null) return;
+    onCreateLanguage(overwriteTarget.slug, overwriteTarget.label);
+    setOverwriteTarget(null);
+    setNewName("");
+    setNewLabel("");
+    setShowCreate(false);
+    setCreateError(null);
+  }, [overwriteTarget, onCreateLanguage]);
 
   return (
     <div className="space-y-3">
@@ -657,11 +702,23 @@ export function LanguageSelector({
                 : "Loading language template…"}
             </p>
           )}
+          {createError && (
+            <p
+              className="text-destructive mt-3 text-xs"
+              role="alert"
+              aria-live="polite"
+            >
+              {createError}
+            </p>
+          )}
           <div className="mt-4 flex justify-end gap-2">
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setShowCreate(false)}
+              onClick={() => {
+                setShowCreate(false);
+                setCreateError(null);
+              }}
             >
               Cancel
             </Button>
@@ -675,6 +732,40 @@ export function LanguageSelector({
           </div>
         </div>
       )}
+
+      {/* #293 — a create over an existing language re-scaffolds it (blank
+          document + unpublish). Confirm before that destructive write instead
+          of doing it silently. Plain Button, not AlertDialogAction, to match
+          the file's other destructive dialogs (#102). */}
+      <AlertDialog
+        open={overwriteTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) setOverwriteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Replace “{overwriteTarget?.slug}”?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              A language named “{overwriteTarget?.slug}” already exists.
+              Creating it again replaces its tuning document with a blank
+              scaffold and unpublishes it. This can&rsquo;t be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isCreating}>Cancel</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              onClick={handleConfirmOverwrite}
+              disabled={isCreating}
+            >
+              Replace and unpublish
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -290,6 +290,15 @@ export function LanguageSelector({
       .replace(/^-+|-+$/g, "");
     if (!slug) return;
     setCreateError(null);
+    // #293 race: until the catalog loads, `languages` is [], so a collision
+    // would classify as `create` and silently overwrite — the exact bug this
+    // guards against. Refuse to classify against a list we don't have yet.
+    if (languagesData === undefined) {
+      setCreateError(
+        "Still loading the language list — try again in a moment."
+      );
+      return;
+    }
     // #293: a create over an existing slug PUTs a blank scaffold that
     // overwrites the language's tuning document and unpublishes it. #272
     // removed the last guard, so it happened silently. #249 lists the org's
@@ -312,7 +321,14 @@ export function LanguageSelector({
     setNewName("");
     setNewLabel("");
     setShowCreate(false);
-  }, [newName, newLabel, onCreateLanguage, languages, editRights]);
+  }, [
+    newName,
+    newLabel,
+    onCreateLanguage,
+    languages,
+    languagesData,
+    editRights,
+  ]);
 
   // Re-scaffolding an existing language is destructive (blank document +
   // unpublish), so it only runs from the confirmation dialog. Fire-and-forget
@@ -703,11 +719,7 @@ export function LanguageSelector({
             </p>
           )}
           {createError && (
-            <p
-              className="text-destructive mt-3 text-xs"
-              role="alert"
-              aria-live="polite"
-            >
+            <p className="text-destructive mt-3 text-xs" role="alert">
               {createError}
             </p>
           )}
@@ -725,7 +737,12 @@ export function LanguageSelector({
             <Button
               size="sm"
               onClick={handleCreate}
-              disabled={!newName.trim() || isCreating || !isScaffoldReady}
+              disabled={
+                !newName.trim() ||
+                isCreating ||
+                !isScaffoldReady ||
+                languagesData === undefined
+              }
             >
               {isCreating ? "Creating..." : "Create Draft"}
             </Button>

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -315,10 +315,21 @@ export function LanguageSelector({
     // whole catalog, so `languages` is authoritative for what names are taken;
     // edit/publish rights + the target's published state decide whether this
     // caller may overwrite (confirm first) or the worker would 403 (block).
-    const existing = languages.find((l) => l.name === slug);
+    const existingRow = languages.find((l) => l.name === slug);
+    // The collection can lag a just-created slug (its save seeds the detail
+    // cache and upserts the list, but a second create can still race a pending
+    // refetch). If the slug is the row currently open, it definitionally
+    // exists, so route it through confirm rather than a silent re-create even
+    // when the list hasn't caught up (grok rd-5). A freshly created row is a
+    // draft; the worker still gates the write.
+    const existing = existingRow
+      ? { published: isPublished(existingRow) }
+      : selectedLanguage === slug
+        ? { published: false }
+        : null;
     const action = classifyLanguageCreate(
       slug,
-      existing ? { published: isPublished(existing) } : null,
+      existing,
       editRights,
       publishRights
     );
@@ -348,6 +359,7 @@ export function LanguageSelector({
     onCreateLanguage,
     languages,
     languagesData,
+    selectedLanguage,
     editRights,
     publishRights,
   ]);

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -53,7 +53,10 @@ interface LanguageSelectorProps {
   languagesData: OrgLanguages | undefined;
   selectedLanguage: string | null;
   onSelectLanguage: (language: string | null) => void;
-  onCreateLanguage: (name: string, label: string) => void;
+  /** Returns a promise that rejects on error so the destructive
+      create-over-existing confirmation can render its failure inline and stay
+      open (grok F2 / #102). The plain create path ignores the result. */
+  onCreateLanguage: (name: string, label: string) => void | Promise<void>;
   /** The caller's effective language EDIT rights, already trump-aware (`"*"`
       for admins and cross-org super-admins). #293: a create over an existing
       slug overwrites its document with a blank scaffold and unpublishes it, so
@@ -61,6 +64,11 @@ interface LanguageSelectorProps {
       refuses up front when they can't (the worker would 403 the write).
       `undefined` is the legacy full-access shape (see hasRights). */
   editRights: LanguageRights | undefined;
+  /** The caller's effective language PUBLISH rights, same trump-aware shape as
+      editRights. #293: re-scaffolding a PUBLISHED language unpublishes it, so
+      the worker's overwrite PUT needs publish rights too — used to block an
+      edit-only caller before a confirmation that would 403. */
+  publishRights: LanguageRights | undefined;
   /** Must return a promise that rejects on error — the destructive
       confirmation dialogs render inline error UI on the rejection path
       and stay open so the user can read it (#102). */
@@ -117,6 +125,7 @@ export function LanguageSelector({
   onSelectLanguage,
   onCreateLanguage,
   editRights,
+  publishRights,
   onDeleteLanguage,
   onSetPublished,
   isCreating,
@@ -145,6 +154,7 @@ export function LanguageSelector({
     slug: string;
     label: string;
   } | null>(null);
+  const [overwriteError, setOverwriteError] = useState<string | null>(null);
 
   // Destructive-confirmation dialogs are controlled so we can keep them
   // open on async failure and render the error inline (#102). Closing on
@@ -303,13 +313,20 @@ export function LanguageSelector({
     // overwrites the language's tuning document and unpublishes it. #272
     // removed the last guard, so it happened silently. #249 lists the org's
     // whole catalog, so `languages` is authoritative for what names are taken;
-    // `editRights` decides whether this caller may overwrite the row (confirm
-    // first) or the worker would 403 the write (block up front).
-    const existingNames = languages.map((l) => l.name);
-    const action = classifyLanguageCreate(slug, existingNames, editRights);
+    // edit/publish rights + the target's published state decide whether this
+    // caller may overwrite (confirm first) or the worker would 403 (block).
+    const existing = languages.find((l) => l.name === slug);
+    const action = classifyLanguageCreate(
+      slug,
+      existing ? { published: isPublished(existing) } : null,
+      editRights,
+      publishRights
+    );
     if (action.kind === "blocked") {
       setCreateError(
-        `A language named “${slug}” already exists in this org, but you don’t have edit rights on it. Pick a different name, or ask a shepherd or admin for access.`
+        action.reason === "publish"
+          ? `“${slug}” is a published language and you don’t have publish rights on it, so it can’t be replaced here — replacing it would unpublish it. Ask an admin.`
+          : `A language named “${slug}” already exists in this org, but you don’t have edit rights on it. Pick a different name, or ask a shepherd or admin for access.`
       );
       return;
     }
@@ -317,7 +334,11 @@ export function LanguageSelector({
       setOverwriteTarget({ slug, label: newLabel.trim() });
       return;
     }
-    onCreateLanguage(slug, newLabel.trim());
+    // Plain create is fire-and-forget; its errors surface via the page's save
+    // state, not inline here. Swallow the rejection so it isn't unhandled.
+    void Promise.resolve(onCreateLanguage(slug, newLabel.trim())).catch(
+      () => {}
+    );
     setNewName("");
     setNewLabel("");
     setShowCreate(false);
@@ -328,20 +349,29 @@ export function LanguageSelector({
     languages,
     languagesData,
     editRights,
+    publishRights,
   ]);
 
   // Re-scaffolding an existing language is destructive (blank document +
-  // unpublish), so it only runs from the confirmation dialog. Fire-and-forget
-  // to match the plain create path — the worker's write error surfaces the
-  // same way either creation does.
+  // unpublish), so it only runs from the confirmation dialog. Unlike the plain
+  // create path it awaits the write and keeps the dialog open on failure,
+  // rendering the error inline (grok F2 / #102) — the same contract as the
+  // Unpublish/Delete dialogs.
   const handleConfirmOverwrite = useCallback(() => {
     if (overwriteTarget === null) return;
-    onCreateLanguage(overwriteTarget.slug, overwriteTarget.label);
-    setOverwriteTarget(null);
-    setNewName("");
-    setNewLabel("");
-    setShowCreate(false);
-    setCreateError(null);
+    const { slug, label } = overwriteTarget;
+    return runConfirmedAction(
+      () => Promise.resolve(onCreateLanguage(slug, label)),
+      setOverwriteError,
+      () => {
+        setOverwriteTarget(null);
+        setNewName("");
+        setNewLabel("");
+        setShowCreate(false);
+        setCreateError(null);
+      },
+      "Failed to replace language."
+    );
   }, [overwriteTarget, onCreateLanguage]);
 
   return (
@@ -757,7 +787,10 @@ export function LanguageSelector({
       <AlertDialog
         open={overwriteTarget !== null}
         onOpenChange={(next) => {
-          if (!next) setOverwriteTarget(null);
+          if (!next) {
+            setOverwriteTarget(null);
+            setOverwriteError(null);
+          }
         }}
       >
         <AlertDialogContent>
@@ -771,6 +804,11 @@ export function LanguageSelector({
               scaffold and unpublishes it. This can&rsquo;t be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {overwriteError && (
+            <p className="text-destructive text-sm" role="alert">
+              {overwriteError}
+            </p>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isCreating}>Cancel</AlertDialogCancel>
             <Button

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -6,7 +6,11 @@ import {
 } from "@tanstack/react-query";
 
 import * as languagesApi from "@/lib/languages-api";
-import type { Language, OrgDefaultLanguage } from "@/types/language";
+import type {
+  Language,
+  OrgDefaultLanguage,
+  OrgLanguages,
+} from "@/types/language";
 
 // Org is part of every key so a super-admin's cross-org view doesn't collide
 // with the same-org cache. `null` is the canonical same-org placeholder.
@@ -73,6 +77,20 @@ export function languageSaveMutationOptions(qc: QueryClient) {
       // the pre-save document straight back into the cache (grok rd-4).
       await qc.cancelQueries({ queryKey: keys.language(name, org) });
       qc.setQueryData(keys.language(name, org), saved);
+      // Upsert the row into the collection cache in the same tick, so a
+      // just-created slug is immediately `existing` for the next create.
+      // Without this, until the list refetch lands, re-creating the slug
+      // classifies as a fresh create and silently overwrites it (grok rd-5).
+      qc.setQueryData<OrgLanguages>(keys.languages(org), (old) =>
+        old
+          ? {
+              ...old,
+              languages: old.languages.some((l) => l.name === saved.name)
+                ? old.languages.map((l) => (l.name === saved.name ? saved : l))
+                : [...old.languages, saved],
+            }
+          : old
+      );
       void qc.invalidateQueries({ queryKey: keys.languages(org) });
     },
   };

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -59,15 +59,19 @@ export function languageSaveMutationOptions(qc: QueryClient) {
   return {
     mutationFn: ({ name, body, org }: LanguageSaveTarget) =>
       languagesApi.putLanguage(name, body, undefined, org),
-    onSuccess: (saved: Language, { name, org }: LanguageSaveTarget) => {
-      // Seed the per-language cache with the saved row (cancelling any GET in
-      // flight for it) rather than only invalidating: an invalidated but
-      // inactive detail query keeps serving its PRE-save document, so a later
-      // select — auto or manual — paints the old doc, the sync effect pins it,
-      // and the next edit saves it back over what we just wrote (grok rd-3).
-      // putLanguage returns a full Language (matches getLanguage), so this is
-      // the authoritative post-save state, org pinned via the variables.
-      void qc.cancelQueries({ queryKey: keys.language(name, org) });
+    onSuccess: async (saved: Language, { name, org }: LanguageSaveTarget) => {
+      // Seed the per-language cache with the saved row rather than only
+      // invalidating: an invalidated but inactive detail query keeps serving
+      // its PRE-save document, so a later select — auto or manual — paints the
+      // old doc, the sync effect pins it, and the next edit saves it back over
+      // what we just wrote (grok rd-3). putLanguage returns a full Language
+      // (matches getLanguage), so this is the authoritative post-save state,
+      // org pinned via the variables.
+      //
+      // AWAIT the cancel before seeding (TanStack's optimistic-update order):
+      // an in-flight getLanguage that settles AFTER setQueryData would write
+      // the pre-save document straight back into the cache (grok rd-4).
+      await qc.cancelQueries({ queryKey: keys.language(name, org) });
       qc.setQueryData(keys.language(name, org), saved);
       void qc.invalidateQueries({ queryKey: keys.languages(org) });
     },

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import * as languagesApi from "@/lib/languages-api";
-import type { OrgDefaultLanguage } from "@/types/language";
+import type { Language, OrgDefaultLanguage } from "@/types/language";
 
 // Org is part of every key so a super-admin's cross-org view doesn't collide
 // with the same-org cache. `null` is the canonical same-org placeholder.
@@ -59,9 +59,17 @@ export function languageSaveMutationOptions(qc: QueryClient) {
   return {
     mutationFn: ({ name, body, org }: LanguageSaveTarget) =>
       languagesApi.putLanguage(name, body, undefined, org),
-    onSuccess: (_data: unknown, { name, org }: LanguageSaveTarget) => {
+    onSuccess: (saved: Language, { name, org }: LanguageSaveTarget) => {
+      // Seed the per-language cache with the saved row (cancelling any GET in
+      // flight for it) rather than only invalidating: an invalidated but
+      // inactive detail query keeps serving its PRE-save document, so a later
+      // select — auto or manual — paints the old doc, the sync effect pins it,
+      // and the next edit saves it back over what we just wrote (grok rd-3).
+      // putLanguage returns a full Language (matches getLanguage), so this is
+      // the authoritative post-save state, org pinned via the variables.
+      void qc.cancelQueries({ queryKey: keys.language(name, org) });
+      qc.setQueryData(keys.language(name, org), saved);
       void qc.invalidateQueries({ queryKey: keys.languages(org) });
-      void qc.invalidateQueries({ queryKey: keys.language(name, org) });
     },
   };
 }

--- a/src/hooks/use-languages.ts
+++ b/src/hooks/use-languages.ts
@@ -81,6 +81,10 @@ export function languageSaveMutationOptions(qc: QueryClient) {
       // just-created slug is immediately `existing` for the next create.
       // Without this, until the list refetch lands, re-creating the slug
       // classifies as a fresh create and silently overwrites it (grok rd-5).
+      // Cancel the list GET first for the same reason as the detail seed: an
+      // in-flight `/languages` started before this row existed would settle
+      // after the upsert and drop it again (grok rd-6).
+      await qc.cancelQueries({ queryKey: keys.languages(org) });
       qc.setQueryData<OrgLanguages>(keys.languages(org), (old) =>
         old
           ? {

--- a/src/lib/language-create.ts
+++ b/src/lib/language-create.ts
@@ -1,0 +1,47 @@
+import type { LanguageRights } from "@/types/auth";
+import { hasRights } from "@/lib/permissions";
+
+/**
+ * What a create-language request should do for a given slug.
+ *
+ * Background (#293): creating a language PUTs a blank scaffold with
+ * `published: false`. #272 removed the last create-time collision guard, so a
+ * slug that already existed fell straight through to that PUT — silently
+ * overwriting the language's tuning document and unpublishing it, with no
+ * confirmation and no undo. #249 makes the dropdown list the org's whole
+ * catalog, so a taken name is always one the caller can SEE; whether they may
+ * overwrite it is a question of edit rights, not visibility.
+ */
+export type LanguageCreateAction =
+  /** Slug is free — create it. */
+  | { kind: "create" }
+  /**
+   * Slug exists and the caller holds no edit right on it. The worker would
+   * 403 the overwrite PUT, so refuse up front rather than offer a destructive
+   * confirmation that can only fail.
+   */
+  | { kind: "blocked" }
+  /**
+   * Slug exists and the caller may overwrite it. Creating replaces the
+   * document with a blank scaffold and unpublishes it, so confirm first.
+   */
+  | { kind: "confirm" };
+
+/**
+ * Decide what a create-language request should do for `slug`.
+ *
+ * `editRights` is already trump-aware (`"*"` for admins and cross-org
+ * super-admins), so admins re-creating any existing language get `confirm`,
+ * never `blocked`. `undefined` is the legacy "full access by default" shape and
+ * behaves the same as `"*"` here (see `hasRights`). The worker's gate remains
+ * the enforcement either way; this only decides the client-side affordance.
+ */
+export function classifyLanguageCreate(
+  slug: string,
+  existingNames: readonly string[],
+  editRights: LanguageRights | undefined
+): LanguageCreateAction {
+  if (!existingNames.includes(slug)) return { kind: "create" };
+  if (!hasRights(editRights, slug)) return { kind: "blocked" };
+  return { kind: "confirm" };
+}

--- a/src/lib/language-create.ts
+++ b/src/lib/language-create.ts
@@ -16,32 +16,51 @@ export type LanguageCreateAction =
   /** Slug is free — create it. */
   | { kind: "create" }
   /**
-   * Slug exists and the caller holds no edit right on it. The worker would
-   * 403 the overwrite PUT, so refuse up front rather than offer a destructive
-   * confirmation that can only fail.
+   * Slug exists and the caller can't legally overwrite it, so the worker would
+   * 403 the PUT — refuse up front rather than offer a confirmation that only
+   * fails. `reason` distinguishes the missing verb for the copy: `"edit"` (no
+   * edit right at all) vs `"publish"` (a PUBLISHED target, which the overwrite
+   * would unpublish, needs the publish verb too).
    */
-  | { kind: "blocked" }
+  | { kind: "blocked"; reason: "edit" | "publish" }
   /**
    * Slug exists and the caller may overwrite it. Creating replaces the
    * document with a blank scaffold and unpublishes it, so confirm first.
    */
   | { kind: "confirm" };
 
+/** The existing language a `slug` collides with, or `null` when the slug is free. */
+export interface ExistingLanguage {
+  /** Whether the colliding row is currently published. */
+  published: boolean;
+}
+
 /**
  * Decide what a create-language request should do for `slug`.
  *
- * `editRights` is already trump-aware (`"*"` for admins and cross-org
- * super-admins), so admins re-creating any existing language get `confirm`,
- * never `blocked`. `undefined` is the legacy "full access by default" shape and
- * behaves the same as `"*"` here (see `hasRights`). The worker's gate remains
- * the enforcement either way; this only decides the client-side affordance.
+ * Re-creating an existing language PUTs a blank scaffold with `published:
+ * false`. The worker derives the required verbs from what changes: the blank
+ * document always needs `edit`, and flipping a PUBLISHED row to unpublished
+ * also needs `publish`. So overwriting a published row the caller can edit but
+ * not publish would 403 — this returns `blocked/"publish"` for that case
+ * instead of a confirmation that can't succeed. Overwriting a draft needs only
+ * `edit`.
+ *
+ * Both rights args are already trump-aware (`"*"` for admins and cross-org
+ * super-admins; `undefined` is the legacy full-access shape — see `hasRights`),
+ * so admins always reach `confirm`. The worker's gate remains the enforcement;
+ * this only decides the client-side affordance.
  */
 export function classifyLanguageCreate(
   slug: string,
-  existingNames: readonly string[],
-  editRights: LanguageRights | undefined
+  existing: ExistingLanguage | null,
+  editRights: LanguageRights | undefined,
+  publishRights: LanguageRights | undefined
 ): LanguageCreateAction {
-  if (!existingNames.includes(slug)) return { kind: "create" };
-  if (!hasRights(editRights, slug)) return { kind: "blocked" };
+  if (existing === null) return { kind: "create" };
+  if (!hasRights(editRights, slug)) return { kind: "blocked", reason: "edit" };
+  if (existing.published && !hasRights(publishRights, slug)) {
+    return { kind: "blocked", reason: "publish" };
+  }
   return { kind: "confirm" };
 }

--- a/src/lib/resource-servers.ts
+++ b/src/lib/resource-servers.ts
@@ -117,3 +117,55 @@ export function resolveServerLabel(
     title: differs ? `${full} (${id})` : full,
   };
 }
+
+/** A resource row's untrusted display fields, each flattened to one safe line. */
+export interface ResourceItemDisplay {
+  /**
+   * Row title: the collapsed label, falling back to the collapsed name when
+   * the label is absent or collapses to nothing. Never blank when `name` is
+   * non-blank, so a whitespace-only label can't produce an empty-looking row.
+   */
+  title: string;
+  /** The collapsed name. */
+  name: string;
+  /**
+   * The collapsed name to show as a secondary code chip — only when a
+   * DISTINCT label titles the row, so `label === name` doesn't print twice and
+   * a label-less row doesn't repeat its own title. `null` otherwise.
+   */
+  secondaryName: string | null;
+  /** Collapsed organization, or `null` when absent or blank after collapse. */
+  organization: string | null;
+  /** Collapsed version, or `null` when absent or blank after collapse. */
+  version: string | null;
+}
+
+/**
+ * Collapse a `ResourceItem`'s untrusted, MCP-relayed display fields (#294).
+ *
+ * Same class of text as `serverName` — third-party output relayed by the
+ * worker, React-escaped, so the hazard is layout/legibility (embedded
+ * newlines, zero-width and bidi characters), not injection. Each field is run
+ * through `collapseDisplayText`; length is left to CSS at the render boundary,
+ * matching how server labels are handled.
+ */
+export function resolveResourceItemDisplay(item: {
+  name: string;
+  label?: string;
+  organization?: string;
+  version?: string;
+}): ResourceItemDisplay {
+  const label = collapseDisplayText(item.label ?? "");
+  const name = collapseDisplayText(item.name);
+  const organization = item.organization
+    ? collapseDisplayText(item.organization)
+    : "";
+  const version = item.version ? collapseDisplayText(item.version) : "";
+  return {
+    title: label || name,
+    name,
+    secondaryName: label && label !== name ? name : null,
+    organization: organization || null,
+    version: version || null,
+  };
+}

--- a/src/lib/resource-servers.ts
+++ b/src/lib/resource-servers.ts
@@ -122,16 +122,20 @@ export function resolveServerLabel(
 export interface ResourceItemDisplay {
   /**
    * Row title: the collapsed label, falling back to the collapsed name when
-   * the label is absent or collapses to nothing. Never blank when `name` is
-   * non-blank, so a whitespace-only label can't produce an empty-looking row.
+   * the label is absent or collapses to nothing — so a whitespace-only label
+   * can't blank the row. It IS empty only when BOTH collapse to nothing (a
+   * name of only control/format characters and no usable label — hostile,
+   * degenerate input); the row still carries its source badge and meta.
    */
   title: string;
   /** The collapsed name. */
   name: string;
   /**
    * The collapsed name to show as a secondary code chip — only when a
-   * DISTINCT label titles the row, so `label === name` doesn't print twice and
-   * a label-less row doesn't repeat its own title. `null` otherwise.
+   * DISTINCT, non-empty name sits under a label title, so `label === name`
+   * doesn't print twice, a label-less row doesn't repeat its own title, and a
+   * name that collapses to nothing doesn't render an empty chip. `null`
+   * otherwise.
    */
   secondaryName: string | null;
   /** Collapsed organization, or `null` when absent or blank after collapse. */
@@ -164,7 +168,9 @@ export function resolveResourceItemDisplay(item: {
   return {
     title: label || name,
     name,
-    secondaryName: label && label !== name ? name : null,
+    // `name &&` keeps the field strictly `string | null`: a name that collapses
+    // to "" must yield null, not the empty string, even when a label is present.
+    secondaryName: label && name && label !== name ? name : null,
     organization: organization || null,
     version: version || null,
   };

--- a/tests/language-create.test.ts
+++ b/tests/language-create.test.ts
@@ -2,46 +2,52 @@ import { describe, expect, it } from "vitest";
 
 import { classifyLanguageCreate } from "../src/lib/language-create";
 
+const draft = { published: false };
+const published = { published: true };
+
 describe("classifyLanguageCreate", () => {
   it("creates a brand-new slug", () => {
-    expect(classifyLanguageCreate("arabic", ["hindi", "french"], "*")).toEqual({
+    expect(classifyLanguageCreate("arabic", null, "*", "*")).toEqual({
       kind: "create",
     });
   });
 
-  it("confirms when an admin (rights '*') re-creates an existing slug", () => {
-    expect(classifyLanguageCreate("hindi", ["hindi"], "*")).toEqual({
+  it("confirms when an admin (rights '*') re-creates any existing language", () => {
+    expect(classifyLanguageCreate("hindi", published, "*", "*")).toEqual({
       kind: "confirm",
     });
   });
 
-  it("confirms when a shepherd holds an edit right on the existing slug", () => {
+  it("confirms when a shepherd holds edit (and publish) on a published target", () => {
     expect(
-      classifyLanguageCreate("hindi", ["hindi", "french"], ["hindi"])
+      classifyLanguageCreate("hindi", published, ["hindi"], ["hindi"])
     ).toEqual({ kind: "confirm" });
   });
 
-  it("blocks when the slug exists but the caller has no edit right on it", () => {
-    expect(
-      classifyLanguageCreate("hindi", ["hindi", "french"], ["french"])
-    ).toEqual({ kind: "blocked" });
-  });
-
-  it("blocks an existing slug when the caller holds no rights at all", () => {
-    expect(classifyLanguageCreate("hindi", ["hindi"], [])).toEqual({
-      kind: "blocked",
-    });
-  });
-
-  it("still creates a NEW slug even with empty rights (the worker gates the write)", () => {
-    expect(classifyLanguageCreate("arabic", ["hindi"], [])).toEqual({
-      kind: "create",
-    });
-  });
-
-  it("treats undefined rights (legacy full access) like '*' — confirm on collision", () => {
-    expect(classifyLanguageCreate("hindi", ["hindi"], undefined)).toEqual({
+  it("confirms overwriting a DRAFT with only edit rights — no publish needed", () => {
+    expect(classifyLanguageCreate("hindi", draft, ["hindi"], [])).toEqual({
       kind: "confirm",
     });
+  });
+
+  it("blocks (reason edit) when the caller has no edit right on the existing slug", () => {
+    expect(
+      classifyLanguageCreate("hindi", draft, ["french"], ["french"])
+    ).toEqual({ kind: "blocked", reason: "edit" });
+  });
+
+  it("blocks (reason publish) an edit-only caller overwriting a PUBLISHED language", () => {
+    // Re-scaffolding a published row sends published:false, which the worker
+    // treats as a publish-verb change — so edit alone would 403.
+    expect(classifyLanguageCreate("hindi", published, ["hindi"], [])).toEqual({
+      kind: "blocked",
+      reason: "publish",
+    });
+  });
+
+  it("treats undefined rights (legacy full access) like '*' — confirm on a published collision", () => {
+    expect(
+      classifyLanguageCreate("hindi", published, undefined, undefined)
+    ).toEqual({ kind: "confirm" });
   });
 });

--- a/tests/language-create.test.ts
+++ b/tests/language-create.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyLanguageCreate } from "../src/lib/language-create";
+
+describe("classifyLanguageCreate", () => {
+  it("creates a brand-new slug", () => {
+    expect(classifyLanguageCreate("arabic", ["hindi", "french"], "*")).toEqual({
+      kind: "create",
+    });
+  });
+
+  it("confirms when an admin (rights '*') re-creates an existing slug", () => {
+    expect(classifyLanguageCreate("hindi", ["hindi"], "*")).toEqual({
+      kind: "confirm",
+    });
+  });
+
+  it("confirms when a shepherd holds an edit right on the existing slug", () => {
+    expect(
+      classifyLanguageCreate("hindi", ["hindi", "french"], ["hindi"])
+    ).toEqual({ kind: "confirm" });
+  });
+
+  it("blocks when the slug exists but the caller has no edit right on it", () => {
+    expect(
+      classifyLanguageCreate("hindi", ["hindi", "french"], ["french"])
+    ).toEqual({ kind: "blocked" });
+  });
+
+  it("blocks an existing slug when the caller holds no rights at all", () => {
+    expect(classifyLanguageCreate("hindi", ["hindi"], [])).toEqual({
+      kind: "blocked",
+    });
+  });
+
+  it("still creates a NEW slug even with empty rights (the worker gates the write)", () => {
+    expect(classifyLanguageCreate("arabic", ["hindi"], [])).toEqual({
+      kind: "create",
+    });
+  });
+
+  it("treats undefined rights (legacy full access) like '*' — confirm on collision", () => {
+    expect(classifyLanguageCreate("hindi", ["hindi"], undefined)).toEqual({
+      kind: "confirm",
+    });
+  });
+});

--- a/tests/resource-servers.test.ts
+++ b/tests/resource-servers.test.ts
@@ -200,4 +200,23 @@ describe("resolveResourceItemDisplay", () => {
       })
     ).toMatchObject({ organization: null, version: null });
   });
+
+  it("keeps secondaryName strictly null (never '') when the name collapses away under a label", () => {
+    const display = resolveResourceItemDisplay({
+      name: "\u200b\u200b",
+      label: "Genesis",
+    });
+
+    expect(display.title).toBe("Genesis");
+    expect(display.secondaryName).toBeNull();
+  });
+
+  it("yields an empty title only when both name and label collapse to nothing", () => {
+    // Degenerate hostile input: a name of only zero-width characters, no label.
+    // Documents the edge — the row still renders (badge + meta), just untitled.
+    const display = resolveResourceItemDisplay({ name: "\u200b\u200b" });
+
+    expect(display.title).toBe("");
+    expect(display.secondaryName).toBeNull();
+  });
 });

--- a/tests/resource-servers.test.ts
+++ b/tests/resource-servers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildServerNameMap,
+  resolveResourceItemDisplay,
   resolveServerLabel,
   resolveServerName,
 } from "../src/lib/resource-servers";
@@ -54,7 +55,7 @@ describe("buildServerNameMap", () => {
     // and must not smuggle invisible structure into a chip.
     const names = buildServerNameMap([
       server("multiline", "Translation\nHelps\r\n  MCP"),
-      server("zerowidth", "Aqui​fer‮"),
+      server("zerowidth", "Aqui\u200bfer‮"),
     ]);
 
     expect(names.get("multiline")).toBe("Translation Helps MCP");
@@ -131,5 +132,72 @@ describe("resolveServerLabel", () => {
     );
 
     expect(label.full).toBe("Aquifer MCP");
+  });
+});
+
+describe("resolveResourceItemDisplay", () => {
+  it("titles the row with the label and keeps the name as a secondary chip", () => {
+    expect(
+      resolveResourceItemDisplay({ name: "gen", label: "Genesis" })
+    ).toEqual({
+      title: "Genesis",
+      name: "gen",
+      secondaryName: "gen",
+      organization: null,
+      version: null,
+    });
+  });
+
+  it("falls back to the name when the label is absent", () => {
+    expect(resolveResourceItemDisplay({ name: "Genesis" })).toEqual({
+      title: "Genesis",
+      name: "Genesis",
+      secondaryName: null,
+      organization: null,
+      version: null,
+    });
+  });
+
+  it("falls back to the name when the label collapses to nothing", () => {
+    expect(
+      resolveResourceItemDisplay({ name: "Genesis", label: "  \u200b " })
+    ).toEqual({
+      title: "Genesis",
+      name: "Genesis",
+      secondaryName: null,
+      organization: null,
+      version: null,
+    });
+  });
+
+  it("drops the secondary chip when the label equals the name", () => {
+    expect(
+      resolveResourceItemDisplay({ name: "Genesis", label: "Genesis" })
+        .secondaryName
+    ).toBeNull();
+  });
+
+  it("collapses control and format characters in every field", () => {
+    const display = resolveResourceItemDisplay({
+      name: "ge\tn",
+      label: "Gen\ne\u200bsis",
+      organization: "unfolding\r\nWord",
+      version: "1\t.0",
+    });
+
+    expect(display.title).toBe("Gen e sis");
+    expect(display.name).toBe("ge n");
+    expect(display.organization).toBe("unfolding Word");
+    expect(display.version).toBe("1 .0");
+  });
+
+  it("nulls organization and version when absent or blank after collapse", () => {
+    expect(
+      resolveResourceItemDisplay({
+        name: "x",
+        organization: "   ",
+        version: "",
+      })
+    ).toMatchObject({ organization: null, version: null });
   });
 });

--- a/tests/use-languages-cache.test.ts
+++ b/tests/use-languages-cache.test.ts
@@ -226,25 +226,44 @@ describe("languageSaveMutationOptions — org travels in the variables", () => {
     }
   });
 
-  it("seeds the saved row's cache and invalidates the collection", async () => {
+  it("seeds the detail cache, upserts the collection, and cancels both GETs", async () => {
     // Seeding (not invalidating) the detail query is what stops a later select
     // of an overwritten language from painting its pre-save document from an
-    // inactive-but-stale cache (grok rd-3).
+    // inactive-but-stale cache (grok rd-3). The collection upsert makes a
+    // just-created slug immediately `existing` (grok rd-5), and BOTH GETs are
+    // cancelled first so an in-flight fetch can't settle over the writes (grok
+    // rd-6).
     const qc = makeClient();
+    qc.setQueryData<OrgLanguages>(languageQueryKeys.languages(null), {
+      languages: [],
+    });
     const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
-    const setSpy = vi.spyOn(qc, "setQueryData");
+    const cancelSpy = vi.spyOn(qc, "cancelQueries");
     const saved: Language = { name: "hindi", document: "x", published: false };
     await languageSaveMutationOptions(qc).onSuccess(saved, {
       name: "hindi",
       body: { document: "x" },
       org: null,
     });
+    // Detail seeded, collection upserted with the new row.
+    expect(qc.getQueryData(languageQueryKeys.language("hindi", null))).toEqual(
+      saved
+    );
+    expect(
+      qc.getQueryData<OrgLanguages>(languageQueryKeys.languages(null))
+        ?.languages
+    ).toContainEqual(saved);
+    // Both GETs cancelled before the writes.
+    const cancelledKeys = cancelSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey
+    );
+    expect(cancelledKeys).toContainEqual(
+      languageQueryKeys.language("hindi", null)
+    );
+    expect(cancelledKeys).toContainEqual(languageQueryKeys.languages(null));
+    // Collection still invalidated for eventual reconciliation.
     expect(invalidatedKeys(invalidateSpy)).toContainEqual(
       languageQueryKeys.languages(null)
-    );
-    expect(setSpy).toHaveBeenCalledWith(
-      languageQueryKeys.language("hindi", null),
-      saved
     );
   });
 });

--- a/tests/use-languages-cache.test.ts
+++ b/tests/use-languages-cache.test.ts
@@ -9,7 +9,11 @@ import {
   languageSaveMutationOptions,
   orgDefaultMutationOptions,
 } from "../src/hooks/use-languages";
-import type { OrgDefaultLanguage, OrgLanguages } from "../src/types/language";
+import type {
+  Language,
+  OrgDefaultLanguage,
+  OrgLanguages,
+} from "../src/types/language";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -200,30 +204,47 @@ describe("languageSaveMutationOptions — org travels in the variables", () => {
     // the pre-save document — a save that looks lost, and a stale base for
     // the next edit to overwrite it from.
     const qc = makeClient();
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    languageSaveMutationOptions(qc).onSuccess(undefined, {
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const setSpy = vi.spyOn(qc, "setQueryData");
+    const cancelSpy = vi.spyOn(qc, "cancelQueries");
+    const saved: Language = { name: "hindi", document: "x", published: false };
+    languageSaveMutationOptions(qc).onSuccess(saved, {
       name: "hindi",
       body: { document: "x" },
       org: "alpha",
     });
-    for (const key of invalidatedKeys(spy)) {
+    for (const key of invalidatedKeys(invalidateSpy)) {
       expect(key).toContain("alpha");
+    }
+    // The seed and the cancel are pinned to the mutate-time org too.
+    expect(setSpy).toHaveBeenCalledWith(
+      languageQueryKeys.language("hindi", "alpha"),
+      saved
+    );
+    for (const call of cancelSpy.mock.calls) {
+      expect((call[0] as { queryKey: unknown[] }).queryKey).toContain("alpha");
     }
   });
 
-  it("refreshes both the collection and the saved row's own entry", () => {
+  it("seeds the saved row's cache and invalidates the collection", () => {
+    // Seeding (not invalidating) the detail query is what stops a later select
+    // of an overwritten language from painting its pre-save document from an
+    // inactive-but-stale cache (grok rd-3).
     const qc = makeClient();
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    languageSaveMutationOptions(qc).onSuccess(undefined, {
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const setSpy = vi.spyOn(qc, "setQueryData");
+    const saved: Language = { name: "hindi", document: "x", published: false };
+    languageSaveMutationOptions(qc).onSuccess(saved, {
       name: "hindi",
       body: { document: "x" },
       org: null,
     });
-    expect(invalidatedKeys(spy)).toContainEqual(
+    expect(invalidatedKeys(invalidateSpy)).toContainEqual(
       languageQueryKeys.languages(null)
     );
-    expect(invalidatedKeys(spy)).toContainEqual(
-      languageQueryKeys.language("hindi", null)
+    expect(setSpy).toHaveBeenCalledWith(
+      languageQueryKeys.language("hindi", null),
+      saved
     );
   });
 });

--- a/tests/use-languages-cache.test.ts
+++ b/tests/use-languages-cache.test.ts
@@ -197,7 +197,7 @@ describe("languageSaveMutationOptions — org travels in the variables", () => {
     );
   });
 
-  it("invalidates the mutate-time org after the ambient key moved on", () => {
+  it("invalidates the mutate-time org after the ambient key moved on", async () => {
     // Reachable, not theoretical: the org-context dialog offers "Discard
     // and switch" WHILE a save is in flight. With a closure-read key, org
     // A's completed save would refresh org B and leave A's cache holding
@@ -208,7 +208,7 @@ describe("languageSaveMutationOptions — org travels in the variables", () => {
     const setSpy = vi.spyOn(qc, "setQueryData");
     const cancelSpy = vi.spyOn(qc, "cancelQueries");
     const saved: Language = { name: "hindi", document: "x", published: false };
-    languageSaveMutationOptions(qc).onSuccess(saved, {
+    await languageSaveMutationOptions(qc).onSuccess(saved, {
       name: "hindi",
       body: { document: "x" },
       org: "alpha",
@@ -226,7 +226,7 @@ describe("languageSaveMutationOptions — org travels in the variables", () => {
     }
   });
 
-  it("seeds the saved row's cache and invalidates the collection", () => {
+  it("seeds the saved row's cache and invalidates the collection", async () => {
     // Seeding (not invalidating) the detail query is what stops a later select
     // of an overwritten language from painting its pre-save document from an
     // inactive-but-stale cache (grok rd-3).
@@ -234,7 +234,7 @@ describe("languageSaveMutationOptions — org travels in the variables", () => {
     const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
     const setSpy = vi.spyOn(qc, "setQueryData");
     const saved: Language = { name: "hindi", document: "x", published: false };
-    languageSaveMutationOptions(qc).onSuccess(saved, {
+    await languageSaveMutationOptions(qc).onSuccess(saved, {
       name: "hindi",
       body: { document: "x" },
       org: null,


### PR DESCRIPTION
Two self-contained portal fixes, both surfaced during PR #288/#289 review cycles.

## #293 — Confirm before a create overwrites an existing language

`handleCreate` on the Languages page PUT a blank scaffold (`published: false`) for whatever slug was typed. #272 removed the last collision guard, so typing a slug that **already existed** fell straight through — **silently overwriting that language's tuning document with the empty scaffold and unpublishing it**, no confirmation, no undo. For a published language this dropped end-user tuning until someone noticed.

- New pure `classifyLanguageCreate(slug, existingNames, editRights)` → `create` | `blocked` | `confirm`.
  - **create** — free slug.
  - **blocked** — slug exists but the caller holds no edit right on it (the worker would 403 the write, so we refuse up front with a helpful message instead of a confusing failed overwrite).
  - **confirm** — slug exists and the caller may overwrite it → destructive `AlertDialog` ("Replace *slug*? … replaces its document with a blank scaffold and unpublishes it"). Preserves the deliberate re-scaffold flow behind an explicit step.
- `editRights` (already trump-aware — `"*"` for admins/cross-org super-admins; `undefined` = legacy full access) is threaded from the page. #249 lists the whole catalog, so the selector's language list is authoritative for "taken".
- Plain `Button`, not `AlertDialogAction`, matching the file's other destructive dialogs (#102).

## #294 — Harden the last raw untrusted MCP text on the resources page

#289 hardened server-name attribution via `collapseDisplayText`, but a few MCP-relayed fields still rendered raw: the resource row's `label` / `name` / `organization` / `version`, and the `ServerChip` `error` tooltip (the map path was already collapsed at the layout source; this DOM tooltip wasn't). Same class as `serverName` — React-escaped, so the hazard is layout/legibility (row-spanning newlines, zero-width/bidi characters), not injection.

- New `resolveResourceItemDisplay` collapses a row's untrusted fields to single safe lines, with a name fallback (whitespace-only label can't yield a blank title) and a secondary-name chip only when a *distinct* label titles the row.
- Load-bearing title gets a CSS width bound with full text kept in the DOM (title tooltip), mirroring the server-badge treatment. `ServerChip` tooltip now routes `server.error` through `collapseDisplayText`.
- **Accepted (per the issue's "decide here or close" note), not changed:** two servers sharing a display name still render identical badges (id is sr-only/hover-only, a deliberate a11y tradeoff); the per-subject header badge strip can squeeze subject labels on narrow desktops. Both cosmetic, out of the hardening core.

## Verification

- `npm run typecheck` ✓ · `npm run lint` (zero warnings) ✓ · `npm run build` ✓
- Tests ✓ — new `tests/language-create.test.ts` (create/blocked/confirm incl. admin `*` and legacy-undefined) and new `resolveResourceItemDisplay` cases in `tests/resource-servers.test.ts` (label/name fallback, equal-label dedupe, control/format collapse across every field, blank→null).

Closes #293
Closes #294
