### PR TITLE
feat(#198): import / re-upload exported mode configs

### DIFF
--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -25,10 +25,7 @@ import {
   reconcileModeFlags,
   type ModeFlags,
 } from "@/lib/mode-flags";
-import {
-  type ParsedModeImport,
-  parseModeImport,
-} from "@/lib/mode-import";
+import { type ParsedModeImport, parseModeImport } from "@/lib/mode-import";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
 import { humanizeModeSlug, slugifyModeName } from "@/lib/mode-slug";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -50,6 +50,7 @@ import {
   useRenameMode,
   useRetireMode,
   useSaveMode,
+  useSeedImportedMode,
 } from "@/hooks/use-prompt-config";
 import type { MarkdownHeading } from "@/types/markdown";
 import type { PromptMode } from "@/types/prompt-override";
@@ -116,6 +117,7 @@ export function ModesPage() {
   const modesQuery = useModes(contextOrg);
   const modeQuery = useMode(selectedMode, contextOrg);
   const saveMode = useSaveMode(contextOrg);
+  const seedImportedMode = useSeedImportedMode();
   const deleteMode = useDeleteMode(contextOrg);
   const renameMode = useRenameMode(contextOrg);
   const cloneMode = useCloneMode(contextOrg);
@@ -545,21 +547,38 @@ export function ModesPage() {
   );
 
   const finishImport = useCallback(
-    (mode: ParsedModeImport, saved: PromptMode) => {
-      // Read the LIVE selection, not the render closure — finishImport runs in
-      // an async continuation (after file.text() + the PUT), during which the
-      // user may have switched modes.
+    async (
+      mode: ParsedModeImport,
+      saved: PromptMode,
+      importOrg: string | null
+    ) => {
+      // Seed the imported mode's OWN per-mode cache with the authoritative PUT
+      // response, org pinned to the org the import targeted. `useSaveMode` only
+      // invalidates (active-refetch), so without this a later select of an
+      // overwritten-but-inactive mode hydrates the pre-import cache and the next
+      // save reverts the import; and the same-mode server-label read would stay
+      // stale until a refetch (grok #306 rd-4). Import-local — never on the
+      // shared save hook.
+      await seedImportedMode(mode.name, importOrg, saved);
+
+      // Read the LIVE (org, selection) — finishImport runs in an async
+      // continuation (after file.text() + the PUT), during which the user may
+      // have switched mode OR org. In-place hydration is safe ONLY when both
+      // still match the import's target: a mode slug is not unique across orgs,
+      // so hydrating on slug alone could paint org A's imported document into a
+      // same-named mode the user is now viewing in org B (codex #306 rd-4 P1).
       const liveSelected = useUiStore.getState().selectedMode;
+      const liveOrg = useUiStore.getState().contextOrg;
       const aliasNote = mode.droppedAliases.length
         ? ` Its aliases (${mode.droppedAliases.join(", ")}) were not restored — aliases are managed through rename/retire, not import.`
         : "";
 
-      if (mode.name === liveSelected) {
-        // Overwrote the mode already open in the editor. Re-hydrate IN PLACE
-        // from the authoritative saved values: setSelectedMode would no-op and
-        // the hydration effect early-returns (syncedNameRef already names this
-        // mode), so without this the draft/lastSyncedDoc/flags stay pre-import
-        // and the next autosave silently reverts the import (#302/#303 class).
+      if (mode.name === liveSelected && importOrg === liveOrg) {
+        // Overwrote the mode open in the editor (same org). Re-hydrate IN PLACE
+        // from the authoritative saved values: the hydration effect early-
+        // returns (syncedNameRef already names this mode), so without this the
+        // draft/lastSyncedDoc/flags stay pre-import and the next autosave
+        // silently reverts the import (#302/#303 class).
         setDraft(mode.document);
         setLastSyncedDoc(mode.document);
         applyLastSyncedFlags(
@@ -569,26 +588,23 @@ export function ModesPage() {
           )
         );
         setLastFailedDoc(null);
-        // Pin the anchor so a late initial GET (syncedNameRef null on a fresh
-        // load) can't re-run hydration and clobber the in-place values; the
-        // invalidate refetch reconciles to the same server truth (grok #306).
         syncedNameRef.current = mode.name;
         setImportNotice(
           aliasNote ? `Imported “${mode.name}”.${aliasNote}` : null
         );
         return;
       }
-      // Different / new mode: do NOT auto-switch. Auto-selecting from this async
-      // continuation fought the render-closure dirty-switch guard (a stale
-      // isDirty could drop the user's in-progress edits) and the stale-selection
-      // guard. The mode is saved server-side and the list invalidate refetches
-      // it into the dropdown, so a notice + leaving the user's current editor
-      // untouched is both simpler and safer than yanking them to the new mode.
+      // Different / new mode (or the target is no longer the live selection): do
+      // NOT auto-switch. Auto-selecting from this async continuation fought the
+      // render-closure dirty-switch guard (a stale isDirty could drop the user's
+      // in-progress edits). The mode is saved and its cache is seeded, so the
+      // user picks it from the list when ready — their current editor is left
+      // untouched.
       setImportNotice(
         `Imported “${mode.name}” — select it from the mode list to edit.${aliasNote}`
       );
     },
-    [applyLastSyncedFlags]
+    [applyLastSyncedFlags, seedImportedMode]
   );
 
   const handleImportFileChange = useCallback(
@@ -679,9 +695,12 @@ export function ModesPage() {
         return;
       }
       // Brand-new mode — create directly; a failure surfaces in the banner.
+      // Pin the org the import targets (this render's contextOrg = the org the
+      // PUT is addressed to) so finishImport can refuse cross-org hydration.
+      const importOrg = contextOrg;
       try {
         const saved = await runImport(result.mode);
-        finishImport(result.mode, saved);
+        await finishImport(result.mode, saved, importOrg);
       } catch (err) {
         setImportError(err instanceof Error ? err.message : "Import failed.");
       }
@@ -690,6 +709,7 @@ export function ModesPage() {
       modesQuery.data,
       canEditModeName,
       modePublishRights,
+      contextOrg,
       runImport,
       finishImport,
     ]
@@ -698,16 +718,18 @@ export function ModesPage() {
   const confirmImport = useCallback(() => {
     if (!pendingImport) return;
     const { mode } = pendingImport;
+    // Pin the target org at confirm time (same render as the PUT's saveMode).
+    const importOrg = contextOrg;
     return runConfirmedAction(
       async () => {
         const saved = await runImport(mode);
-        finishImport(mode, saved);
+        await finishImport(mode, saved, importOrg);
       },
       setImportConfirmError,
       () => setPendingImport(null),
       "Import failed."
     );
-  }, [pendingImport, runImport, finishImport]);
+  }, [pendingImport, contextOrg, runImport, finishImport]);
 
   const confirmSwitch = useCallback(() => {
     setSelectedMode(pendingSwitch);

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -1,7 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { faSpinnerThird } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Download, ListOrdered, Save } from "lucide-react";
+import { Download, ListOrdered, Save, Upload } from "lucide-react";
 import { useBlocker } from "react-router";
 
 import { shouldAutoSaveDraft } from "@/lib/autosave-gate";
@@ -18,6 +25,10 @@ import {
   reconcileModeFlags,
   type ModeFlags,
 } from "@/lib/mode-flags";
+import {
+  type ParsedModeImport,
+  parseModeImport,
+} from "@/lib/mode-import";
 import { MODE_DOCUMENT_SCAFFOLD } from "@/lib/mode-scaffold";
 import { humanizeModeSlug, slugifyModeName } from "@/lib/mode-slug";
 import { runConfirmedAction } from "@/lib/run-confirmed-action";
@@ -407,6 +418,135 @@ export function ModesPage() {
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
   }, [draft, effectiveOrg, lastSyncedFlags, modeQuery.data, selectedMode]);
+
+  // #198 — import a mode from a file produced by Export. The hidden input is
+  // clicked by the Import button; `parseModeImport` validates the file, and a
+  // collision opens an overwrite confirm before any PUT.
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const [pendingImport, setPendingImport] = useState<{
+    mode: ParsedModeImport;
+    isOverwrite: boolean;
+  } | null>(null);
+  // Pre-flight banner (parse / permission / read errors, before any dialog).
+  const [importError, setImportError] = useState<string | null>(null);
+  // Inline error inside the overwrite dialog (a failed PUT), same contract as
+  // `labelSyncError` — the dialog stays open so it can render.
+  const [importConfirmError, setImportConfirmError] = useState<string | null>(
+    null
+  );
+  // Non-blocking notice after a successful import (currently: dropped aliases).
+  const [importNotice, setImportNotice] = useState<string | null>(null);
+
+  // The create-or-overwrite PUT for an imported mode, shared by the direct
+  // create path and the overwrite-confirm dialog. Participates in the same
+  // synchronous save lock as every other save path (#209 serialization), and
+  // sends the always-explicit published/requires_group pair the worker needs
+  // (it has no partial update).
+  const runImport = useCallback(
+    (mode: ParsedModeImport) => {
+      inFlightSavesRef.current += 1;
+      return saveMode
+        .mutateAsync({
+          name: mode.name,
+          body: {
+            label: mode.label,
+            description: mode.description,
+            document: mode.document,
+            published: mode.published,
+            requires_group: mode.requires_group,
+          },
+        })
+        .finally(() => {
+          inFlightSavesRef.current -= 1;
+        });
+    },
+    [saveMode]
+  );
+
+  const finishImport = useCallback(
+    (mode: ParsedModeImport) => {
+      setSelectedMode(mode.name);
+      setImportNotice(
+        mode.droppedAliases.length
+          ? `Imported “${mode.name}”. Its aliases (${mode.droppedAliases.join(
+              ", "
+            )}) were not restored — aliases are managed through rename/retire, not import.`
+          : null
+      );
+    },
+    [setSelectedMode]
+  );
+
+  const handleImportFileChange = useCallback(
+    async (e: ChangeEvent<HTMLInputElement>) => {
+      const input = e.currentTarget;
+      const file = input.files?.[0];
+      // Clear the input synchronously so the same file can be re-selected
+      // later (a change event won't fire twice for an identical value).
+      input.value = "";
+      if (!file) return;
+      setImportError(null);
+      setImportNotice(null);
+
+      let text: string;
+      try {
+        text = await file.text();
+      } catch {
+        setImportError("Could not read the selected file.");
+        return;
+      }
+      const result = parseModeImport(text);
+      if (!result.ok) {
+        setImportError(result.error);
+        return;
+      }
+
+      const name = result.mode.name;
+      // Existence is checked against the FULL org mode list, not the
+      // authorized subset: importing over a mode the user can't see would
+      // still overwrite it, so a hidden collision must be caught here and
+      // gated by edit rights rather than falling through to the create path.
+      const exists = (modesQuery.data?.modes ?? []).some(
+        (m) => m.name === name
+      );
+      if (exists ? !canEditModeName(name) : !canCreate) {
+        setImportError(
+          exists
+            ? `You don't have permission to overwrite the “${name}” mode.`
+            : "You don't have permission to create modes."
+        );
+        return;
+      }
+
+      if (exists) {
+        setImportConfirmError(null);
+        setPendingImport({ mode: result.mode, isOverwrite: true });
+        return;
+      }
+      // Brand-new mode — create directly; a failure surfaces in the banner.
+      try {
+        await runImport(result.mode);
+        finishImport(result.mode);
+      } catch (err) {
+        setImportError(err instanceof Error ? err.message : "Import failed.");
+      }
+    },
+    [modesQuery.data, canEditModeName, canCreate, runImport, finishImport]
+  );
+
+  const confirmImport = useCallback(() => {
+    if (!pendingImport) return;
+    const { mode } = pendingImport;
+    return runConfirmedAction(
+      () => runImport(mode),
+      setImportConfirmError,
+      () => {
+        setPendingImport(null);
+        finishImport(mode);
+      },
+      "Import failed."
+    );
+  }, [pendingImport, runImport, finishImport]);
 
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
@@ -1027,6 +1167,28 @@ export function ModesPage() {
             />
           </div>
 
+          {/* #198 — import a mode from an exported file. Available whenever
+              the user can create/edit some mode; the per-file check enforces
+              the specific target's rights. */}
+          <input
+            ref={importInputRef}
+            type="file"
+            accept=".md,text/markdown"
+            className="hidden"
+            onChange={handleImportFileChange}
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0"
+            onClick={() => importInputRef.current?.click()}
+            disabled={!canCreate || !effectiveOrg}
+            title="Import a mode from an exported Markdown file"
+          >
+            <Upload className="mr-1.5 size-3.5" />
+            Import
+          </Button>
+
           {hasSelection && (
             <div className="flex shrink-0 items-center gap-3">
               {/* #209 — group-only gate. Saves immediately on toggle
@@ -1126,6 +1288,26 @@ export function ModesPage() {
           aria-live="polite"
         >
           Save failed: {saveError.message}
+        </div>
+      )}
+
+      {importError && (
+        <div
+          className="bg-destructive/10 text-destructive border-destructive border-l-2 px-6 py-3 text-sm"
+          role="alert"
+          aria-live="polite"
+        >
+          Import failed: {importError}
+        </div>
+      )}
+
+      {importNotice && (
+        <div
+          className="bg-muted text-muted-foreground border-border border-l-2 px-6 py-3 text-sm"
+          role="status"
+          aria-live="polite"
+        >
+          {importNotice}
         </div>
       )}
 
@@ -1324,6 +1506,54 @@ export function ModesPage() {
               disabled={saveMode.isPending || !labelSyncValue.trim()}
             >
               {saveMode.isPending ? "Updating…" : "Update name"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* #198 — confirm before an import overwrites an existing mode. */}
+      <AlertDialog
+        open={pendingImport !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingImport(null);
+            setImportConfirmError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Overwrite “{pendingImport?.mode.name}”?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              A mode named{" "}
+              <span className="text-foreground font-mono font-medium">
+                {pendingImport?.mode.name}
+              </span>{" "}
+              already exists. Importing this file replaces its document, label,
+              description, and flags with the file&rsquo;s contents. This
+              can&rsquo;t be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {importConfirmError && (
+            <p className="bg-destructive/10 text-destructive border-destructive border-l-2 px-3 py-2 text-sm">
+              {importConfirmError}
+            </p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saveMode.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            {/* Plain Button — AlertDialogAction auto-closes before an inline
+                error could render (#102); close happens in confirmImport on
+                success. */}
+            <Button
+              variant="destructive"
+              onClick={confirmImport}
+              disabled={saveMode.isPending}
+            >
+              {saveMode.isPending ? "Importing…" : "Overwrite"}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -514,6 +514,17 @@ export function ModesPage() {
   // (it has no partial update).
   const runImport = useCallback(
     (mode: ParsedModeImport) => {
+      // A GATE, not just a counter (#209 contract, mirrors handleSetPublished).
+      // The file-pick lock check is stale by the time we get here: `await
+      // file.text()` yields, and the overwrite dialog holds no lock for an
+      // unbounded time, so an autosave of the open mode can start in between.
+      // Refuse rather than overlap a second PUT on the same hook whose
+      // late-settling onSuccess would revert the import (grok #306 Issue 3).
+      if (inFlightSavesRef.current > 0) {
+        throw new Error(
+          "A save is already in progress — try again in a moment."
+        );
+      }
       inFlightSavesRef.current += 1;
       return saveMode
         .mutateAsync({
@@ -558,6 +569,13 @@ export function ModesPage() {
           )
         );
         setLastFailedDoc(null);
+        // Pin the anchor to this mode. If the initial GET was still in flight
+        // (syncedNameRef null on a fresh page load), its late arrival with the
+        // PRE-import document would otherwise re-run hydration and clobber the
+        // values just written; pinning makes that hydration early-return
+        // (grok #306 Issue 4). The useSaveMode cache-seed holds the imported
+        // doc, so the invalidate refetch reconciles to server truth.
+        syncedNameRef.current = mode.name;
         return;
       }
       // Landing on a DIFFERENT mode — route through the dirty/in-flight switch
@@ -1568,9 +1586,10 @@ export function ModesPage() {
               <span className="text-foreground font-mono font-medium">
                 {pendingImport?.mode.name}
               </span>{" "}
-              already exists. Importing this file replaces its document, label,
-              description, and flags with the file&rsquo;s contents. This
-              can&rsquo;t be undone.
+              already exists. Importing this file replaces its document and its
+              published / group-chat settings, and updates the display name and
+              description when the file includes them. This can&rsquo;t be
+              undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           {importConfirmError && (

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -282,6 +282,13 @@ export function ModesPage() {
     draftRef.current = draft;
   }, [draft]);
 
+  // Committed dirty state, readable from an async callback (the import handler)
+  // without a stale closure — same synced-in-effect discipline as draftRef.
+  const isDirtyRef = useRef(isDirty);
+  useEffect(() => {
+    isDirtyRef.current = isDirty;
+  }, [isDirty]);
+
   const performSave = useCallback(
     (doc: string) => {
       if (!selectedMode) return;
@@ -425,6 +432,8 @@ export function ModesPage() {
   const [pendingImport, setPendingImport] = useState<{
     mode: ParsedModeImport;
     isOverwrite: boolean;
+    /** Org validated at file-pick; the confirm executes against this org. */
+    org: string | null;
   } | null>(null);
   // Pre-flight banner (parse / permission / read errors, before any dialog).
   const [importError, setImportError] = useState<string | null>(null);
@@ -617,15 +626,9 @@ export function ModesPage() {
       if (!file) return;
       setImportError(null);
       setImportNotice(null);
-      // Honor the shared save lock like every other write path: don't start an
-      // import PUT while another save is in flight (it would race a concurrent
-      // autosave on the same hook).
-      if (inFlightSavesRef.current > 0) {
-        setImportError(
-          "A save is already in progress — try again in a moment."
-        );
-        return;
-      }
+      // The org the import is validated and executed against, pinned at the
+      // moment the picker opened.
+      const startOrg = contextOrg;
 
       let text: string;
       try {
@@ -634,6 +637,36 @@ export function ModesPage() {
         setImportError("Could not read the selected file.");
         return;
       }
+      // The OS file picker does not block the page: org, selection, and dirty
+      // state can all change between opening it and choosing a file. Re-check
+      // LIVE state now, before validating or writing anything — otherwise a
+      // stale render's mode list / rights / org would gate a cross-context PUT.
+      if (useUiStore.getState().contextOrg !== startOrg) {
+        setImportError(
+          "The org context changed while the file picker was open — reopen Import for the current org."
+        );
+        return;
+      }
+      // Import requires a clean, idle editor. A dirty or mid-save open mode plus
+      // a same-slug import is the one path where autosave can revert the import
+      // (the wholesale document replace races the debounce); requiring a clean
+      // editor removes that class outright rather than racing it.
+      if (isDirtyRef.current || inFlightSavesRef.current > 0) {
+        setImportError(
+          "Save or discard your current changes before importing."
+        );
+        return;
+      }
+      // Fail CLOSED when the mode list has not loaded: without it the collision
+      // check below would see an empty list, treat an existing mode as new, and
+      // overwrite it with no confirmation.
+      if (!modesQuery.data) {
+        setImportError(
+          "The mode list is still loading — try again in a moment."
+        );
+        return;
+      }
+
       const result = parseModeImport(text);
       if (!result.ok) {
         setImportError(result.error);
@@ -648,9 +681,8 @@ export function ModesPage() {
       // DIFFERENT canonical mode with no confirmation — refuse and point the
       // user at the canonical slug rather than clobber it (codex+grok rd-2).
       // (Full list, not authorized subset: a hidden collision must still be
-      // caught; the Import button is disabled until the list has loaded.)
-      const modes = modesQuery.data?.modes ?? [];
-      const collision = modes.find(
+      // caught. The list is guaranteed loaded by the fail-closed guard above.)
+      const collision = modesQuery.data.modes.find(
         (m) => m.name === name || m.aliases?.includes(name)
       );
       if (collision && collision.name !== name) {
@@ -691,16 +723,24 @@ export function ModesPage() {
 
       if (exists) {
         setImportConfirmError(null);
-        setPendingImport({ mode: result.mode, isOverwrite: true });
+        // Pin the validated org onto the pending import. The overwrite dialog
+        // can sit open across an org switch; confirming must target the org
+        // whose list / collision / rights were just checked, not whatever org
+        // is live at click time (codex rd-5). A context-change effect also
+        // clears pendingImport, so the two together forbid a cross-org confirm.
+        setPendingImport({
+          mode: result.mode,
+          isOverwrite: true,
+          org: startOrg,
+        });
         return;
       }
       // Brand-new mode — create directly; a failure surfaces in the banner.
-      // Pin the org the import targets (this render's contextOrg = the org the
-      // PUT is addressed to) so finishImport can refuse cross-org hydration.
-      const importOrg = contextOrg;
+      // startOrg is the validated + PUT-target org (unchanged since the picker
+      // opened, enforced above), so finishImport can refuse cross-org hydration.
       try {
         const saved = await runImport(result.mode);
-        await finishImport(result.mode, saved, importOrg);
+        await finishImport(result.mode, saved, startOrg);
       } catch (err) {
         setImportError(err instanceof Error ? err.message : "Import failed.");
       }
@@ -715,21 +755,26 @@ export function ModesPage() {
     ]
   );
 
+  // Discard a pending overwrite when the org context changes — its collision
+  // and permission checks were validated against the previous org (codex rd-5).
+  useEffect(() => {
+    setPendingImport(null);
+    setImportConfirmError(null);
+  }, [contextOrg]);
+
   const confirmImport = useCallback(() => {
     if (!pendingImport) return;
-    const { mode } = pendingImport;
-    // Pin the target org at confirm time (same render as the PUT's saveMode).
-    const importOrg = contextOrg;
+    const { mode, org } = pendingImport;
     return runConfirmedAction(
       async () => {
         const saved = await runImport(mode);
-        await finishImport(mode, saved, importOrg);
+        await finishImport(mode, saved, org);
       },
       setImportConfirmError,
       () => setPendingImport(null),
       "Import failed."
     );
-  }, [pendingImport, contextOrg, runImport, finishImport]);
+  }, [pendingImport, runImport, finishImport]);
 
   const confirmSwitch = useCallback(() => {
     setSelectedMode(pendingSwitch);
@@ -1296,10 +1341,23 @@ export function ModesPage() {
             variant="outline"
             className="shrink-0"
             onClick={() => importInputRef.current?.click()}
-            // Gated until the mode list has loaded so the overwrite-vs-create
-            // decision can't silently degrade to "create" on an undefined list.
-            disabled={!canCreate || !effectiveOrg || !modesQuery.data}
-            title="Import a mode from an exported Markdown file"
+            // Gated until the mode list has loaded (so overwrite-vs-create can't
+            // degrade to "create" on an undefined list) and while the editor is
+            // dirty/saving (a same-slug import could otherwise race autosave).
+            // The handler re-checks live, for the case where state changes while
+            // the OS file picker is open.
+            disabled={
+              !canCreate ||
+              !effectiveOrg ||
+              !modesQuery.data ||
+              isDirty ||
+              isSaving
+            }
+            title={
+              isDirty || isSaving
+                ? "Save or discard your changes before importing"
+                : "Import a mode from an exported Markdown file"
+            }
           >
             <Upload className="mr-1.5 size-3.5" />
             Import

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -434,117 +434,6 @@ export function ModesPage() {
   // Non-blocking notice after a successful import (currently: dropped aliases).
   const [importNotice, setImportNotice] = useState<string | null>(null);
 
-  // The create-or-overwrite PUT for an imported mode, shared by the direct
-  // create path and the overwrite-confirm dialog. Participates in the same
-  // synchronous save lock as every other save path (#209 serialization), and
-  // sends the always-explicit published/requires_group pair the worker needs
-  // (it has no partial update).
-  const runImport = useCallback(
-    (mode: ParsedModeImport) => {
-      inFlightSavesRef.current += 1;
-      return saveMode
-        .mutateAsync({
-          name: mode.name,
-          body: {
-            label: mode.label,
-            description: mode.description,
-            document: mode.document,
-            published: mode.published,
-            requires_group: mode.requires_group,
-          },
-        })
-        .finally(() => {
-          inFlightSavesRef.current -= 1;
-        });
-    },
-    [saveMode]
-  );
-
-  const finishImport = useCallback(
-    (mode: ParsedModeImport) => {
-      setSelectedMode(mode.name);
-      setImportNotice(
-        mode.droppedAliases.length
-          ? `Imported “${mode.name}”. Its aliases (${mode.droppedAliases.join(
-              ", "
-            )}) were not restored — aliases are managed through rename/retire, not import.`
-          : null
-      );
-    },
-    [setSelectedMode]
-  );
-
-  const handleImportFileChange = useCallback(
-    async (e: ChangeEvent<HTMLInputElement>) => {
-      const input = e.currentTarget;
-      const file = input.files?.[0];
-      // Clear the input synchronously so the same file can be re-selected
-      // later (a change event won't fire twice for an identical value).
-      input.value = "";
-      if (!file) return;
-      setImportError(null);
-      setImportNotice(null);
-
-      let text: string;
-      try {
-        text = await file.text();
-      } catch {
-        setImportError("Could not read the selected file.");
-        return;
-      }
-      const result = parseModeImport(text);
-      if (!result.ok) {
-        setImportError(result.error);
-        return;
-      }
-
-      const name = result.mode.name;
-      // Existence is checked against the FULL org mode list, not the
-      // authorized subset: importing over a mode the user can't see would
-      // still overwrite it, so a hidden collision must be caught here and
-      // gated by edit rights rather than falling through to the create path.
-      const exists = (modesQuery.data?.modes ?? []).some(
-        (m) => m.name === name
-      );
-      if (exists ? !canEditModeName(name) : !canCreate) {
-        setImportError(
-          exists
-            ? `You don't have permission to overwrite the “${name}” mode.`
-            : "You don't have permission to create modes."
-        );
-        return;
-      }
-
-      if (exists) {
-        setImportConfirmError(null);
-        setPendingImport({ mode: result.mode, isOverwrite: true });
-        return;
-      }
-      // Brand-new mode — create directly; a failure surfaces in the banner.
-      try {
-        await runImport(result.mode);
-        finishImport(result.mode);
-      } catch (err) {
-        setImportError(err instanceof Error ? err.message : "Import failed.");
-      }
-    },
-    [modesQuery.data, canEditModeName, canCreate, runImport, finishImport]
-  );
-
-  const confirmImport = useCallback(() => {
-    if (!pendingImport) return;
-    const { mode } = pendingImport;
-    return runConfirmedAction(
-      () => runImport(mode),
-      setImportConfirmError,
-      () => {
-        setPendingImport(null);
-        finishImport(mode);
-      },
-      "Import failed."
-    );
-  }, [pendingImport, runImport, finishImport]);
-
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
       (isDirty || isSaving) &&
@@ -613,6 +502,155 @@ export function ModesPage() {
     },
     [isDirty, isSaving, selectedMode, setSelectedMode]
   );
+
+  // #198 — import handlers. Defined here, AFTER handleSelectMode, because
+  // finishImport routes a post-import switch through it (the fix for the
+  // dirty-switch-guard bypass below).
+
+  // The create-or-overwrite PUT for an imported mode, shared by the direct
+  // create path and the overwrite-confirm dialog. Participates in the same
+  // synchronous save lock as every other save path (#209 serialization), and
+  // sends the always-explicit published/requires_group pair the worker needs
+  // (it has no partial update).
+  const runImport = useCallback(
+    (mode: ParsedModeImport) => {
+      inFlightSavesRef.current += 1;
+      return saveMode
+        .mutateAsync({
+          name: mode.name,
+          body: {
+            label: mode.label,
+            description: mode.description,
+            document: mode.document,
+            published: mode.published,
+            requires_group: mode.requires_group,
+          },
+        })
+        .finally(() => {
+          inFlightSavesRef.current -= 1;
+        });
+    },
+    [saveMode]
+  );
+
+  const finishImport = useCallback(
+    (mode: ParsedModeImport, saved: PromptMode) => {
+      setImportNotice(
+        mode.droppedAliases.length
+          ? `Imported “${mode.name}”. Its aliases (${mode.droppedAliases.join(
+              ", "
+            )}) were not restored — aliases are managed through rename/retire, not import.`
+          : null
+      );
+      if (mode.name === selectedMode) {
+        // Overwrote the mode already open in the editor. setSelectedMode would
+        // no-op and the hydration effect early-returns (syncedNameRef already
+        // names this mode), so re-hydrate the editor IN PLACE from the
+        // authoritative saved values — otherwise draft/lastSyncedDoc/flags stay
+        // pre-import and the next autosave silently reverts the import (the
+        // exact stale-tracker class of #302/#303).
+        setDraft(mode.document);
+        setLastSyncedDoc(mode.document);
+        applyLastSyncedFlags(
+          reconcileModeFlags(
+            { published: mode.published, requires_group: mode.requires_group },
+            saved
+          )
+        );
+        setLastFailedDoc(null);
+        return;
+      }
+      // Landing on a DIFFERENT mode — route through the dirty/in-flight switch
+      // guard so unsaved edits on the current mode aren't dropped silently
+      // (same reason clone/retire route through it). The imported mode already
+      // exists server-side, so cancelling the switch merely stays put; the
+      // hydration effect loads the imported document on arrival.
+      handleSelectMode(mode.name);
+    },
+    [applyLastSyncedFlags, handleSelectMode, selectedMode]
+  );
+
+  const handleImportFileChange = useCallback(
+    async (e: ChangeEvent<HTMLInputElement>) => {
+      const input = e.currentTarget;
+      const file = input.files?.[0];
+      // Clear the input synchronously so the same file can be re-selected
+      // later (a change event won't fire twice for an identical value).
+      input.value = "";
+      if (!file) return;
+      setImportError(null);
+      setImportNotice(null);
+      // Honor the shared save lock like every other write path: don't start an
+      // import PUT while another save is in flight (it would race a concurrent
+      // autosave on the same hook).
+      if (inFlightSavesRef.current > 0) {
+        setImportError(
+          "A save is already in progress — try again in a moment."
+        );
+        return;
+      }
+
+      let text: string;
+      try {
+        text = await file.text();
+      } catch {
+        setImportError("Could not read the selected file.");
+        return;
+      }
+      const result = parseModeImport(text);
+      if (!result.ok) {
+        setImportError(result.error);
+        return;
+      }
+
+      const name = result.mode.name;
+      // Existence is checked against the FULL org mode list, not the
+      // authorized subset: importing over a mode the user can't see would
+      // still overwrite it, so a hidden collision must be caught here and
+      // gated by edit rights rather than falling through to the create path.
+      // The Import button is disabled until the list has loaded, so an
+      // undefined list here is not a silent "treat as create".
+      const exists = (modesQuery.data?.modes ?? []).some(
+        (m) => m.name === name
+      );
+      if (exists ? !canEditModeName(name) : !canCreate) {
+        setImportError(
+          exists
+            ? `You don't have permission to overwrite the “${name}” mode.`
+            : "You don't have permission to create modes."
+        );
+        return;
+      }
+
+      if (exists) {
+        setImportConfirmError(null);
+        setPendingImport({ mode: result.mode, isOverwrite: true });
+        return;
+      }
+      // Brand-new mode — create directly; a failure surfaces in the banner.
+      try {
+        const saved = await runImport(result.mode);
+        finishImport(result.mode, saved);
+      } catch (err) {
+        setImportError(err instanceof Error ? err.message : "Import failed.");
+      }
+    },
+    [modesQuery.data, canEditModeName, canCreate, runImport, finishImport]
+  );
+
+  const confirmImport = useCallback(() => {
+    if (!pendingImport) return;
+    const { mode } = pendingImport;
+    return runConfirmedAction(
+      async () => {
+        const saved = await runImport(mode);
+        finishImport(mode, saved);
+      },
+      setImportConfirmError,
+      () => setPendingImport(null),
+      "Import failed."
+    );
+  }, [pendingImport, runImport, finishImport]);
 
   const confirmSwitch = useCallback(() => {
     setSelectedMode(pendingSwitch);
@@ -1179,7 +1217,9 @@ export function ModesPage() {
             variant="outline"
             className="shrink-0"
             onClick={() => importInputRef.current?.click()}
-            disabled={!canCreate || !effectiveOrg}
+            // Gated until the mode list has loaded so the overwrite-vs-create
+            // decision can't silently degrade to "create" on an undefined list.
+            disabled={!canCreate || !effectiveOrg || !modesQuery.data}
             title="Import a mode from an exported Markdown file"
           >
             <Upload className="mr-1.5 size-3.5" />
@@ -1294,7 +1334,7 @@ export function ModesPage() {
           role="alert"
           aria-live="polite"
         >
-          Import failed: {importError}
+          {importError}
         </div>
       )}
 

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -546,20 +546,20 @@ export function ModesPage() {
 
   const finishImport = useCallback(
     (mode: ParsedModeImport, saved: PromptMode) => {
-      setImportNotice(
-        mode.droppedAliases.length
-          ? `Imported “${mode.name}”. Its aliases (${mode.droppedAliases.join(
-              ", "
-            )}) were not restored — aliases are managed through rename/retire, not import.`
-          : null
-      );
-      if (mode.name === selectedMode) {
-        // Overwrote the mode already open in the editor. setSelectedMode would
-        // no-op and the hydration effect early-returns (syncedNameRef already
-        // names this mode), so re-hydrate the editor IN PLACE from the
-        // authoritative saved values — otherwise draft/lastSyncedDoc/flags stay
-        // pre-import and the next autosave silently reverts the import (the
-        // exact stale-tracker class of #302/#303).
+      // Read the LIVE selection, not the render closure — finishImport runs in
+      // an async continuation (after file.text() + the PUT), during which the
+      // user may have switched modes.
+      const liveSelected = useUiStore.getState().selectedMode;
+      const aliasNote = mode.droppedAliases.length
+        ? ` Its aliases (${mode.droppedAliases.join(", ")}) were not restored — aliases are managed through rename/retire, not import.`
+        : "";
+
+      if (mode.name === liveSelected) {
+        // Overwrote the mode already open in the editor. Re-hydrate IN PLACE
+        // from the authoritative saved values: setSelectedMode would no-op and
+        // the hydration effect early-returns (syncedNameRef already names this
+        // mode), so without this the draft/lastSyncedDoc/flags stay pre-import
+        // and the next autosave silently reverts the import (#302/#303 class).
         setDraft(mode.document);
         setLastSyncedDoc(mode.document);
         applyLastSyncedFlags(
@@ -569,23 +569,26 @@ export function ModesPage() {
           )
         );
         setLastFailedDoc(null);
-        // Pin the anchor to this mode. If the initial GET was still in flight
-        // (syncedNameRef null on a fresh page load), its late arrival with the
-        // PRE-import document would otherwise re-run hydration and clobber the
-        // values just written; pinning makes that hydration early-return
-        // (grok #306 Issue 4). The useSaveMode cache-seed holds the imported
-        // doc, so the invalidate refetch reconciles to server truth.
+        // Pin the anchor so a late initial GET (syncedNameRef null on a fresh
+        // load) can't re-run hydration and clobber the in-place values; the
+        // invalidate refetch reconciles to the same server truth (grok #306).
         syncedNameRef.current = mode.name;
+        setImportNotice(
+          aliasNote ? `Imported “${mode.name}”.${aliasNote}` : null
+        );
         return;
       }
-      // Landing on a DIFFERENT mode — route through the dirty/in-flight switch
-      // guard so unsaved edits on the current mode aren't dropped silently
-      // (same reason clone/retire route through it). The imported mode already
-      // exists server-side, so cancelling the switch merely stays put; the
-      // hydration effect loads the imported document on arrival.
-      handleSelectMode(mode.name);
+      // Different / new mode: do NOT auto-switch. Auto-selecting from this async
+      // continuation fought the render-closure dirty-switch guard (a stale
+      // isDirty could drop the user's in-progress edits) and the stale-selection
+      // guard. The mode is saved server-side and the list invalidate refetches
+      // it into the dropdown, so a notice + leaving the user's current editor
+      // untouched is both simpler and safer than yanking them to the new mode.
+      setImportNotice(
+        `Imported “${mode.name}” — select it from the mode list to edit.${aliasNote}`
+      );
     },
-    [applyLastSyncedFlags, handleSelectMode, selectedMode]
+    [applyLastSyncedFlags]
   );
 
   const handleImportFileChange = useCallback(
@@ -654,17 +657,18 @@ export function ModesPage() {
         );
         return;
       }
-      // An overwrite that FLIPS published additionally needs publish rights —
-      // the worker's diff gate requires the `publish` verb when the flag
-      // changes, so an edit-only user would otherwise hit a bare 403 after
-      // confirming (codex rd-2 / grok P3).
-      if (
-        exists &&
-        result.mode.published !== (collision?.published ?? false) &&
-        !hasRights(modePublishRights, name)
-      ) {
+      // Publishing additionally needs publish rights — the worker's diff gate
+      // requires the `publish` verb when creating a published mode OR flipping
+      // an existing one's flag, so a user without it would hit a bare 403 after
+      // confirming (codex+grok rd-2/3). Compute whether this import publishes:
+      // a create sets published from false→its value; an overwrite is a change
+      // only when the flag differs.
+      const publishChanges = exists
+        ? result.mode.published !== (collision?.published ?? false)
+        : result.mode.published;
+      if (publishChanges && !hasRights(modePublishRights, name)) {
         setImportError(
-          `Importing this file changes whether “${name}” is published, which needs publish rights you don't have on it.`
+          `This import changes the published state of “${name}”, which needs publish rights you don't have on it.`
         );
         return;
       }

--- a/src/app/pages/modes.tsx
+++ b/src/app/pages/modes.tsx
@@ -622,20 +622,49 @@ export function ModesPage() {
       }
 
       const name = result.mode.name;
-      // Existence is checked against the FULL org mode list, not the
-      // authorized subset: importing over a mode the user can't see would
-      // still overwrite it, so a hidden collision must be caught here and
-      // gated by edit rights rather than falling through to the create path.
-      // The Import button is disabled until the list has loaded, so an
-      // undefined list here is not a silent "treat as create".
-      const exists = (modesQuery.data?.modes ?? []).some(
-        (m) => m.name === name
+      // Resolve against the FULL org mode list by canonical name AND aliases.
+      // The engine resolves alias slugs on PUT (findModeBySlug honors aliases),
+      // so a PUT addressed to an alias mutates the aliased-TO mode. An import
+      // whose name is a stale/retired slug would therefore silently overwrite a
+      // DIFFERENT canonical mode with no confirmation — refuse and point the
+      // user at the canonical slug rather than clobber it (codex+grok rd-2).
+      // (Full list, not authorized subset: a hidden collision must still be
+      // caught; the Import button is disabled until the list has loaded.)
+      const modes = modesQuery.data?.modes ?? [];
+      const collision = modes.find(
+        (m) => m.name === name || m.aliases?.includes(name)
       );
-      if (exists ? !canEditModeName(name) : !canCreate) {
+      if (collision && collision.name !== name) {
+        setImportError(
+          `“${name}” is an alias of “${collision.name}” — import against the canonical slug.`
+        );
+        return;
+      }
+      const exists = collision !== undefined;
+
+      // Edit rights on the TARGET slug are required whether creating or
+      // overwriting: the worker early-denies any caller with no rights on the
+      // exact name (admins and cross-org carry "*"), so `canCreate` — "has a
+      // right on SOME mode" — is not sufficient for a new slug (codex rd-2).
+      if (!canEditModeName(name)) {
         setImportError(
           exists
             ? `You don't have permission to overwrite the “${name}” mode.`
-            : "You don't have permission to create modes."
+            : `You don't have permission to create the “${name}” mode. Creating a new mode needs edit rights on that slug (admin or a wildcard grant).`
+        );
+        return;
+      }
+      // An overwrite that FLIPS published additionally needs publish rights —
+      // the worker's diff gate requires the `publish` verb when the flag
+      // changes, so an edit-only user would otherwise hit a bare 403 after
+      // confirming (codex rd-2 / grok P3).
+      if (
+        exists &&
+        result.mode.published !== (collision?.published ?? false) &&
+        !hasRights(modePublishRights, name)
+      ) {
+        setImportError(
+          `Importing this file changes whether “${name}” is published, which needs publish rights you don't have on it.`
         );
         return;
       }
@@ -653,7 +682,13 @@ export function ModesPage() {
         setImportError(err instanceof Error ? err.message : "Import failed.");
       }
     },
-    [modesQuery.data, canEditModeName, canCreate, runImport, finishImport]
+    [
+      modesQuery.data,
+      canEditModeName,
+      modePublishRights,
+      runImport,
+      finishImport,
+    ]
   );
 
   const confirmImport = useCallback(() => {

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -88,21 +88,28 @@ export function useSaveMode(org?: string | null) {
         requires_group?: boolean;
       };
     }) => configApi.putMode(name, body, undefined, key),
-    onSuccess: (data, { name }) => {
-      // Seed both caches from the server response BEFORE invalidating — the
-      // same three-step pattern as clone/rename/retire. Invalidate alone only
-      // refetches ACTIVE queries in TanStack v5, so an INACTIVE per-mode query
-      // (import overwriting a non-selected mode) or a not-yet-listed new mode
-      // (import creating one) would otherwise be read stale by the page, which
-      // hydrates the editor / runs its stale-selection guard off that cache
-      // (grok #306 Issues 1/2/4). Every non-import caller saves the ACTIVE
-      // mode, where this write is a harmless no-op the refetch would produce.
+    onSuccess: async (data, { name }) => {
+      // Seed both caches from the server response rather than only
+      // invalidating — invalidate refetches ACTIVE queries only in TanStack
+      // v5, so an INACTIVE per-mode query (import overwriting a non-selected
+      // mode) or a not-yet-listed new mode (import creating one) would be read
+      // stale by the page, which hydrates the editor / runs its stale-selection
+      // guard off that cache. Every non-import caller saves the ACTIVE mode,
+      // where this write is the no-op the refetch would have produced. Mirrors
+      // `languageSaveMutationOptions` exactly, including the load-bearing
+      // AWAIT-cancel-before-seed: an in-flight getMode that settled AFTER
+      // setQueryData would write the PRE-save document straight back into the
+      // cache and poison it for the hydration effect (grok #306 rd-2).
+      await qc.cancelQueries({ queryKey: keys.mode(name, key) });
       qc.setQueryData(keys.mode(name, key), data);
+      // Cancel the list GET first for the same reason: an in-flight /modes that
+      // predates an import-create would settle after the upsert and drop the
+      // new slug, tripping the stale-selection guard.
+      await qc.cancelQueries({ queryKey: keys.modes(key) });
       qc.setQueryData<OrgModes>(keys.modes(key), (prev) =>
         applyCloneToModeList(prev, data)
       );
       void qc.invalidateQueries({ queryKey: keys.modes(key) });
-      void qc.invalidateQueries({ queryKey: keys.mode(name, key) });
     },
   });
 }

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -111,6 +111,16 @@ export function useSeedImportedMode() {
     const key = normalize(org);
     await qc.cancelQueries({ queryKey: keys.mode(name, key) });
     qc.setQueryData(keys.mode(name, key), mode);
+    // Upsert the LIST too, in the same tick, so a just-created slug is
+    // immediately present in the dropdown AND classified `existing` on a
+    // re-import — otherwise a user who re-picks the file before the list
+    // refetch lands takes the create path again and clobbers the first write
+    // with no overwrite confirm (grok #306 rd-5 / languages rd-5). Cancel the
+    // in-flight list GET first so a pre-create response can't drop the row.
+    await qc.cancelQueries({ queryKey: keys.modes(key) });
+    qc.setQueryData<OrgModes>(keys.modes(key), (prev) =>
+      applyCloneToModeList(prev, mode)
+    );
   };
 }
 

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -88,7 +88,19 @@ export function useSaveMode(org?: string | null) {
         requires_group?: boolean;
       };
     }) => configApi.putMode(name, body, undefined, key),
-    onSuccess: (_data, { name }) => {
+    onSuccess: (data, { name }) => {
+      // Seed both caches from the server response BEFORE invalidating — the
+      // same three-step pattern as clone/rename/retire. Invalidate alone only
+      // refetches ACTIVE queries in TanStack v5, so an INACTIVE per-mode query
+      // (import overwriting a non-selected mode) or a not-yet-listed new mode
+      // (import creating one) would otherwise be read stale by the page, which
+      // hydrates the editor / runs its stale-selection guard off that cache
+      // (grok #306 Issues 1/2/4). Every non-import caller saves the ACTIVE
+      // mode, where this write is a harmless no-op the refetch would produce.
+      qc.setQueryData(keys.mode(name, key), data);
+      qc.setQueryData<OrgModes>(keys.modes(key), (prev) =>
+        applyCloneToModeList(prev, data)
+      );
       void qc.invalidateQueries({ queryKey: keys.modes(key) });
       void qc.invalidateQueries({ queryKey: keys.mode(name, key) });
     },

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -88,28 +88,9 @@ export function useSaveMode(org?: string | null) {
         requires_group?: boolean;
       };
     }) => configApi.putMode(name, body, undefined, key),
-    onSuccess: async (data, { name }) => {
-      // Seed both caches from the server response rather than only
-      // invalidating — invalidate refetches ACTIVE queries only in TanStack
-      // v5, so an INACTIVE per-mode query (import overwriting a non-selected
-      // mode) or a not-yet-listed new mode (import creating one) would be read
-      // stale by the page, which hydrates the editor / runs its stale-selection
-      // guard off that cache. Every non-import caller saves the ACTIVE mode,
-      // where this write is the no-op the refetch would have produced. Mirrors
-      // `languageSaveMutationOptions` exactly, including the load-bearing
-      // AWAIT-cancel-before-seed: an in-flight getMode that settled AFTER
-      // setQueryData would write the PRE-save document straight back into the
-      // cache and poison it for the hydration effect (grok #306 rd-2).
-      await qc.cancelQueries({ queryKey: keys.mode(name, key) });
-      qc.setQueryData(keys.mode(name, key), data);
-      // Cancel the list GET first for the same reason: an in-flight /modes that
-      // predates an import-create would settle after the upsert and drop the
-      // new slug, tripping the stale-selection guard.
-      await qc.cancelQueries({ queryKey: keys.modes(key) });
-      qc.setQueryData<OrgModes>(keys.modes(key), (prev) =>
-        applyCloneToModeList(prev, data)
-      );
+    onSuccess: (_data, { name }) => {
       void qc.invalidateQueries({ queryKey: keys.modes(key) });
+      void qc.invalidateQueries({ queryKey: keys.mode(name, key) });
     },
   });
 }

--- a/src/hooks/use-prompt-config.ts
+++ b/src/hooks/use-prompt-config.ts
@@ -95,6 +95,25 @@ export function useSaveMode(org?: string | null) {
   });
 }
 
+// Import-local cache seed (#198). After an import PUT succeeds, write the
+// authoritative response into the TARGET mode's per-mode cache so a later
+// select (overwrite of a mode viewed earlier this session) or the same-mode
+// server-label read cannot resurrect a stale INACTIVE cache — `useSaveMode`'s
+// invalidate refetches ACTIVE queries only, and the imported mode is usually
+// inactive. Deliberately kept OUT of `useSaveMode`: only the import writes its
+// own target here (org pinned by the caller, captured when the import started),
+// so it never touches the shared save-cache machinery on every mode save.
+// Cancels a late in-flight GET first (TanStack optimistic-update order) so it
+// can't overwrite the seed with the pre-import document.
+export function useSeedImportedMode() {
+  const qc = useQueryClient();
+  return async (name: string, org: string | null, mode: PromptMode) => {
+    const key = normalize(org);
+    await qc.cancelQueries({ queryKey: keys.mode(name, key) });
+    qc.setQueryData(keys.mode(name, key), mode);
+  };
+}
+
 // Note: publish/unpublish flows through useSaveMode with the full body
 // (always send { label, description, document, published }). The worker
 // PUT contract requires exactly one of `document` or `overrides` per

--- a/src/lib/mode-import.ts
+++ b/src/lib/mode-import.ts
@@ -1,0 +1,218 @@
+// Pure parser for the Modes page's "Import Config" action (#198) — the exact
+// inverse of `mode-export.ts`. Takes the Markdown-with-YAML-frontmatter file
+// produced by `buildModeExportContent` and returns a validated shape ready to
+// map onto the mode PUT body. Kept pure (no React, no I/O) so every parse and
+// rejection path is unit-testable, mirroring the sibling gate/lib extractions.
+//
+// It reverses `mode-export`'s emitter, not an arbitrary YAML document: the
+// frontmatter keys, the always-double-quoted scalars, and the block-form
+// `aliases` list are all known. It is lenient about hand-edits a human might
+// make (extra whitespace, unquoted scalars, CRLF line endings, unknown keys
+// from a future export) but strict where ambiguity would corrupt data.
+
+import { MODE_EXPORT_VERSION } from "./mode-export";
+
+export interface ParsedModeImport {
+  name: string;
+  label?: string;
+  description?: string;
+  document: string;
+  /** Always resolved to a definite boolean — an absent key means false. */
+  published: boolean;
+  /** Always resolved to a definite boolean — an absent key means false. */
+  requires_group: boolean;
+  /**
+   * Aliases present in the file that this import will NOT restore. The mode
+   * PUT contract has no `aliases` field (they are managed only through
+   * `_rename`/`_retire`), so a round-trip drops them. Surfaced so the UI can
+   * warn instead of silently losing them.
+   */
+  droppedAliases: string[];
+}
+
+export type ModeImportResult =
+  | { ok: true; mode: ParsedModeImport }
+  | { ok: false; error: string };
+
+const FRONTMATTER_FENCE = "---";
+
+/**
+ * Parse an exported mode file. Returns a discriminated result rather than
+ * throwing so the caller can render the message inline.
+ */
+export function parseModeImport(raw: string): ModeImportResult {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    return { ok: false, error: "The file is empty." };
+  }
+
+  // Tolerate a UTF-8 BOM and CRLF/CR line endings from editors/OSes.
+  const normalized = raw.replace(/^﻿/, "").replace(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+
+  // The first non-blank line must be the opening fence.
+  let start = 0;
+  while (start < lines.length && lines[start]?.trim() === "") start++;
+  if (lines[start] !== FRONTMATTER_FENCE) {
+    return {
+      ok: false,
+      error:
+        "Not a recognized mode export — the file must start with a '---' frontmatter block.",
+    };
+  }
+
+  // Find the closing fence.
+  let closing = -1;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i] === FRONTMATTER_FENCE) {
+      closing = i;
+      break;
+    }
+  }
+  if (closing === -1) {
+    return {
+      ok: false,
+      error: "Malformed export — the frontmatter block is not closed with '---'.",
+    };
+  }
+
+  const frontmatterLines = lines.slice(start + 1, closing);
+  // The emitter writes exactly one blank line between the closing fence and
+  // the document; drop it to recover the document verbatim (any blank lines
+  // that are genuinely part of the document survive, because only ONE is
+  // removed). Everything after is the document body.
+  const bodyLines = lines.slice(closing + 1);
+  if (bodyLines.length > 0 && bodyLines[0] === "") bodyLines.shift();
+  const document = bodyLines.join("\n");
+
+  const fields = parseFrontmatter(frontmatterLines);
+
+  // export_version gates the whole parse: a file from a newer portal may use
+  // a shape we don't understand, and a file with no version is not our export.
+  const versionRaw = fields.scalars.export_version;
+  if (versionRaw === undefined) {
+    return {
+      ok: false,
+      error: "Not a recognized mode export — missing 'export_version'.",
+    };
+  }
+  const version = Number(versionRaw);
+  if (!Number.isInteger(version) || version < 1) {
+    return {
+      ok: false,
+      error: `Unrecognized export_version '${versionRaw}'.`,
+    };
+  }
+  if (version > MODE_EXPORT_VERSION) {
+    return {
+      ok: false,
+      error: `This file was exported by a newer version of the portal (export_version ${version}); update the portal to import it.`,
+    };
+  }
+
+  const name = fields.scalars.name;
+  if (name === undefined || name.trim() === "") {
+    return {
+      ok: false,
+      error: "Not a recognized mode export — missing a mode 'name'.",
+    };
+  }
+
+  const mode: ParsedModeImport = {
+    name,
+    document,
+    published: fields.scalars.published === "true",
+    requires_group: fields.scalars.requires_group === "true",
+    droppedAliases: fields.aliases,
+  };
+  if (fields.scalars.label !== undefined) mode.label = fields.scalars.label;
+  if (fields.scalars.description !== undefined) {
+    mode.description = fields.scalars.description;
+  }
+
+  return { ok: true, mode };
+}
+
+interface ParsedFrontmatter {
+  scalars: Record<string, string>;
+  aliases: string[];
+}
+
+function parseFrontmatter(frontmatterLines: string[]): ParsedFrontmatter {
+  const scalars: Record<string, string> = {};
+  const aliases: string[] = [];
+
+  for (let i = 0; i < frontmatterLines.length; i++) {
+    const line = frontmatterLines[i];
+    if (line === undefined || line.trim() === "") continue;
+
+    const keyMatch = /^([A-Za-z_][A-Za-z0-9_]*):[ \t]?(.*)$/.exec(line);
+    if (!keyMatch) continue; // list items handled by their key; ignore stray lines
+
+    const key = keyMatch[1];
+    if (key === undefined) continue;
+    const rawValue = keyMatch[2] ?? "";
+
+    // Block-form list (`aliases:` with an empty value, followed by `  - x`).
+    if (key === "aliases" && rawValue.trim() === "") {
+      while (i + 1 < frontmatterLines.length) {
+        const nextLine = frontmatterLines[i + 1];
+        if (nextLine === undefined) break;
+        const item = /^[ \t]+-[ \t]+(.*)$/.exec(nextLine);
+        if (!item) break;
+        aliases.push(parseScalar(item[1] ?? ""));
+        i++;
+      }
+      continue;
+    }
+
+    scalars[key] = parseScalar(rawValue);
+  }
+
+  return { scalars, aliases };
+}
+
+/**
+ * Reverse of `mode-export`'s `yamlScalar`. A value the emitter wrote is always
+ * double-quoted; unquote and unescape it. A hand-edited unquoted value is
+ * returned trimmed as-is (covers `true`/`false`/numbers and plain text).
+ */
+function parseScalar(rawValue: string): string {
+  const trimmed = rawValue.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return unescapeYaml(trimmed.slice(1, -1));
+  }
+  return trimmed;
+}
+
+function unescapeYaml(inner: string): string {
+  let out = "";
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (c === undefined) break;
+    if (c === "\\" && i + 1 < inner.length) {
+      const next = inner[i + 1];
+      if (next === "\\") {
+        out += "\\";
+        i++;
+      } else if (next === '"') {
+        out += '"';
+        i++;
+      } else if (next === "n") {
+        out += "\n";
+        i++;
+      } else if (next === "r") {
+        out += "\r";
+        i++;
+      } else if (next === "t") {
+        out += "\t";
+        i++;
+      } else {
+        // Unknown escape — keep the backslash literally rather than guessing.
+        out += c;
+      }
+    } else {
+      out += c;
+    }
+  }
+  return out;
+}

--- a/src/lib/mode-import.ts
+++ b/src/lib/mode-import.ts
@@ -11,6 +11,7 @@
 // from a future export) but strict where ambiguity would corrupt data.
 
 import { MODE_EXPORT_VERSION } from "./mode-export";
+import { slugifyModeName } from "./mode-slug";
 
 export interface ParsedModeImport {
   name: string;
@@ -117,12 +118,43 @@ export function parseModeImport(raw: string): ModeImportResult {
       error: "Not a recognized mode export — missing a mode 'name'.",
     };
   }
+  // The name is PUT straight into the URL path; a non-slug (e.g. a hand-typed
+  // "Spoken Mode") would either 400 at the engine or create a second row
+  // beside the canonical slug. Reject anything that isn't already canonical
+  // rather than silently reslugging behind the user's back.
+  if (name !== slugifyModeName(name)) {
+    return {
+      ok: false,
+      error: `Invalid mode name “${name}” — expected a slug like “${slugifyModeName(
+        name
+      )}”.`,
+    };
+  }
+
+  // Flags default to false when absent, but a PRESENT value must be exactly
+  // "true" or "false". Coercing anything else to false would let a typo
+  // ("published: TRUE", "published: tru") silently unpublish an overwritten
+  // mode — the parser presents its result as validated, so reject instead.
+  const published = parseFlag(fields.scalars.published);
+  if (published === null) {
+    return {
+      ok: false,
+      error: `Invalid 'published' value “${fields.scalars.published}” — expected true or false.`,
+    };
+  }
+  const requiresGroup = parseFlag(fields.scalars.requires_group);
+  if (requiresGroup === null) {
+    return {
+      ok: false,
+      error: `Invalid 'requires_group' value “${fields.scalars.requires_group}” — expected true or false.`,
+    };
+  }
 
   const mode: ParsedModeImport = {
     name,
     document,
-    published: fields.scalars.published === "true",
-    requires_group: fields.scalars.requires_group === "true",
+    published,
+    requires_group: requiresGroup,
     droppedAliases: fields.aliases,
   };
   if (fields.scalars.label !== undefined) mode.label = fields.scalars.label;
@@ -170,6 +202,18 @@ function parseFrontmatter(frontmatterLines: string[]): ParsedFrontmatter {
   }
 
   return { scalars, aliases };
+}
+
+/**
+ * Parse a boolean flag scalar: absent → false (the documented default), the
+ * exact strings "true"/"false" → their value, anything else → null (malformed,
+ * the caller rejects).
+ */
+function parseFlag(raw: string | undefined): boolean | null {
+  if (raw === undefined) return false;
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return null;
 }
 
 /**

--- a/src/lib/mode-import.ts
+++ b/src/lib/mode-import.ts
@@ -71,7 +71,8 @@ export function parseModeImport(raw: string): ModeImportResult {
   if (closing === -1) {
     return {
       ok: false,
-      error: "Malformed export — the frontmatter block is not closed with '---'.",
+      error:
+        "Malformed export — the frontmatter block is not closed with '---'.",
     };
   }
 

--- a/tests/mode-import.test.ts
+++ b/tests/mode-import.test.ts
@@ -192,3 +192,59 @@ describe("parseModeImport — rejections", () => {
     expect(result.error).toContain("newer version");
   });
 });
+
+describe("parseModeImport — document body edge cases", () => {
+  it("round-trips a document that contains a bare '---' horizontal rule", () => {
+    // The closing fence is the FIRST '---' after the opening one, found only
+    // in the frontmatter region; '---' lines in the body must survive.
+    const mode: PromptMode = {
+      name: "hr",
+      document: "Intro\n\n---\n\nAfter the rule\n\n---\n\nEnd",
+    };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.document).toBe(
+      "Intro\n\n---\n\nAfter the rule\n\n---\n\nEnd"
+    );
+  });
+
+  it("round-trips an empty document", () => {
+    const result = parseModeImport(exported({ name: "empty", document: "" }));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.document).toBe("");
+  });
+
+  it("round-trips a document with a trailing newline and trailing blank line", () => {
+    const mode: PromptMode = { name: "trail", document: "body\n\n" };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.document).toBe("body\n\n");
+  });
+
+  it("round-trips a scalar whose value is a single double-quote", () => {
+    const mode: PromptMode = { name: "q", label: '"', document: "d" };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.label).toBe('"');
+  });
+
+  it("round-trips alias values containing ':' , '\"' and '\\'", () => {
+    const mode: PromptMode = {
+      name: "a",
+      document: "d",
+      aliases: ["ns:old", 'has"quote', "back\\slash"],
+    };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.droppedAliases).toEqual([
+      "ns:old",
+      'has"quote',
+      "back\\slash",
+    ]);
+  });
+});

--- a/tests/mode-import.test.ts
+++ b/tests/mode-import.test.ts
@@ -191,6 +191,53 @@ describe("parseModeImport — rejections", () => {
     if (result.ok) return;
     expect(result.error).toContain("newer version");
   });
+
+  it("rejects a non-slug mode name instead of silently reslugging", () => {
+    const raw = [
+      "---",
+      'name: "Spoken Mode"',
+      "export_version: 1",
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    const result = parseModeImport(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("spoken-mode");
+  });
+
+  it("rejects a malformed 'published' value rather than coercing to false", () => {
+    const raw = [
+      "---",
+      'name: "spoken"',
+      "published: TRUE",
+      "export_version: 1",
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    const result = parseModeImport(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("published");
+  });
+
+  it("rejects a malformed 'requires_group' value", () => {
+    const raw = [
+      "---",
+      'name: "spoken"',
+      "requires_group: yes",
+      "export_version: 1",
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    const result = parseModeImport(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("requires_group");
+  });
 });
 
 describe("parseModeImport — document body edge cases", () => {

--- a/tests/mode-import.test.ts
+++ b/tests/mode-import.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MODE_EXPORT_VERSION,
+  buildModeExportContent,
+} from "../src/lib/mode-export";
+import { parseModeImport } from "../src/lib/mode-import";
+import type { PromptMode } from "../src/types/prompt-override";
+
+const FIXED_DATE = new Date("2026-05-28T15:30:00.000Z");
+
+function exported(mode: PromptMode, org = "unfoldingWord"): string {
+  return buildModeExportContent(mode, { org, exportedAt: FIXED_DATE });
+}
+
+describe("parseModeImport — round-trip with mode-export", () => {
+  it("recovers every supported field from a fully-populated export", () => {
+    const mode: PromptMode = {
+      name: "spoken",
+      label: "Spoken Mode",
+      description: "Conversational responses tuned for spoken delivery.",
+      document: "# Spoken mode\n\nUse natural prose.\n\n## Closing\n\nBye.",
+      published: true,
+      requires_group: true,
+    };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.name).toBe("spoken");
+    expect(result.mode.label).toBe("Spoken Mode");
+    expect(result.mode.description).toBe(
+      "Conversational responses tuned for spoken delivery."
+    );
+    expect(result.mode.document).toBe(mode.document);
+    expect(result.mode.published).toBe(true);
+    expect(result.mode.requires_group).toBe(true);
+    expect(result.mode.droppedAliases).toEqual([]);
+  });
+
+  it("round-trips a minimal mode (name + document only)", () => {
+    const mode: PromptMode = { name: "minimal", document: "body only" };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.name).toBe("minimal");
+    expect(result.mode.label).toBeUndefined();
+    expect(result.mode.description).toBeUndefined();
+    expect(result.mode.document).toBe("body only");
+    // Absent keys resolve to definite false, matching the always-explicit
+    // pair the page sends on save.
+    expect(result.mode.published).toBe(false);
+    expect(result.mode.requires_group).toBe(false);
+  });
+
+  it("preserves document content that itself begins with a blank line", () => {
+    const mode: PromptMode = { name: "m", document: "\n\nleading blanks kept" };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.document).toBe("\n\nleading blanks kept");
+  });
+
+  it("round-trips escaped characters in metadata (quotes, newlines, backslash)", () => {
+    const mode: PromptMode = {
+      name: "tricky",
+      label: 'Has "quotes" and\ttabs',
+      description: "Line one\nLine two with a \\ backslash",
+      document: "doc",
+      published: false,
+    };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.label).toBe('Has "quotes" and\ttabs');
+    expect(result.mode.description).toBe(
+      "Line one\nLine two with a \\ backslash"
+    );
+  });
+});
+
+describe("parseModeImport — aliases", () => {
+  it("surfaces exported aliases as droppedAliases (PUT can't restore them)", () => {
+    const mode: PromptMode = {
+      name: "spoken",
+      document: "doc",
+      aliases: ["spoken-old", "spoken-legacy"],
+    };
+    const result = parseModeImport(exported(mode));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.droppedAliases).toEqual(["spoken-old", "spoken-legacy"]);
+  });
+});
+
+describe("parseModeImport — tolerant of hand-edits", () => {
+  it("accepts CRLF line endings", () => {
+    const crlf = exported({ name: "m", document: "a\nb", published: true })
+      .split("\n")
+      .join("\r\n");
+    const result = parseModeImport(crlf);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.document).toBe("a\nb");
+    expect(result.mode.published).toBe(true);
+  });
+
+  it("accepts a leading UTF-8 BOM", () => {
+    const result = parseModeImport("﻿" + exported({ name: "m", document: "d" }));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.name).toBe("m");
+  });
+
+  it("ignores unknown future keys without failing", () => {
+    const withExtra = exported({ name: "m", document: "d" }).replace(
+      "export_version:",
+      "some_future_key: hello\nexport_version:"
+    );
+    const result = parseModeImport(withExtra);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts an unquoted scalar value", () => {
+    const raw = [
+      "---",
+      "name: plain",
+      "published: false",
+      "export_version: 1",
+      "---",
+      "",
+      "doc",
+    ].join("\n");
+    const result = parseModeImport(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mode.name).toBe("plain");
+  });
+});
+
+describe("parseModeImport — rejections", () => {
+  it("rejects an empty file", () => {
+    expect(parseModeImport("")).toEqual({
+      ok: false,
+      error: "The file is empty.",
+    });
+  });
+
+  it("rejects a file without a frontmatter fence", () => {
+    const result = parseModeImport("# Just a markdown doc\n\nno frontmatter");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("must start with a '---'");
+  });
+
+  it("rejects an unclosed frontmatter block", () => {
+    const result = parseModeImport("---\nname: x\nexport_version: 1\nbody");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("not closed");
+  });
+
+  it("rejects a file with no export_version", () => {
+    const raw = ["---", 'name: "x"', "---", "", "body"].join("\n");
+    const result = parseModeImport(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("missing 'export_version'");
+  });
+
+  it("rejects a file with no name", () => {
+    const raw = ["---", "export_version: 1", "---", "", "body"].join("\n");
+    const result = parseModeImport(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("missing a mode 'name'");
+  });
+
+  it("rejects an export from a newer portal version", () => {
+    const raw = [
+      "---",
+      'name: "x"',
+      `export_version: ${MODE_EXPORT_VERSION + 1}`,
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    const result = parseModeImport(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("newer version");
+  });
+});

--- a/tests/mode-import.test.ts
+++ b/tests/mode-import.test.ts
@@ -105,7 +105,9 @@ describe("parseModeImport — tolerant of hand-edits", () => {
   });
 
   it("accepts a leading UTF-8 BOM", () => {
-    const result = parseModeImport("﻿" + exported({ name: "m", document: "d" }));
+    const result = parseModeImport(
+      "﻿" + exported({ name: "m", document: "d" })
+    );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.mode.name).toBe("m");


### PR DESCRIPTION
## What

Adds **Import / re-upload of exported mode configs** — the inverse of the Export action (#187). Users can re-upload a mode file that Export produced to recreate a deleted mode, move one between orgs, or restore a known-good version.

Closes #198.

## How

Import composes **entirely from the existing `PUT /api/config/modes/{name}` endpoint** the Modes page already uses for create/save — **no worker or engine change**. #209 (which added `requires_group` to the PUT body) is what makes a lossless round-trip of the flags possible.

- **New pure parser** `src/lib/mode-import.ts` — `parseModeImport(raw)`, the exact inverse of `mode-export.ts`:
  - Splits YAML frontmatter from the document body (recovers the document verbatim, preserving blank lines that are genuinely part of it).
  - Unescapes the double-quoted scalars the exporter emits.
  - Validates `export_version` (rejects a file from a **newer** portal) and `name`.
  - Returns a discriminated `{ ok: true, mode } | { ok: false, error }` so the UI renders failures inline.
  - Tolerant of hand-edits: CRLF, BOM, unquoted scalars, unknown future keys. Strict where ambiguity would corrupt data.
- **Aliases** are parsed but reported as `droppedAliases`: the mode PUT contract has no `aliases` field (they're managed only through `_rename`/`_retire`), so a round-trip can't restore them. The UI shows a non-blocking notice rather than losing them silently.

## UI

- **Import** button + hidden file input in the Modes toolbar, gated on create/edit capability and org context.
- **New name** → creates directly.
- **Existing name** → a destructive **overwrite-confirm** dialog first (plain `Button` + `runConfirmedAction`, per the `AlertDialogAction`-is-unsafe-for-async rule #102).
- Existence is checked against the **full org mode list**, not the authorized subset, so an import can't silently clobber a mode the user can't see — a hidden collision is gated by edit rights.
- The PUT rides the same in-flight save lock (#209 serialization) and sends the always-explicit `published`/`requires_group` pair. Success selects the imported mode.

## Tests

`tests/mode-import.test.ts` — 15 cases: **export → import round-trip** (incl. escaped metadata and document-preserving blank lines), alias drop, hand-edit tolerance (CRLF/BOM/unquoted/unknown-key), and every rejection path (empty, no fence, unclosed fence, missing version, missing name, future version).

Full suite **921 pass** (37 files); typecheck, lint (`--max-warnings 0`), build all clean.

## Scope note

`aliases` not restored on import is an inherent limit of the current PUT contract (documented in-code and surfaced to the user), not a regression — Export already treats import as a separate concern.

## External review outcome (codex + grok, 6 rounds)

Reviewed to convergence. codex: **clean**. Each round's medium+ findings were fixed; round-3's two P1s led to deleting the two mechanisms generating them (the shared cache-seed and the post-import auto-switch), and round-5's edges led to constraining the feature (import requires a clean editor, org-pinned, fail-closed on an unloaded list). grok's residual 2 P2s + 4 P3s — which require concurrent interaction during a modal file picker / dialog (near-unreachable in a real browser) — are tracked in **#308**.
