### PR TITLE
fix(#303): unify languages-editor mutation-ownership gate (Part 1)

### DIFF
--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/language-error-surface";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
+  mayApplyMutationResult,
   stillOwnsSelection,
   type SelectionTarget,
 } from "@/lib/mutation-ownership";
@@ -174,6 +175,20 @@ export function LanguagesPage() {
     undefined
   );
 
+  // A token bumped on every (org, language) change — including RETURNING to a
+  // pair we were just on. Mutation callbacks capture it at call time and
+  // re-check it at settle (`mayApplyMutationResult`): the product lets the user
+  // leave and come back while a PUT is in flight, and on the return the locals
+  // are re-anchored to the reloaded cache, so a settling mutation must NOT
+  // stamp its result even though the (org, language) pair matches again — doing
+  // so would let the next autosave PUT the stale doc over the good save (grok
+  // review P2). Delete stays on bare pair-equality (re-selecting the just-
+  // deleted row should still clear).
+  const selectionGenRef = useRef(0);
+  useEffect(() => {
+    selectionGenRef.current += 1;
+  }, [contextOrg, selectedLanguage]);
+
   // Re-sync from the server *only* when the selection changes — never
   // post-save. The ref tracks the language whose contents we last loaded
   // into local state, so we don't repeatedly overwrite the draft each time
@@ -241,6 +256,10 @@ export function LanguagesPage() {
         org: contextOrg,
         language: selectedLanguage,
       };
+      // Captured with the target: a leave-and-return to the same pair while
+      // this PUT is in flight moves the generation, so the settle callbacks
+      // refuse to stamp even though the pair matches again.
+      const targetGen = selectionGenRef.current;
       saveLanguage.mutate(
         {
           name: selectedLanguage,
@@ -257,12 +276,28 @@ export function LanguagesPage() {
         },
         {
           onSuccess: () => {
-            if (!stillOwnsSelection(target, liveSelectionTarget())) return;
+            if (
+              !mayApplyMutationResult(
+                target,
+                liveSelectionTarget(),
+                targetGen,
+                selectionGenRef.current
+              )
+            )
+              return;
             setLastSyncedDoc(doc);
             setLastFailedDoc(null);
           },
           onError: () => {
-            if (!stillOwnsSelection(target, liveSelectionTarget())) return;
+            if (
+              !mayApplyMutationResult(
+                target,
+                liveSelectionTarget(),
+                targetGen,
+                selectionGenRef.current
+              )
+            )
+              return;
             setLastFailedDoc(doc);
           },
         }
@@ -505,18 +540,30 @@ export function LanguagesPage() {
       // await + render inline errors (#102).
       const isSelected = name === selectedLanguage;
       const doc = isSelected ? draft : (languageQuery.data?.document ?? "");
+      // Capture the target AND the generation BEFORE the await, same as
+      // performSave — `name`/`contextOrg` are call-time values, and the gen
+      // pins "this exact visit" so a leave-and-return to the same pair mid-PUT
+      // doesn't stamp (grok review P2 / the PR's own capture-at-call rule).
+      const target: SelectionTarget = { org: contextOrg, language: name };
+      const targetGen = selectionGenRef.current;
       await saveLanguage.mutateAsync({
         name,
         org: contextOrg,
         body: { label: lastSyncedLabel, document: doc, published },
       });
       // Only bookkeep locals if we're STILL on the (org, language) this toggle
-      // targeted — a discard-and-switch, or an org switch to a namespace that
-      // has the same slug, would otherwise stamp this row's published flag and
-      // document onto the newly selected language, which the next autosave then
-      // PUTs (grok rd-6). Same unified gate as performSave (#303).
-      const target: SelectionTarget = { org: contextOrg, language: name };
-      if (stillOwnsSelection(target, liveSelectionTarget())) {
+      // targeted AND haven't left-and-returned since — a discard-and-switch, an
+      // org switch to a namespace with the same slug, or a re-entry would
+      // otherwise stamp this row's published flag and document onto the current
+      // selection, which the next autosave then PUTs (grok rd-6 + re-entry P2).
+      if (
+        mayApplyMutationResult(
+          target,
+          liveSelectionTarget(),
+          targetGen,
+          selectionGenRef.current
+        )
+      ) {
         setLastSyncedDoc(doc);
         setLastSyncedPublished(published);
       }

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -16,6 +16,10 @@ import {
 } from "@/lib/language-error-surface";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
+  stillOwnsSelection,
+  type SelectionTarget,
+} from "@/lib/mutation-ownership";
+import {
   effectiveLanguageEditRights,
   effectiveLanguagePublishRights,
   hasAdminPowers,
@@ -56,6 +60,15 @@ import { OrgContextSelector } from "@/components/org-context-selector";
 import { PageHeader } from "@/components/page-header";
 
 const AUTO_SAVE_DEBOUNCE_MS = 800;
+
+// The live (org, language) selection, read from the store at the moment a
+// mutation settles. Module-scope so it needs no dependency threading, and
+// reads `getState()` (not the render-time closure) so it reflects any
+// discard-and-switch or org switch that happened during the in-flight write.
+function liveSelectionTarget(): SelectionTarget {
+  const s = useUiStore.getState();
+  return { org: s.contextOrg, language: s.selectedLanguage };
+}
 
 export function LanguagesPage() {
   const user = useAuthStore((s) => s.user);
@@ -219,14 +232,18 @@ export function LanguagesPage() {
   const performSave = useCallback(
     (doc: string) => {
       if (!selectedLanguage) return;
-      // The row this save targets, pinned at call time. A save that settles
-      // after a discard-and-switch must not retarget the NEW selection's
-      // shared bookkeeping — check the live selection in the callbacks before
-      // touching lastSyncedDoc/lastFailedDoc (grok rd-5).
-      const target = selectedLanguage;
+      // The (org, language) this save targets, pinned at call time. A save
+      // that settles after a discard-and-switch — or an org switch — must not
+      // retarget the NEW selection's shared bookkeeping, so both callbacks
+      // gate on `stillOwnsSelection` before touching lastSyncedDoc/
+      // lastFailedDoc (grok rd-5; #303 unifies + adds the org dimension).
+      const target: SelectionTarget = {
+        org: contextOrg,
+        language: selectedLanguage,
+      };
       saveLanguage.mutate(
         {
-          name: target,
+          name: selectedLanguage,
           // Org pinned at call time — see handleSetDefault.
           org: contextOrg,
           body: {
@@ -240,12 +257,12 @@ export function LanguagesPage() {
         },
         {
           onSuccess: () => {
-            if (useUiStore.getState().selectedLanguage !== target) return;
+            if (!stillOwnsSelection(target, liveSelectionTarget())) return;
             setLastSyncedDoc(doc);
             setLastFailedDoc(null);
           },
           onError: () => {
-            if (useUiStore.getState().selectedLanguage !== target) return;
+            if (!stillOwnsSelection(target, liveSelectionTarget())) return;
             setLastFailedDoc(doc);
           },
         }
@@ -493,11 +510,13 @@ export function LanguagesPage() {
         org: contextOrg,
         body: { label: lastSyncedLabel, document: doc, published },
       });
-      // Only bookkeep locals if we're STILL on the row this toggle targeted —
-      // a discard-and-switch during the await would otherwise stamp this row's
-      // published flag and document onto the newly selected language, which the
-      // next autosave then PUTs (grok rd-6). Same live check as performSave.
-      if (useUiStore.getState().selectedLanguage === name) {
+      // Only bookkeep locals if we're STILL on the (org, language) this toggle
+      // targeted — a discard-and-switch, or an org switch to a namespace that
+      // has the same slug, would otherwise stamp this row's published flag and
+      // document onto the newly selected language, which the next autosave then
+      // PUTs (grok rd-6). Same unified gate as performSave (#303).
+      const target: SelectionTarget = { org: contextOrg, language: name };
+      if (stillOwnsSelection(target, liveSelectionTarget())) {
         setLastSyncedDoc(doc);
         setLastSyncedPublished(published);
       }
@@ -559,10 +578,18 @@ export function LanguagesPage() {
   const handleDeleteLanguage = useCallback(
     async (name: string) => {
       // Org pinned at click time — same reason as handleSetDefault.
+      const target: SelectionTarget = { org: contextOrg, language: name };
       await deleteLanguage.mutateAsync({ name, org: contextOrg });
-      if (name === selectedLanguage) setSelectedLanguage(null);
+      // Clear the selection ONLY if the deleted row is still the live
+      // selection. #302 hardened the other mutation callbacks but left this
+      // one reading the click-time closure `selectedLanguage`: a delete of A
+      // that settled after the user switched to B (or switched org) would then
+      // yank the selection off B. Read live, gated on (org, language) (#303).
+      if (stillOwnsSelection(target, liveSelectionTarget())) {
+        setSelectedLanguage(null);
+      }
     },
-    [contextOrg, deleteLanguage, selectedLanguage, setSelectedLanguage]
+    [contextOrg, deleteLanguage, setSelectedLanguage]
   );
 
   const handleJumpToLine = useCallback((line: number) => {

--- a/src/app/pages/languages.tsx
+++ b/src/app/pages/languages.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/lib/language-error-surface";
 import { LanguageForbiddenError } from "@/lib/languages-api";
 import {
-  mayApplyMutationResult,
   stillOwnsSelection,
   type SelectionTarget,
 } from "@/lib/mutation-ownership";
@@ -175,20 +174,6 @@ export function LanguagesPage() {
     undefined
   );
 
-  // A token bumped on every (org, language) change — including RETURNING to a
-  // pair we were just on. Mutation callbacks capture it at call time and
-  // re-check it at settle (`mayApplyMutationResult`): the product lets the user
-  // leave and come back while a PUT is in flight, and on the return the locals
-  // are re-anchored to the reloaded cache, so a settling mutation must NOT
-  // stamp its result even though the (org, language) pair matches again — doing
-  // so would let the next autosave PUT the stale doc over the good save (grok
-  // review P2). Delete stays on bare pair-equality (re-selecting the just-
-  // deleted row should still clear).
-  const selectionGenRef = useRef(0);
-  useEffect(() => {
-    selectionGenRef.current += 1;
-  }, [contextOrg, selectedLanguage]);
-
   // Re-sync from the server *only* when the selection changes — never
   // post-save. The ref tracks the language whose contents we last loaded
   // into local state, so we don't repeatedly overwrite the draft each time
@@ -256,10 +241,6 @@ export function LanguagesPage() {
         org: contextOrg,
         language: selectedLanguage,
       };
-      // Captured with the target: a leave-and-return to the same pair while
-      // this PUT is in flight moves the generation, so the settle callbacks
-      // refuse to stamp even though the pair matches again.
-      const targetGen = selectionGenRef.current;
       saveLanguage.mutate(
         {
           name: selectedLanguage,
@@ -276,28 +257,12 @@ export function LanguagesPage() {
         },
         {
           onSuccess: () => {
-            if (
-              !mayApplyMutationResult(
-                target,
-                liveSelectionTarget(),
-                targetGen,
-                selectionGenRef.current
-              )
-            )
-              return;
+            if (!stillOwnsSelection(target, liveSelectionTarget())) return;
             setLastSyncedDoc(doc);
             setLastFailedDoc(null);
           },
           onError: () => {
-            if (
-              !mayApplyMutationResult(
-                target,
-                liveSelectionTarget(),
-                targetGen,
-                selectionGenRef.current
-              )
-            )
-              return;
+            if (!stillOwnsSelection(target, liveSelectionTarget())) return;
             setLastFailedDoc(doc);
           },
         }
@@ -540,30 +505,18 @@ export function LanguagesPage() {
       // await + render inline errors (#102).
       const isSelected = name === selectedLanguage;
       const doc = isSelected ? draft : (languageQuery.data?.document ?? "");
-      // Capture the target AND the generation BEFORE the await, same as
-      // performSave — `name`/`contextOrg` are call-time values, and the gen
-      // pins "this exact visit" so a leave-and-return to the same pair mid-PUT
-      // doesn't stamp (grok review P2 / the PR's own capture-at-call rule).
-      const target: SelectionTarget = { org: contextOrg, language: name };
-      const targetGen = selectionGenRef.current;
       await saveLanguage.mutateAsync({
         name,
         org: contextOrg,
         body: { label: lastSyncedLabel, document: doc, published },
       });
       // Only bookkeep locals if we're STILL on the (org, language) this toggle
-      // targeted AND haven't left-and-returned since — a discard-and-switch, an
-      // org switch to a namespace with the same slug, or a re-entry would
-      // otherwise stamp this row's published flag and document onto the current
-      // selection, which the next autosave then PUTs (grok rd-6 + re-entry P2).
-      if (
-        mayApplyMutationResult(
-          target,
-          liveSelectionTarget(),
-          targetGen,
-          selectionGenRef.current
-        )
-      ) {
+      // targeted — a discard-and-switch, or an org switch to a namespace that
+      // has the same slug, would otherwise stamp this row's published flag and
+      // document onto the newly selected language, which the next autosave then
+      // PUTs (grok rd-6). Same unified gate as performSave (#303).
+      const target: SelectionTarget = { org: contextOrg, language: name };
+      if (stillOwnsSelection(target, liveSelectionTarget())) {
         setLastSyncedDoc(doc);
         setLastSyncedPublished(published);
       }

--- a/src/lib/mutation-ownership.ts
+++ b/src/lib/mutation-ownership.ts
@@ -1,0 +1,50 @@
+// Ownership gate for the Languages editor's mutation callbacks, lifted out of
+// the page so the rule is stated once and tested directly (same shape as
+// `autosave-gate`, `context-org-guard`, and `language-bootstrap-gate`).
+//
+// The editor keeps per-selection local bookkeeping — `draft`, `lastSyncedDoc`,
+// `lastSyncedPublished`, `lastSyncedLabel`, `syncedName` — that must belong to
+// the CURRENT selection. A selection is not a language name alone: the same
+// slug (`en`) can exist in more than one org, so the identity of "what the
+// editor is showing" is the pair (org, language).
+//
+// Every mutation callback captures its target at call time but applies its
+// local bookkeeping AFTER an `await`/settle. In that window the user can:
+//   - switch languages (the switch dialog offers "discard and switch" even
+//     while a save is in flight),
+//   - switch org context (super-admins, via the OrgContextSelector), or
+//   - both.
+// If the callback then stamps its result without re-checking, it writes one
+// row's document / published flag / label onto another row's locals, which the
+// next autosave dutifully PUTs — a silent cross-row (or cross-org) data loss.
+//
+// PR #302 fixed every instance it found with an ad-hoc, per-function check
+// (`useUiStore.getState().selectedLanguage === name`, `.contextOrg !== org`).
+// Those checks were LANGUAGE-ONLY at the bookkeeping sites and were missing
+// entirely on `handleDeleteLanguage` (it read the click-time closure). This
+// gate replaces them with one uniform (org + language) comparison so no site
+// can drift, and closes the org dimension the ad-hoc checks left open.
+
+export interface SelectionTarget {
+  /** The org context the mutation was issued under, pinned at call time. */
+  org: string | null;
+  /** The language the mutation's bookkeeping belongs to. */
+  language: string | null;
+}
+
+/**
+ * Whether a settled mutation still owns the selection it targeted — i.e. the
+ * live selection is the SAME (org, language) pair the mutation captured when it
+ * started. Only then is it safe to apply the mutation's local bookkeeping (or,
+ * for delete, to clear the selection it removed).
+ *
+ * A `null` language is a legitimate target value (no selection) and compares
+ * like any other: `stillOwnsSelection({org, language: null}, {org, language:
+ * null})` is true.
+ */
+export function stillOwnsSelection(
+  target: SelectionTarget,
+  live: SelectionTarget
+): boolean {
+  return target.org === live.org && target.language === live.language;
+}

--- a/src/lib/mutation-ownership.ts
+++ b/src/lib/mutation-ownership.ts
@@ -48,35 +48,3 @@ export function stillOwnsSelection(
 ): boolean {
   return target.org === live.org && target.language === live.language;
 }
-
-/**
- * Whether a settled mutation may STAMP its result onto the editor's
- * per-selection local bookkeeping.
- *
- * Pair-equality (`stillOwnsSelection`) is necessary but NOT sufficient. The
- * editor tears down and rebuilds its locals (`draft`, `lastSyncedDoc`, …) on
- * every selection change — including LEAVING and RETURNING to the same (org,
- * language). The product allows leaving and coming back while a PUT is still
- * in flight (each hop only prompts "Discard and switch"); on the return the
- * locals are re-anchored to the reloaded cache. A mutation that then settles
- * still finds a matching pair and would stamp its (now superseded) result,
- * which the next autosave PUTs back over the good save — silent data loss
- * (grok review of #303 Part 1).
- *
- * A generation counter that the page bumps on every (org, language) change
- * distinguishes "never left" from "left and returned". The mutation captures
- * the generation at call time; only if it is unchanged at settle, AND the pair
- * still matches, is the stamp safe.
- *
- * (Delete's "clear the removed selection" decision deliberately does NOT use
- * this — re-selecting the just-deleted row should still clear, even across a
- * generation bump — so it stays on bare `stillOwnsSelection`.)
- */
-export function mayApplyMutationResult(
-  target: SelectionTarget,
-  live: SelectionTarget,
-  capturedGen: number,
-  liveGen: number
-): boolean {
-  return stillOwnsSelection(target, live) && capturedGen === liveGen;
-}

--- a/src/lib/mutation-ownership.ts
+++ b/src/lib/mutation-ownership.ts
@@ -48,3 +48,35 @@ export function stillOwnsSelection(
 ): boolean {
   return target.org === live.org && target.language === live.language;
 }
+
+/**
+ * Whether a settled mutation may STAMP its result onto the editor's
+ * per-selection local bookkeeping.
+ *
+ * Pair-equality (`stillOwnsSelection`) is necessary but NOT sufficient. The
+ * editor tears down and rebuilds its locals (`draft`, `lastSyncedDoc`, …) on
+ * every selection change — including LEAVING and RETURNING to the same (org,
+ * language). The product allows leaving and coming back while a PUT is still
+ * in flight (each hop only prompts "Discard and switch"); on the return the
+ * locals are re-anchored to the reloaded cache. A mutation that then settles
+ * still finds a matching pair and would stamp its (now superseded) result,
+ * which the next autosave PUTs back over the good save — silent data loss
+ * (grok review of #303 Part 1).
+ *
+ * A generation counter that the page bumps on every (org, language) change
+ * distinguishes "never left" from "left and returned". The mutation captures
+ * the generation at call time; only if it is unchanged at settle, AND the pair
+ * still matches, is the stamp safe.
+ *
+ * (Delete's "clear the removed selection" decision deliberately does NOT use
+ * this — re-selecting the just-deleted row should still clear, even across a
+ * generation bump — so it stays on bare `stillOwnsSelection`.)
+ */
+export function mayApplyMutationResult(
+  target: SelectionTarget,
+  live: SelectionTarget,
+  capturedGen: number,
+  liveGen: number
+): boolean {
+  return stillOwnsSelection(target, live) && capturedGen === liveGen;
+}

--- a/tests/mutation-ownership.test.ts
+++ b/tests/mutation-ownership.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { stillOwnsSelection } from "../src/lib/mutation-ownership";
+
+describe("stillOwnsSelection", () => {
+  it("owns the selection when org and language both match", () => {
+    expect(
+      stillOwnsSelection(
+        { org: null, language: "en" },
+        { org: null, language: "en" }
+      )
+    ).toBe(true);
+  });
+
+  it("does not own when the language switched during the mutation", () => {
+    expect(
+      stillOwnsSelection(
+        { org: null, language: "en" },
+        { org: null, language: "fr" }
+      )
+    ).toBe(false);
+  });
+
+  it("does not own when the org switched but the language slug is the same", () => {
+    // The load-bearing case: `en` exists in both orgs, so a language-only
+    // check would wrongly report ownership and stamp org A's document onto
+    // org B's row. The org dimension is what makes this false.
+    expect(
+      stillOwnsSelection(
+        { org: null, language: "en" },
+        { org: "partner-org", language: "en" }
+      )
+    ).toBe(false);
+  });
+
+  it("does not own when both org and language switched", () => {
+    expect(
+      stillOwnsSelection(
+        { org: null, language: "en" },
+        { org: "partner-org", language: "fr" }
+      )
+    ).toBe(false);
+  });
+
+  it("treats a null language as a first-class value that matches null", () => {
+    expect(
+      stillOwnsSelection(
+        { org: "partner-org", language: null },
+        { org: "partner-org", language: null }
+      )
+    ).toBe(true);
+  });
+
+  it("does not own when the target had no language but a selection now exists", () => {
+    expect(
+      stillOwnsSelection(
+        { org: null, language: null },
+        { org: null, language: "en" }
+      )
+    ).toBe(false);
+  });
+
+  it("distinguishes a null org (home) from a named org", () => {
+    expect(
+      stillOwnsSelection(
+        { org: null, language: "en" },
+        { org: "unfoldingWord", language: "en" }
+      )
+    ).toBe(false);
+  });
+});

--- a/tests/mutation-ownership.test.ts
+++ b/tests/mutation-ownership.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  mayApplyMutationResult,
-  type SelectionTarget,
-  stillOwnsSelection,
-} from "../src/lib/mutation-ownership";
+import { stillOwnsSelection } from "../src/lib/mutation-ownership";
 
 describe("stillOwnsSelection", () => {
   it("owns the selection when org and language both match", () => {
@@ -83,29 +79,5 @@ describe("stillOwnsSelection", () => {
         { org: "unfoldingWord", language: "en" }
       )
     ).toBe(false);
-  });
-});
-
-describe("mayApplyMutationResult", () => {
-  const en: SelectionTarget = { org: null, language: "en" };
-  const fr: SelectionTarget = { org: null, language: "fr" };
-
-  it("allows the stamp when the pair matches and the generation is unchanged", () => {
-    expect(mayApplyMutationResult(en, en, 3, 3)).toBe(true);
-  });
-
-  it("refuses the stamp on RE-ENTRY: same pair, but the generation moved", () => {
-    // en (gen 3) → fr → back to en (gen 5) while the PUT was in flight. The
-    // pair matches again, but the locals were re-anchored in between, so
-    // stamping would revert the save.
-    expect(mayApplyMutationResult(en, en, 3, 5)).toBe(false);
-  });
-
-  it("refuses the stamp when the pair no longer matches, generation aside", () => {
-    expect(mayApplyMutationResult(en, fr, 3, 3)).toBe(false);
-  });
-
-  it("refuses the stamp when both the pair and the generation differ", () => {
-    expect(mayApplyMutationResult(en, fr, 3, 4)).toBe(false);
   });
 });

--- a/tests/mutation-ownership.test.ts
+++ b/tests/mutation-ownership.test.ts
@@ -60,6 +60,18 @@ describe("stillOwnsSelection", () => {
     ).toBe(false);
   });
 
+  it("does not own when the selection was CLEARED during the mutation", () => {
+    // The load-bearing runtime case: a delete (or discard-and-switch) settles
+    // after the selection was nulled. The mutation must not touch bookkeeping
+    // for a row that is no longer selected.
+    expect(
+      stillOwnsSelection(
+        { org: null, language: "en" },
+        { org: null, language: null }
+      )
+    ).toBe(false);
+  });
+
   it("distinguishes a null org (home) from a named org", () => {
     expect(
       stillOwnsSelection(

--- a/tests/mutation-ownership.test.ts
+++ b/tests/mutation-ownership.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { stillOwnsSelection } from "../src/lib/mutation-ownership";
+import {
+  mayApplyMutationResult,
+  type SelectionTarget,
+  stillOwnsSelection,
+} from "../src/lib/mutation-ownership";
 
 describe("stillOwnsSelection", () => {
   it("owns the selection when org and language both match", () => {
@@ -79,5 +83,29 @@ describe("stillOwnsSelection", () => {
         { org: "unfoldingWord", language: "en" }
       )
     ).toBe(false);
+  });
+});
+
+describe("mayApplyMutationResult", () => {
+  const en: SelectionTarget = { org: null, language: "en" };
+  const fr: SelectionTarget = { org: null, language: "fr" };
+
+  it("allows the stamp when the pair matches and the generation is unchanged", () => {
+    expect(mayApplyMutationResult(en, en, 3, 3)).toBe(true);
+  });
+
+  it("refuses the stamp on RE-ENTRY: same pair, but the generation moved", () => {
+    // en (gen 3) → fr → back to en (gen 5) while the PUT was in flight. The
+    // pair matches again, but the locals were re-anchored in between, so
+    // stamping would revert the save.
+    expect(mayApplyMutationResult(en, en, 3, 5)).toBe(false);
+  });
+
+  it("refuses the stamp when the pair no longer matches, generation aside", () => {
+    expect(mayApplyMutationResult(en, fr, 3, 3)).toBe(false);
+  });
+
+  it("refuses the stamp when both the pair and the generation differ", () => {
+    expect(mayApplyMutationResult(en, fr, 3, 4)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Systematizes the discard-and-switch mutation-safety guards in the Languages editor — **Part 1 of #303** (the portal-fixable half).

## Why

PR #302's multi-round codex + grok review found a **systemic race class**: each mutation callback captures its target at call time but applies per-selection local bookkeeping (`draft`, `lastSyncedDoc`, `lastSyncedPublished`, `lastSyncedLabel`, `syncedName`) *after* an `await`. In that window a language switch, an org switch, or a "discard and switch" can stamp one row's document / published flag onto another row's locals — which the next autosave then PUTs, a silent cross-row (or cross-org) data loss.

#302 fixed every instance it found with an **ad-hoc, per-function** check. Two weaknesses remained:
1. Those checks were **language-only**. A selection's real identity is `(org, language)` — the same slug (`en`) can exist in more than one org — so an org switch onto a namespace with the same slug slipped through.
2. `handleDeleteLanguage` was **never covered**: it read the click-time closure `selectedLanguage`, so a delete settling after a switch to another row (or org) would yank the selection off the row now on screen.

## Changes

- **New pure gate** `src/lib/mutation-ownership.ts` — `stillOwnsSelection(target, live)` answers "does this settled mutation still own the live selection it targeted?" over the `(org, language)` pair. Mirrors the sibling `autosave-gate` / `context-org-guard` / `language-bootstrap-gate` extraction pattern.
- **Applied uniformly** at every post-await bookkeeping site:
  - `performSave` `onSuccess`/`onError`
  - `handleSetPublished`
  - `handleDeleteLanguage` (the uncovered path — now reads live state, gated on `(org, language)`)
- Both `performSave` and `handleSetPublished` previously checked language only; the gate adds the **org dimension**, closing the latent cross-org stamp.
- `handleSetDefault` **audited**: it pins org at call time and stamps no per-selection locals, so it needs no ownership gate — documented in-code, left unchanged.

## Tests

`tests/mutation-ownership.test.ts` — 7 cases, including the load-bearing same-slug **cross-org** case. Full suite **913 pass** (37 files); typecheck, lint (`--max-warnings 0`), and build all clean.

## Scope / follow-up

Part 2 of the tracking issue — the cross-client create-only TOCTOU (another user/tab creates a slug after this client loaded its catalog, so a "create" PUTs over an existing doc) — is **not fixable client-side**. It needs an atomic create-only endpoint (or conditional `If-None-Match` PUT) on **bt-servant-worker**. That half stays open for Ian's lane; a worker issue will be filed and the portal create path wired to it once it exists.

Tracking issue: #303 (this PR is Part 1 only — the issue must stay open for Part 2, so no closing keyword is used here).

## Review notes

- **`handleCreateLanguage` is deliberately not unified onto `stillOwnsSelection`.** Its post-await logic isn't a simple ownership check — it makes a three-way landing decision (bail on org switch / leave the selection put / install-scaffold-and-select), so it can't be a drop-in gate call. It already performs the equivalent live (org + selection) reads that #302 hardened, so it's correct; folding its bespoke branching into the shared gate is out of scope here.

## External review outcome (codex + grok, 2 rounds)

- Both codex rounds + grok round-1 confirmed the **pair-equality core is a strict improvement** over #302 with no regressions (it closes the cross-org same-slug stamp and the `handleDeleteLanguage` closure bug).
- grok's deep lens surfaced a **deeper leave-and-return-during-save race** that pair-equality cannot cover. A first attempt to fix it here with a selection-generation token was **committed then reverted** — the token was keyed to selection *identity* rather than the sync-effect re-anchor, which false-positived and could revert a publish toggle. Per the "converge by deleting the mechanism" discipline (the same that produced #303 from #302), that whole class — re-entry data loss, the create-path bookkeeping site, and the publish-revert nuance — is deferred to a dedicated systematic pass: **#307**.
- Net: this PR ships the clean, reviewed pair-equality systematization; the pre-existing deeper race is tracked in **#307**, not made worse here.
